### PR TITLE
allow detecting eigen on easybuild; fixes #17

### DIFF
--- a/cmake/custom/FindEigen3.cmake
+++ b/cmake/custom/FindEigen3.cmake
@@ -61,7 +61,7 @@ if (EIGEN3_INCLUDE_DIR)
 else (EIGEN3_INCLUDE_DIR)
   find_path(EIGEN3_INCLUDE_DIR NAMES signature_of_eigen3_matrix_library
       PATHS ${EIGEN3_ROOT} ENV EIGEN3_ROOT
-      PATH_SUFFIXES include/eigen3 include/eigen
+      PATH_SUFFIXES include/eigen3 include/eigen include
       NO_DEFAULT_PATHS
     )
 


### PR DESCRIPTION
@stigrj @ilfreddy With this change I was able to configure under EasyBuild:
```
ml notur
source mod_setup.sh
module load CMake
module load Eigen
export EIGEN3_ROOT=/global/hds/software/cpu/eb2/Eigen/3.2.9-foss-2016b
module load Boost
./setup --cc=icc --cxx=icpc
```