### PR TITLE
Cmake issue

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -14,8 +14,11 @@ ExternalProject_Add(submodule-libgetkw
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libgetkw
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libgetkw
     INSTALL_DIR ${PROJECT_BINARY_DIR}/external
-    CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/external
-    -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+    CMAKE_ARGS  -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/external
+                -DCMAKE_BUILD_TYPE=Release
+                -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                -DCMAKE_FORTRAN_COMPILER=${CMAKE_FORTRAN_COMPILER}
     )
 add_dependencies(submodule-libgetkw git-submodule-init)
 add_dependencies(external-modules submodule-libgetkw)
@@ -30,7 +33,11 @@ if (ENABLE_XCFUN)
         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/xcfun
         BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/xcfun
         INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
-        CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/external -DCMAKE_BUILD_TYPE=Release
+        CMAKE_ARGS  -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/external
+                    -DCMAKE_BUILD_TYPE=Release
+                    -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+                    -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+                    -DCMAKE_FORTRAN_COMPILER=${CMAKE_FORTRAN_COMPILER}
         )
     add_dependencies(submodule-xcfun git-submodule-init)
     add_dependencies(external-modules submodule-xcfun)

--- a/src/mrcpp/parallel.cpp
+++ b/src/mrcpp/parallel.cpp
@@ -9,8 +9,6 @@
 #include "InterpolatingBasis.h"
 #include "MultiResolutionAnalysis.h"
 
-#include "mrchem.h"
-
 
 using namespace std;
 


### PR DESCRIPTION
@bast: was there a reason why the compiler options were not passed on to xcfun (as they are to getkw)? This is probably not a problem unless xcfun is compiled "manually", see below.

The mrchem.h introduced a spurious dependency on getkw for mrcpp that was not passed to cmake, which broke the compilation (unless the external modes were compiled manually first). Now mrcpp is properly independent of the external modules and the order of compilation is
1) mrcpp
2) external modules (getkw and xcfun)
3) mrchem