### PR TITLE
fix MPI compilation error

### DIFF
--- a/src/mrcpp/parallel.cpp
+++ b/src/mrcpp/parallel.cpp
@@ -99,11 +99,10 @@ void Rcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MPI
     timer.start();
     for(int ichunk = 0 ; ichunk <Nchunks ; ichunk++){
       if(ichunk<STree->nodeChunks.size()){
-	STree->sNodesCoeff = STree->nodeCoeffChunks[ichunk];
 	STree->sNodes = STree->nodeChunks[ichunk];
       }else{
-        STree->sNodesCoeff = new double[STree->sizeNodeCoeff*STree->maxNodesPerChunk];
-        STree->nodeCoeffChunks.push_back(STree->sNodesCoeff);
+        double *sNodesCoeff = new double[STree->sizeNodeCoeff*STree->maxNodesPerChunk];
+        STree->nodeCoeffChunks.push_back(sNodesCoeff);
 	STree->sNodes = (ProjectedNode<D>*) new char[STree->maxNodesPerChunk*sizeof(ProjectedNode<D>)];
 	STree->nodeChunks.push_back(STree->sNodes);
       }      
@@ -141,11 +140,10 @@ void IRcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MP
     timer.start();
     for(int ichunk = 0 ; ichunk <Nchunks ; ichunk++){
       if(ichunk<STree->nodeChunks.size()){
-	STree->sNodesCoeff = STree->nodeCoeffChunks[ichunk];
 	STree->sNodes = STree->nodeChunks[ichunk];
       }else{
-        STree->sNodesCoeff = new double[STree->sizeNodeCoeff*STree->maxNodesPerChunk];
-        STree->nodeCoeffChunks.push_back(STree->sNodesCoeff);
+        double *sNodesCoeff = new double[STree->sizeNodeCoeff*STree->maxNodesPerChunk];
+        STree->nodeCoeffChunks.push_back(sNodesCoeff);
 	STree->sNodes = (ProjectedNode<D>*) new char[STree->maxNodesPerChunk*sizeof(ProjectedNode<D>)];
 	STree->nodeChunks.push_back(STree->sNodes);
       }      


### PR DESCRIPTION
Related to the nasty memory bug in commit 5547a0530e4, where I removed sNodesCoeff from the SerialTree class and replaced it with a local variable in the routine it was used. This was not the actual bug, but I removed it from the class because it was never used outside the routine where it was assigned, and I **think** it still applies to the current changes. With this the code compiles and runs in MPI/OMP using intel/2015b, but there are still some bugs when running in MPI (see issues).