### PR TITLE
Exchange and Shared memory

### DIFF
--- a/src/mrchem/MREnv.cpp
+++ b/src/mrchem/MREnv.cpp
@@ -10,7 +10,6 @@ MultiResolutionAnalysis<3> *MRA;
 
 void MREnv::initializeMRCPP(int argc, char **argv) {
 #ifdef HAVE_MPI
-    MPI_Init(NULL, NULL);
     MPI_Initializations();
 #endif
     int nThreads = omp_get_max_threads();
@@ -59,11 +58,11 @@ void MREnv::initializeMRCPP(int argc, char **argv) {
     println(0, "BLAS was NOT found, Eigen will be used instead!" << endl);
 #endif
 
-    if (MPI_size > 1 or nThreads > 1) {
+    if (MPI_Orb_size > 1 or nThreads > 1) {
         println(0,"+++ Parallel execution: ");
-        println(0,"  MPI hosts available     : " << MPI_size);
+        println(0,"  MPI hosts available     : " << MPI_Orb_size);
         println(0,"  Threads/host            : " << nThreads);
-        println(0,"  Total used CPUs         : " << MPI_size*nThreads);
+        println(0,"  Total used CPUs         : " << MPI_Orb_size*nThreads);
         println(0,"");
     } else {
         println(0,"+++ Serial execution" << endl);

--- a/src/mrchem/MREnv.cpp
+++ b/src/mrchem/MREnv.cpp
@@ -58,11 +58,11 @@ void MREnv::initializeMRCPP(int argc, char **argv) {
     println(0, "BLAS was NOT found, Eigen will be used instead!" << endl);
 #endif
 
-    if (MPI_Orb_size > 1 or nThreads > 1) {
+    if (mpiOrbSize > 1 or nThreads > 1) {
         println(0,"+++ Parallel execution: ");
-        println(0,"  MPI hosts available     : " << MPI_Orb_size);
+        println(0,"  MPI hosts available     : " << mpiOrbSize);
         println(0,"  Threads/host            : " << nThreads);
-        println(0,"  Total used CPUs         : " << MPI_Orb_size*nThreads);
+        println(0,"  Total used CPUs         : " << mpiOrbSize*nThreads);
         println(0,"");
     } else {
         println(0,"+++ Serial execution" << endl);

--- a/src/mrchem/qmfunctions/Density.cpp
+++ b/src/mrchem/qmfunctions/Density.cpp
@@ -16,7 +16,7 @@ Density::Density(bool spin, bool shared)
       dens_s(0),
       dens_a(0),
       dens_b(0) {
-    if(this->is_shared and MPI_SH_size>1){
+    if(this->is_shared and mpiShSize>1){
 	this->shMem = new SharedMemory(500);//initiate up to 500MB shared memory
     }else{
 	this->setIsShared(false);//at least 2 processes for sharing
@@ -138,7 +138,7 @@ void Density::allocBeta() {
 void Density::send_Density(int dest, int tag){
 #ifdef HAVE_MPI
     MPI_Status status;
-    MPI_Comm comm=MPI_Comm_Orb;
+    MPI_Comm comm=mpiCommOrb;
 
     struct Metadata{
 	bool spin;
@@ -179,7 +179,7 @@ void Density::send_Density(int dest, int tag){
 void Density::Rcv_Density(int source, int tag){
 #ifdef HAVE_MPI
     MPI_Status status;
-    MPI_Comm comm=MPI_Comm_Orb;
+    MPI_Comm comm=mpiCommOrb;
 
     struct Metadata{
 	bool spin;

--- a/src/mrchem/qmfunctions/Density.cpp
+++ b/src/mrchem/qmfunctions/Density.cpp
@@ -16,7 +16,11 @@ Density::Density(bool spin, bool shared)
       dens_s(0),
       dens_a(0),
       dens_b(0) {
-  if(this->is_shared)Allocate_Shared_Density(1000);//1000-> 1000MB
+    if(this->is_shared and MPI_SH_size>1){
+	//Ideally shared memory should be allocated here
+    }else{
+	this->setIsShared(false);
+    }
 }
 Density::Density(bool s)
     : is_spin(s),
@@ -29,7 +33,7 @@ Density::Density(bool s)
 
 Density::Density(const Density &rho)
     : is_spin(rho.is_spin),
-      is_shared(rho.is_shared),
+      is_shared(false),//shared memory is not transfered, but must be set explicitely
       dens_t(0),
       dens_s(0),
       dens_a(0),
@@ -44,6 +48,10 @@ Density::~Density() {
 }
 
 void Density::clear() {
+    if(this->isShared()){
+	//must first free the shared memory
+	MPI_Win_free(&this->MPI_win);//NB: collective command
+    }
     if (this->hasTotal()) delete this->dens_t;
     if (this->hasSpin()) delete this->dens_s;
     if (this->hasAlpha()) delete this->dens_a;
@@ -80,68 +88,76 @@ void Density::setDensity(int s, FunctionTree<3> *rho) {
 void Density::allocTotal() {
     if (this->hasTotal()) MSG_ERROR("Density not empty");
     this->dens_t = new FunctionTree<3>(*MRA);
+    this->dens_t->getSerialFunctionTree()->isShared = this->isShared();
 }
 
 void Density::allocSpin() {
     if (this->hasSpin()) MSG_ERROR("Density not empty");
     this->dens_s = new FunctionTree<3>(*MRA);
+    this->dens_s->getSerialFunctionTree()->isShared = this->isShared();
 }
 
 void Density::allocAlpha() {
     if (this->hasAlpha()) MSG_ERROR("Density not empty");
     this->dens_a = new FunctionTree<3>(*MRA);
+    this->dens_a->getSerialFunctionTree()->isShared = this->isShared();
 }
 
 void Density::allocBeta() {
     if (this->hasBeta()) MSG_ERROR("Density not empty");
     this->dens_b = new FunctionTree<3>(*MRA);
+    this->dens_b->getSerialFunctionTree()->isShared = this->isShared();
 }
 
 /*
-int Density::printTreeSizes() const {
-    int nNodes = 0;
-    if (this->dens_t != 0) nNodes += this->total().getNNodes();
-    if (this->dens_a != 0) nNodes += this->alpha().getNNodes();
-    if (this->dens_b != 0) nNodes += this->beta().getNNodes();
-    println(0, " Density           " << setw(15) << 1 << setw(25) << nNodes);
-    return nNodes;
-}
+  int Density::printTreeSizes() const {
+  int nNodes = 0;
+  if (this->dens_t != 0) nNodes += this->total().getNNodes();
+  if (this->dens_a != 0) nNodes += this->alpha().getNNodes();
+  if (this->dens_b != 0) nNodes += this->beta().getNNodes();
+  println(0, " Density           " << setw(15) << 1 << setw(25) << nNodes);
+  return nNodes;
+  }
 */
 
 
 //send Density with MPI
 void Density::send_Density(int dest, int tag){
 #ifdef HAVE_MPI
-  MPI_Status status;
-  MPI_Comm comm=MPI_COMM_WORLD;
+    MPI_Status status;
+    MPI_Comm comm=MPI_Comm_Orb;
 
-  struct Metadata{
-    bool spin;
-    int NchunksTotal;
-    int NchunksAlpha;
-    int NchunksBeta;
-  };
+    struct Metadata{
+	bool spin;
+	int NchunksTotal;
+	int NchunksSpin;
+	int NchunksAlpha;
+	int NchunksBeta;
+    };
 
-  Metadata Densinfo;
+    Metadata Densinfo;
 
-  Densinfo.spin = this->isSpinDensity();
-  if(this->dens_t){
-    Densinfo.NchunksTotal = this->total().getSerialFunctionTree()->nodeChunks.size();//should reduce to actual number of chunks
-  }else{Densinfo.NchunksTotal = 0;}
-  if(this->dens_a){
-    Densinfo.NchunksAlpha = this->alpha().getSerialFunctionTree()->nodeChunks.size();//should reduce to actual number of chunks
-  }else{Densinfo.NchunksAlpha = 0;}
-  if(this->dens_b){
-    Densinfo.NchunksBeta = this->beta().getSerialFunctionTree()->nodeChunks.size();//should reduce to actual number of chunks
-  }else{Densinfo.NchunksBeta = 0;}
+    Densinfo.spin = this->isSpinDensity();
+    if(this->dens_t){
+	Densinfo.NchunksTotal = this->total().getSerialFunctionTree()->nodeChunks.size();//should reduce to actual number of chunks
+    }else{Densinfo.NchunksTotal = 0;}
+    if(this->dens_s){
+	Densinfo.NchunksSpin = this->spin().getSerialFunctionTree()->nodeChunks.size();//should reduce to actual number of chunks
+    }else{Densinfo.NchunksSpin = 0;}
+    if(this->dens_a){
+	Densinfo.NchunksAlpha = this->alpha().getSerialFunctionTree()->nodeChunks.size();//should reduce to actual number of chunks
+    }else{Densinfo.NchunksAlpha = 0;}
+    if(this->dens_b){
+	Densinfo.NchunksBeta = this->beta().getSerialFunctionTree()->nodeChunks.size();//should reduce to actual number of chunks
+    }else{Densinfo.NchunksBeta = 0;}
  
 
-  int count=sizeof(Metadata);
-  MPI_Send(&Densinfo, count, MPI_BYTE, dest, tag, comm);
- 
-  if(this->hasTotal())Send_SerialTree(this->dens_t, Densinfo.NchunksTotal, dest, tag+10000, comm);
-  if(this->hasAlpha())Send_SerialTree(this->dens_a, Densinfo.NchunksAlpha, dest, tag+20000, comm);
-  if(this->hasBeta())Send_SerialTree(this->dens_b, Densinfo.NchunksBeta, dest, tag+30000, comm);
+    int count=sizeof(Metadata);
+    MPI_Send(&Densinfo, count, MPI_BYTE, dest, tag, comm);
+    if(this->hasTotal())Send_SerialTree(this->dens_t, Densinfo.NchunksTotal, dest, tag+10000, comm);
+    if(this->hasSpin())Send_SerialTree(this->dens_s, Densinfo.NchunksSpin, dest, tag+15000, comm);
+    if(this->hasAlpha())Send_SerialTree(this->dens_a, Densinfo.NchunksAlpha, dest, tag+20000, comm);
+    if(this->hasBeta())Send_SerialTree(this->dens_b, Densinfo.NchunksBeta, dest, tag+30000, comm);
 
 #endif
 }
@@ -149,57 +165,46 @@ void Density::send_Density(int dest, int tag){
 //receive Density with MPI
 void Density::Rcv_Density(int source, int tag){
 #ifdef HAVE_MPI
-  MPI_Status status;
-  MPI_Comm comm=MPI_COMM_WORLD;
+    MPI_Status status;
+    MPI_Comm comm=MPI_Comm_Orb;
 
-  struct Metadata{
-    bool spin;
-    int NchunksTotal;
-    int NchunksAlpha;
-    int NchunksBeta;
-  };
+    struct Metadata{
+	bool spin;
+	int NchunksTotal;
+	int NchunksSpin;
+	int NchunksAlpha;
+	int NchunksBeta;
+    };
 
-  Metadata Densinfo;
+    Metadata Densinfo;
 
-  int count=sizeof(Metadata);
-  MPI_Recv(&Densinfo, count, MPI_BYTE, source, tag, comm, &status);
+    int count=sizeof(Metadata);
+    MPI_Recv(&Densinfo, count, MPI_BYTE, source, tag, comm, &status);
 
-  assert(this->isSpinDensity() == Densinfo.spin);
-
-  if(Densinfo.NchunksTotal>0){
-    if(not this->hasTotal()){
-      //We must have a tree defined for receiving nodes. Define one:
-      this->dens_t = new FunctionTree<3>(*MRA,MaxAllocNodes);
-    }
-    Rcv_SerialTree(this->dens_t, Densinfo.NchunksTotal, source, tag+10000, comm);}
-  if(Densinfo.NchunksAlpha>0){
-    if(not this->hasAlpha()){
-      //We must have a tree defined for receiving nodes. Define one:
-      this->dens_a = new FunctionTree<3>(*MRA,MaxAllocNodes);
-    }
-    Rcv_SerialTree(this->dens_a, Densinfo.NchunksAlpha, source, tag+20000, comm);}
-  if(Densinfo.NchunksBeta>0){
-    if(not this->hasBeta()){
-      //We must have a tree defined for receiving nodes. Define one:
-      this->dens_b = new FunctionTree<3>(*MRA,MaxAllocNodes);
-    }
-    Rcv_SerialTree(this->dens_b, Densinfo.NchunksBeta, source, tag+30000, comm);}
+    if(Densinfo.NchunksTotal>0){
+	if (not this->hasTotal()) this->allocTotal();
+	Rcv_SerialTree(this->dens_t, Densinfo.NchunksTotal, source, tag+10000, comm);}
+    if(Densinfo.NchunksSpin>0){
+	if (not this->hasSpin()) this->allocSpin();
+	Rcv_SerialTree(this->dens_s, Densinfo.NchunksSpin, source, tag+15000, comm);}
+    if(Densinfo.NchunksAlpha>0){
+	if (not this->hasAlpha()) this->allocAlpha();
+	Rcv_SerialTree(this->dens_a, Densinfo.NchunksAlpha, source, tag+20000, comm);}
+    if(Densinfo.NchunksBeta>0){
+	if (not this->hasBeta()) this->allocBeta();
+	Rcv_SerialTree(this->dens_b, Densinfo.NchunksBeta, source, tag+30000, comm);}
   
 #endif
 }
 //Allocate an empty Density where the coefficients are shared between processes within a compute-node
 void Density::Allocate_Shared_Density(int shared_size){
+    //NB: for now only total spin is shared
 #ifdef HAVE_MPI
-  MPI_Comm ncomm=MPI_COMM_WORLD;
-  MPI_Comm ncomm_sh;
-  double * shared_mem_ptr;
-  //allocate a big chunk of shared memory
-  Share_memory(ncomm, ncomm_sh, shared_size, shared_mem_ptr);
-  int shrank;
-  MPI_Comm_rank(ncomm_sh, &shrank);
-  bool master = (shrank==0);//rank 0 is master
+    double * shared_mem_ptr;
+    //allocate a big chunk of shared memory
+    Share_memory(shared_size, shared_mem_ptr, this->MPI_win);
 
-  if(this->hasTotal()){
+    //  if(this->hasTotal()){
     SerialFunctionTree<3>* serialTree_p = (SerialFunctionTree<3>*) this->dens_t->getSerialTree();
     if(serialTree_p->nodeCoeffChunks.size()!=1)MSG_ERROR("shared density must start from empty density");
     
@@ -208,8 +213,8 @@ void Density::Allocate_Shared_Density(int shared_size){
     int nRoots = this->dens_t->getRootBox().size();
     double * d_ptr = shared_mem_ptr;
     for (int rIdx = 0; rIdx < nRoots; rIdx++) {
-      roots[rIdx]->coefs =  d_ptr; //repoint adress of root nodecoeff
-    d_ptr += serialTree_p->sizeNodeCoeff; 
+	roots[rIdx]->coefs =  d_ptr; //repoint adress of root nodecoeff
+	d_ptr += serialTree_p->sizeNodeCoeff; 
     }
     //deallocate the old coefficients
     delete[] serialTree_p->nodeCoeffChunks[0];//deallocate old chunk
@@ -219,121 +224,122 @@ void Density::Allocate_Shared_Density(int shared_size){
     int size_NodeChunk = sizeof(ProjectedNode<3>)*serialTree_p->maxNodesPerChunk;//in Bytes
     d_ptr = shared_mem_ptr;
     serialTree_p->nodeCoeffChunks[0]= shared_mem_ptr;//reset adress of first chunk
-    
+   
     long int nextsize = 2*size_NodeCoeffChunk;//already set one, and need space for next.
     long int availsize = shared_size;
     availsize *= 1024*1024;
     int maxNChunks = serialTree_p->maxNodes / serialTree_p->maxNodesPerChunk -1;
-    for (int i = 0; nextsize < availsize and i  <maxNChunks; i++) {
-      d_ptr += size_NodeCoeffChunk;
-      nextsize += size_NodeCoeffChunk;
-      serialTree_p->nodeCoeffChunks.push_back(d_ptr);
-      serialTree_p->sNodes = (ProjectedNode<3>*) new char[size_NodeChunk];//NB: nodes (without coeff) are allocated individually, not shared
-      serialTree_p->nodeChunks.push_back(serialTree_p->sNodes);
-    }
-  }
-  if(this->hasSpin()){
-    SerialFunctionTree<3>* serialTree_p = (SerialFunctionTree<3>*) this->dens_s->getSerialTree();
-    if(serialTree_p->nodeCoeffChunks.size()!=1)MSG_ERROR("shared density must start from empty density");
-    
-    //repoint the root coeff
-    MWNode<3> **roots = this->dens_s->getRootBox().getNodes();
-    int nRoots = this->dens_s->getRootBox().size();
-    double * d_ptr = shared_mem_ptr;
-    for (int rIdx = 0; rIdx < nRoots; rIdx++) {
-      roots[rIdx]->coefs =  d_ptr; //repoint adress of root nodecoeff
-      d_ptr += serialTree_p->sizeNodeCoeff; 
-    }
-    //deallocate the old coefficients
-    delete[] serialTree_p->nodeCoeffChunks[0];//deallocate old chunk
-    
-    //preallocate all chunks
-    int size_NodeCoeffChunk = serialTree_p->sizeNodeCoeff*serialTree_p->maxNodesPerChunk;//in units of doubles
-    int size_NodeChunk = sizeof(ProjectedNode<3>)*serialTree_p->maxNodesPerChunk;//in Bytes
-    d_ptr = shared_mem_ptr;
-    serialTree_p->nodeCoeffChunks[0]= shared_mem_ptr;//reset adress of first chunk
-    
-    long int nextsize = 2*size_NodeCoeffChunk;//already set one, and need space for next.
-    long int availsize = shared_size;
-    availsize *= 1024*1024;
-    int maxNChunks = serialTree_p->maxNodes / serialTree_p->maxNodesPerChunk -1;
-    for (int i = 0; nextsize < availsize and i  <maxNChunks; i++) {
-      d_ptr += size_NodeCoeffChunk;
-      nextsize += size_NodeCoeffChunk;
-      serialTree_p->nodeCoeffChunks.push_back(d_ptr);
-      serialTree_p->sNodes = (ProjectedNode<3>*) new char[size_NodeChunk];//NB: nodes (without coeff) are allocated individually, not shared
-      serialTree_p->nodeChunks.push_back(serialTree_p->sNodes);
-    }
-  }
 
-  if(this->hasAlpha()){
-    SerialFunctionTree<3>* serialTree_p = (SerialFunctionTree<3>*) this->dens_a->getSerialTree();
-    if(serialTree_p->nodeCoeffChunks.size()!=1)MSG_ERROR("shared density must start from empty density");
-    
-    //repoint the root coeff
-    MWNode<3> **roots = this->dens_a->getRootBox().getNodes();
-    int nRoots = this->dens_a->getRootBox().size();
-    double * d_ptr = shared_mem_ptr;
-    for (int rIdx = 0; rIdx < nRoots; rIdx++) {
-      roots[rIdx]->coefs =  d_ptr; //repoint adress of root nodecoeff
-      d_ptr += serialTree_p->sizeNodeCoeff; 
-    }
-    //deallocate the old coefficients
-    delete[] serialTree_p->nodeCoeffChunks[0];//deallocate old chunk
-    
-    //preallocate all chunks
-    int size_NodeCoeffChunk = serialTree_p->sizeNodeCoeff*serialTree_p->maxNodesPerChunk;//in units of doubles
-    int size_NodeChunk = sizeof(ProjectedNode<3>)*serialTree_p->maxNodesPerChunk;//in Bytes
-    d_ptr = shared_mem_ptr;
-    serialTree_p->nodeCoeffChunks[0]= shared_mem_ptr;//reset adress of first chunk
-    
-    long int nextsize = 2*size_NodeCoeffChunk;//already set one, and need space for next.
-    long int availsize = shared_size;
-    availsize *= 1024*1024;
-    int maxNChunks = serialTree_p->maxNodes / serialTree_p->maxNodesPerChunk -1;
     for (int i = 0; nextsize < availsize and i  <maxNChunks; i++) {
-      d_ptr += size_NodeCoeffChunk;
-      nextsize += size_NodeCoeffChunk;
-      serialTree_p->nodeCoeffChunks.push_back(d_ptr);
-      serialTree_p->sNodes = (ProjectedNode<3>*) new char[size_NodeChunk];//NB: nodes (without coeff) are allocated individually, not shared
-      serialTree_p->nodeChunks.push_back(serialTree_p->sNodes);
+	d_ptr += size_NodeCoeffChunk;
+	nextsize += size_NodeCoeffChunk;
+	serialTree_p->nodeCoeffChunks.push_back(d_ptr);
+	serialTree_p->sNodes = (ProjectedNode<3>*) new char[size_NodeChunk];//NB: nodes (without coeff) are allocated individually, not shared
+	serialTree_p->nodeChunks.push_back(serialTree_p->sNodes);
     }
-  }
-  if(this->hasBeta()){
-    SerialFunctionTree<3>* serialTree_p = (SerialFunctionTree<3>*) this->dens_b->getSerialTree();
-    if(serialTree_p->nodeCoeffChunks.size()!=1)MSG_ERROR("shared density must start from empty density");
+    // }
+    /*  if(this->hasSpin()){
+	SerialFunctionTree<3>* serialTree_p = (SerialFunctionTree<3>*) this->dens_s->getSerialTree();
+	if(serialTree_p->nodeCoeffChunks.size()!=1)MSG_ERROR("shared density must start from empty density");
     
-    //repoint the root coeff
-    MWNode<3> **roots = this->dens_b->getRootBox().getNodes();
-    int nRoots = this->dens_b->getRootBox().size();
-    double * d_ptr = shared_mem_ptr;
-    for (int rIdx = 0; rIdx < nRoots; rIdx++) {
-      roots[rIdx]->coefs =  d_ptr; //repoint adress of root nodecoeff
-      d_ptr += serialTree_p->sizeNodeCoeff; 
-    }
-    //deallocate the old coefficients
-    delete[] serialTree_p->nodeCoeffChunks[0];//deallocate old chunk
+	//repoint the root coeff
+	MWNode<3> **roots = this->dens_s->getRootBox().getNodes();
+	int nRoots = this->dens_s->getRootBox().size();
+	double * d_ptr = shared_mem_ptr;
+	for (int rIdx = 0; rIdx < nRoots; rIdx++) {
+	roots[rIdx]->coefs =  d_ptr; //repoint adress of root nodecoeff
+	d_ptr += serialTree_p->sizeNodeCoeff; 
+	}
+	//deallocate the old coefficients
+	delete[] serialTree_p->nodeCoeffChunks[0];//deallocate old chunk
     
-    //preallocate all chunks
-    int size_NodeCoeffChunk = serialTree_p->sizeNodeCoeff*serialTree_p->maxNodesPerChunk;//in units of doubles
-    int size_NodeChunk = sizeof(ProjectedNode<3>)*serialTree_p->maxNodesPerChunk;//in Bytes
-    d_ptr = shared_mem_ptr;
-    serialTree_p->nodeCoeffChunks[0]= shared_mem_ptr;//reset adress of first chunk
+	//preallocate all chunks
+	int size_NodeCoeffChunk = serialTree_p->sizeNodeCoeff*serialTree_p->maxNodesPerChunk;//in units of doubles
+	int size_NodeChunk = sizeof(ProjectedNode<3>)*serialTree_p->maxNodesPerChunk;//in Bytes
+	d_ptr = shared_mem_ptr;
+	serialTree_p->nodeCoeffChunks[0]= shared_mem_ptr;//reset adress of first chunk
     
-    long int nextsize = 2*size_NodeCoeffChunk;//already set one, and need space for next.
-    long int availsize = shared_size;
-    availsize *= 1024*1024;
-    int maxNChunks = serialTree_p->maxNodes / serialTree_p->maxNodesPerChunk -1;
-    for (int i = 0; nextsize < availsize and i  <maxNChunks; i++) {
-      d_ptr += size_NodeCoeffChunk;
-      nextsize += size_NodeCoeffChunk;
-      serialTree_p->nodeCoeffChunks.push_back(d_ptr);
-      serialTree_p->sNodes = (ProjectedNode<3>*) new char[size_NodeChunk];//NB: nodes (without coeff) are allocated individually, not shared
-      serialTree_p->nodeChunks.push_back(serialTree_p->sNodes);
-    }
-  }
+	long int nextsize = 2*size_NodeCoeffChunk;//already set one, and need space for next.
+	long int availsize = shared_size;
+	availsize *= 1024*1024;
+	int maxNChunks = serialTree_p->maxNodes / serialTree_p->maxNodesPerChunk -1;
+	for (int i = 0; nextsize < availsize and i  <maxNChunks; i++) {
+	d_ptr += size_NodeCoeffChunk;
+	nextsize += size_NodeCoeffChunk;
+	serialTree_p->nodeCoeffChunks.push_back(d_ptr);
+	serialTree_p->sNodes = (ProjectedNode<3>*) new char[size_NodeChunk];//NB: nodes (without coeff) are allocated individually, not shared
+	serialTree_p->nodeChunks.push_back(serialTree_p->sNodes);
+	}
+	}
+
+	if(this->hasAlpha()){
+	SerialFunctionTree<3>* serialTree_p = (SerialFunctionTree<3>*) this->dens_a->getSerialTree();
+	if(serialTree_p->nodeCoeffChunks.size()!=1)MSG_ERROR("shared density must start from empty density");
+    
+	//repoint the root coeff
+	MWNode<3> **roots = this->dens_a->getRootBox().getNodes();
+	int nRoots = this->dens_a->getRootBox().size();
+	double * d_ptr = shared_mem_ptr;
+	for (int rIdx = 0; rIdx < nRoots; rIdx++) {
+	roots[rIdx]->coefs =  d_ptr; //repoint adress of root nodecoeff
+	d_ptr += serialTree_p->sizeNodeCoeff; 
+	}
+	//deallocate the old coefficients
+	delete[] serialTree_p->nodeCoeffChunks[0];//deallocate old chunk
+    
+	//preallocate all chunks
+	int size_NodeCoeffChunk = serialTree_p->sizeNodeCoeff*serialTree_p->maxNodesPerChunk;//in units of doubles
+	int size_NodeChunk = sizeof(ProjectedNode<3>)*serialTree_p->maxNodesPerChunk;//in Bytes
+	d_ptr = shared_mem_ptr;
+	serialTree_p->nodeCoeffChunks[0]= shared_mem_ptr;//reset adress of first chunk
+    
+	long int nextsize = 2*size_NodeCoeffChunk;//already set one, and need space for next.
+	long int availsize = shared_size;
+	availsize *= 1024*1024;
+	int maxNChunks = serialTree_p->maxNodes / serialTree_p->maxNodesPerChunk -1;
+	for (int i = 0; nextsize < availsize and i  <maxNChunks; i++) {
+	d_ptr += size_NodeCoeffChunk;
+	nextsize += size_NodeCoeffChunk;
+	serialTree_p->nodeCoeffChunks.push_back(d_ptr);
+	serialTree_p->sNodes = (ProjectedNode<3>*) new char[size_NodeChunk];//NB: nodes (without coeff) are allocated individually, not shared
+	serialTree_p->nodeChunks.push_back(serialTree_p->sNodes);
+	}
+	}
+	if(this->hasBeta()){
+	SerialFunctionTree<3>* serialTree_p = (SerialFunctionTree<3>*) this->dens_b->getSerialTree();
+	if(serialTree_p->nodeCoeffChunks.size()!=1)MSG_ERROR("shared density must start from empty density");
+    
+	//repoint the root coeff
+	MWNode<3> **roots = this->dens_b->getRootBox().getNodes();
+	int nRoots = this->dens_b->getRootBox().size();
+	double * d_ptr = shared_mem_ptr;
+	for (int rIdx = 0; rIdx < nRoots; rIdx++) {
+	roots[rIdx]->coefs =  d_ptr; //repoint adress of root nodecoeff
+	d_ptr += serialTree_p->sizeNodeCoeff; 
+	}
+	//deallocate the old coefficients
+	delete[] serialTree_p->nodeCoeffChunks[0];//deallocate old chunk
+    
+	//preallocate all chunks
+	int size_NodeCoeffChunk = serialTree_p->sizeNodeCoeff*serialTree_p->maxNodesPerChunk;//in units of doubles
+	int size_NodeChunk = sizeof(ProjectedNode<3>)*serialTree_p->maxNodesPerChunk;//in Bytes
+	d_ptr = shared_mem_ptr;
+	serialTree_p->nodeCoeffChunks[0]= shared_mem_ptr;//reset adress of first chunk
+    
+	long int nextsize = 2*size_NodeCoeffChunk;//already set one, and need space for next.
+	long int availsize = shared_size;
+	availsize *= 1024*1024;
+	int maxNChunks = serialTree_p->maxNodes / serialTree_p->maxNodesPerChunk -1;
+	for (int i = 0; nextsize < availsize and i  <maxNChunks; i++) {
+	d_ptr += size_NodeCoeffChunk;
+	nextsize += size_NodeCoeffChunk;
+	serialTree_p->nodeCoeffChunks.push_back(d_ptr);
+	serialTree_p->sNodes = (ProjectedNode<3>*) new char[size_NodeChunk];//NB: nodes (without coeff) are allocated individually, not shared
+	serialTree_p->nodeChunks.push_back(serialTree_p->sNodes);
+	}
+	}*/
 #else
-  MSG_ERROR("Cannot allocate shared memory for serial runs");
+    MSG_ERROR("Cannot allocate shared memory for serial runs");
 #endif
 }
 

--- a/src/mrchem/qmfunctions/Density.h
+++ b/src/mrchem/qmfunctions/Density.h
@@ -33,6 +33,7 @@ public:
     bool hasBeta() const { if (this->dens_b == 0) return false; return true; }
 
     bool IsShared() const { if (this->is_shared == 0) return false; return true; }
+    SharedMemory* shMem;
 
     FunctionTree<3> &total() { return *this->dens_t; }
     FunctionTree<3> &spin() { return *this->dens_s; }
@@ -46,7 +47,6 @@ public:
 
     void send_Density(int dest, int tag);
     void Rcv_Density(int source, int tag);
-    void Allocate_Shared_Density(int shared_size);
 #ifdef HAVE_MPI
     MPI_Win MPI_win = MPI_WIN_NULL;
 #endif

--- a/src/mrchem/qmfunctions/Density.h
+++ b/src/mrchem/qmfunctions/Density.h
@@ -2,6 +2,7 @@
 #define DENSITY_H
 
 #include "constants.h"
+#include "parallel.h"
 
 template<int D> class FunctionTree;
 
@@ -46,7 +47,9 @@ public:
     void send_Density(int dest, int tag);
     void Rcv_Density(int source, int tag);
     void Allocate_Shared_Density(int shared_size);
-
+#ifdef HAVE_MPI
+    MPI_Win MPI_win = MPI_WIN_NULL;
+#endif
     enum Spin { Total, Spin, Alpha, Beta };
 
 protected:

--- a/src/mrchem/qmfunctions/Density.h
+++ b/src/mrchem/qmfunctions/Density.h
@@ -7,6 +7,7 @@ template<int D> class FunctionTree;
 
 class Density {
 public:
+    Density(bool spin, bool shared);
     Density(bool s = false);
     Density(const Density &rho);
     virtual ~Density();
@@ -15,6 +16,8 @@ public:
     void setIsSpinDensity(bool s) { this->is_spin = s; }
     bool isSpinDensity() const { return this->is_spin; }
     int getNNodes(int type = Density::Total) const;
+    void setIsShared(bool s) { this->is_shared = s; }
+    bool isShared() const { return this->is_shared; }
 
     void setDensity(int s, FunctionTree<3> *rho);
 
@@ -28,6 +31,8 @@ public:
     bool hasAlpha() const { if (this->dens_a == 0) return false; return true; }
     bool hasBeta() const { if (this->dens_b == 0) return false; return true; }
 
+    bool IsShared() const { if (this->is_shared == 0) return false; return true; }
+
     FunctionTree<3> &total() { return *this->dens_t; }
     FunctionTree<3> &spin() { return *this->dens_s; }
     FunctionTree<3> &alpha() { return *this->dens_a; }
@@ -40,11 +45,13 @@ public:
 
     void send_Density(int dest, int tag);
     void Rcv_Density(int source, int tag);
+    void Allocate_Shared_Density(int shared_size);
 
     enum Spin { Total, Spin, Alpha, Beta };
 
 protected:
     bool is_spin;
+    bool is_shared;
     FunctionTree<3> *dens_t;
     FunctionTree<3> *dens_s;
     FunctionTree<3> *dens_a;

--- a/src/mrchem/qmfunctions/DensityProjector.cpp
+++ b/src/mrchem/qmfunctions/DensityProjector.cpp
@@ -113,7 +113,7 @@ void DensityProjector::operator()(Density &rho, OrbitalVector &phi) {
 	if (rho.isShared()) {
 	    //only master does the summation
 	    if (not rho.hasTotal()) rho.allocTotal();
-	    rho.Allocate_Shared_Density(500);//500-> 500MB //TODO: put somewhere else
+	    //rho.Allocate_Shared_Density(500);//500-> 500MB //TODO: put somewhere else
 	    for (int i_Orb = 0; i_Orb < phi.size(); i_Orb++) {
 		rho_i = new Density(rho);	
 		if (i_Orb%MPI_Orb_size == MPI_Orb_rank) {

--- a/src/mrchem/qmfunctions/Orbital.cpp
+++ b/src/mrchem/qmfunctions/Orbital.cpp
@@ -90,7 +90,7 @@ complex<double> Orbital::dot(Orbital &ket) {
 void Orbital::send_Orbital(int dest, int tag){
 #ifdef HAVE_MPI
   MPI_Status status;
-  MPI_Comm comm=MPI_COMM_WORLD;
+  MPI_Comm comm=MPI_Comm_Orb;
 
   struct Metadata{
     int spin;
@@ -125,7 +125,7 @@ void Orbital::send_Orbital(int dest, int tag){
 //send an orbital with MPI
 void Orbital::Isend_Orbital(int dest, int tag, MPI_Request& request){
   MPI_Status status;
-  MPI_Comm comm=MPI_COMM_WORLD;
+  MPI_Comm comm=MPI_Comm_Orb;
 
   struct Metadata{
     int spin;
@@ -159,7 +159,7 @@ void Orbital::Isend_Orbital(int dest, int tag, MPI_Request& request){
 void Orbital::Rcv_Orbital(int source, int tag){
 #ifdef HAVE_MPI
   MPI_Status status;
-  MPI_Comm comm=MPI_COMM_WORLD;
+  MPI_Comm comm=MPI_Comm_Orb;
 
   struct Metadata{
     int spin;
@@ -202,7 +202,7 @@ void Orbital::Rcv_Orbital(int source, int tag){
 //receive an orbital with MPI
 void Orbital::IRcv_Orbital(int source, int tag){
   MPI_Status status;
-  MPI_Comm comm=MPI_COMM_WORLD;
+  MPI_Comm comm=MPI_Comm_Orb;
 
   struct Metadata{
     int spin;

--- a/src/mrchem/qmfunctions/Orbital.cpp
+++ b/src/mrchem/qmfunctions/Orbital.cpp
@@ -121,9 +121,9 @@ void Orbital::send_Orbital(int dest, int tag){
 #endif
 }
 
-//send an orbital with MPI
-void Orbital::Isend_Orbital(int dest, int tag){
 #ifdef HAVE_MPI
+//send an orbital with MPI
+void Orbital::Isend_Orbital(int dest, int tag, MPI_Request& request){
   MPI_Status status;
   MPI_Comm comm=MPI_COMM_WORLD;
 
@@ -147,15 +147,14 @@ void Orbital::Isend_Orbital(int dest, int tag){
     Orbinfo.NchunksImag = this->imag().getSerialFunctionTree()->nodeChunks.size();//should reduce to actual number of chunks
   }else{Orbinfo.NchunksImag = 0;}
   
-  MPI_Request request;
   int count=sizeof(Metadata);
   MPI_Isend(&Orbinfo, count, MPI_BYTE, dest, 0, comm, &request);
   
-  if(this->hasReal())ISend_SerialTree(&this->real(), Orbinfo.NchunksReal, dest, tag, comm);
-  if(this->hasImag())ISend_SerialTree(&this->imag(), Orbinfo.NchunksImag, dest, tag*10000, comm);
+  if(this->hasReal())ISend_SerialTree(&this->real(), Orbinfo.NchunksReal, dest, tag, comm,  request);
+  if(this->hasImag())ISend_SerialTree(&this->imag(), Orbinfo.NchunksImag, dest, tag*10000, comm, request);
   
-#endif
 }
+#endif
 //receive an orbital with MPI
 void Orbital::Rcv_Orbital(int source, int tag){
 #ifdef HAVE_MPI
@@ -199,9 +198,9 @@ void Orbital::Rcv_Orbital(int source, int tag){
 
 }
 
+#ifdef HAVE_MPI
 //receive an orbital with MPI
 void Orbital::IRcv_Orbital(int source, int tag){
-#ifdef HAVE_MPI
   MPI_Status status;
   MPI_Comm comm=MPI_COMM_WORLD;
 
@@ -214,7 +213,7 @@ void Orbital::IRcv_Orbital(int source, int tag){
   };
 
   Metadata Orbinfo;
-  MPI_Request request;
+  MPI_Request request=MPI_REQUEST_NULL;
 
   int count=sizeof(Metadata);
   MPI_Irecv(&Orbinfo, count, MPI_BYTE, source, 0, comm, &request);
@@ -239,7 +238,5 @@ void Orbital::IRcv_Orbital(int source, int tag){
   }else{
     //&(this->imag())=0;
   }
-  
-#endif
-
 }
+#endif

--- a/src/mrchem/qmfunctions/Orbital.cpp
+++ b/src/mrchem/qmfunctions/Orbital.cpp
@@ -90,7 +90,7 @@ complex<double> Orbital::dot(Orbital &ket) {
 void Orbital::send_Orbital(int dest, int tag){
 #ifdef HAVE_MPI
   MPI_Status status;
-  MPI_Comm comm=MPI_Comm_Orb;
+  MPI_Comm comm=mpiCommOrb;
 
   struct Metadata{
     int spin;
@@ -125,7 +125,7 @@ void Orbital::send_Orbital(int dest, int tag){
 //send an orbital with MPI
 void Orbital::Isend_Orbital(int dest, int tag, MPI_Request& request){
   MPI_Status status;
-  MPI_Comm comm=MPI_Comm_Orb;
+  MPI_Comm comm=mpiCommOrb;
 
   struct Metadata{
     int spin;
@@ -159,7 +159,7 @@ void Orbital::Isend_Orbital(int dest, int tag, MPI_Request& request){
 void Orbital::Rcv_Orbital(int source, int tag){
 #ifdef HAVE_MPI
   MPI_Status status;
-  MPI_Comm comm=MPI_Comm_Orb;
+  MPI_Comm comm=mpiCommOrb;
 
   struct Metadata{
     int spin;
@@ -202,7 +202,7 @@ void Orbital::Rcv_Orbital(int source, int tag){
 //receive an orbital with MPI
 void Orbital::IRcv_Orbital(int source, int tag){
   MPI_Status status;
-  MPI_Comm comm=MPI_Comm_Orb;
+  MPI_Comm comm=mpiCommOrb;
 
   struct Metadata{
     int spin;

--- a/src/mrchem/qmfunctions/Orbital.h
+++ b/src/mrchem/qmfunctions/Orbital.h
@@ -67,8 +67,10 @@ public:
 
     void send_Orbital(int dest, int tag);
     void Rcv_Orbital(int source, int tag);
-    void Isend_Orbital(int dest, int tag);
+#ifdef HAVE_MPI
+    void Isend_Orbital(int dest, int tag, MPI_Request& request);
     void IRcv_Orbital(int source, int tag);
+#endif
 
     friend std::ostream& operator<<(std::ostream &o, Orbital &orb) {
         o << std::setw(25) << orb.getSquareNorm();

--- a/src/mrchem/qmfunctions/OrbitalAdder.cpp
+++ b/src/mrchem/qmfunctions/OrbitalAdder.cpp
@@ -210,7 +210,7 @@ void OrbitalAdder::rotate_P(OrbitalVector &out, const MatrixXd &U, OrbitalVector
     
     //make vector with adresses of own orbitals
     int i = 0;
-    for (int Ix = MPI_rank;  Ix < Ni; Ix += MPI_size) {
+    for (int Ix = MPI_Orb_rank;  Ix < Ni; Ix += MPI_Orb_size) {
       OrbVecChunk_i.push_back(phi.getOrbital(Ix));//i orbitals
       out.getOrbital(Ix).clear(true);
       OrbsIx[i++] = Ix;
@@ -221,7 +221,7 @@ void OrbitalAdder::rotate_P(OrbitalVector &out, const MatrixXd &U, OrbitalVector
       OrbVecChunk_i.getOrbVecChunk(OrbsIx, rcvOrbs, rcvOrbsIx, Ni, iter);
       //Update only own orbitals	
       int j = 0;
-      for (int Jx = MPI_rank;  Jx < Ni; Jx += MPI_size) {
+      for (int Jx = MPI_Orb_rank;  Jx < Ni; Jx += MPI_Orb_size) {
 	VectorXd U_Chunk(rcvOrbs.size());
 	for (int ix = 0; ix<rcvOrbs.size(); ix++)U_Chunk(ix)=U(Jx,rcvOrbsIx[ix]);
 	this->inPlace(out.getOrbital(Jx),U_Chunk, rcvOrbs, false);//can start with empty orbital
@@ -237,7 +237,7 @@ void OrbitalAdder::rotate_P(OrbitalVector &out, const MatrixXd &U, OrbitalVector
 void OrbitalAdder::rotate(OrbitalVector &out, const MatrixXd &U, OrbitalVector &inp) {
     if (U.cols() != inp.size()) MSG_ERROR("Invalid arguments");
     if (U.rows() < out.size()) MSG_ERROR("Invalid arguments");
-    if(MPI_size>1){
+    if(MPI_Orb_size>1){
       rotate_P(out, U, inp);
     }else{
       for (int i = 0; i < out.size(); i++) {
@@ -251,7 +251,7 @@ void OrbitalAdder::rotate(OrbitalVector &out, const MatrixXd &U, OrbitalVector &
 /** In place rotation of orbital vector */
 void OrbitalAdder::rotate(OrbitalVector &out, const MatrixXd &U) {
     OrbitalVector tmp(out);
-    if(MPI_size>1){
+    if(MPI_Orb_size>1){
       rotate_P(tmp, U, out);
     }else{
       rotate(tmp, U, out);

--- a/src/mrchem/qmfunctions/OrbitalAdder.cpp
+++ b/src/mrchem/qmfunctions/OrbitalAdder.cpp
@@ -210,7 +210,7 @@ void OrbitalAdder::rotate_P(OrbitalVector &out, const MatrixXd &U, OrbitalVector
     
     //make vector with adresses of own orbitals
     int i = 0;
-    for (int Ix = MPI_Orb_rank;  Ix < Ni; Ix += MPI_Orb_size) {
+    for (int Ix = mpiOrbRank;  Ix < Ni; Ix += mpiOrbSize) {
       OrbVecChunk_i.push_back(phi.getOrbital(Ix));//i orbitals
       out.getOrbital(Ix).clear(true);
       OrbsIx[i++] = Ix;
@@ -221,7 +221,7 @@ void OrbitalAdder::rotate_P(OrbitalVector &out, const MatrixXd &U, OrbitalVector
       OrbVecChunk_i.getOrbVecChunk(OrbsIx, rcvOrbs, rcvOrbsIx, Ni, iter);
       //Update only own orbitals	
       int j = 0;
-      for (int Jx = MPI_Orb_rank;  Jx < Ni; Jx += MPI_Orb_size) {
+      for (int Jx = mpiOrbRank;  Jx < Ni; Jx += mpiOrbSize) {
 	VectorXd U_Chunk(rcvOrbs.size());
 	for (int ix = 0; ix<rcvOrbs.size(); ix++)U_Chunk(ix)=U(Jx,rcvOrbsIx[ix]);
 	this->inPlace(out.getOrbital(Jx),U_Chunk, rcvOrbs, false);//can start with empty orbital
@@ -237,7 +237,7 @@ void OrbitalAdder::rotate_P(OrbitalVector &out, const MatrixXd &U, OrbitalVector
 void OrbitalAdder::rotate(OrbitalVector &out, const MatrixXd &U, OrbitalVector &inp) {
     if (U.cols() != inp.size()) MSG_ERROR("Invalid arguments");
     if (U.rows() < out.size()) MSG_ERROR("Invalid arguments");
-    if(MPI_Orb_size>1){
+    if(mpiOrbSize>1){
       rotate_P(out, U, inp);
     }else{
       for (int i = 0; i < out.size(); i++) {
@@ -251,7 +251,7 @@ void OrbitalAdder::rotate(OrbitalVector &out, const MatrixXd &U, OrbitalVector &
 /** In place rotation of orbital vector */
 void OrbitalAdder::rotate(OrbitalVector &out, const MatrixXd &U) {
     OrbitalVector tmp(out);
-    if(MPI_Orb_size>1){
+    if(mpiOrbSize>1){
       rotate_P(tmp, U, out);
     }else{
       rotate(tmp, U, out);

--- a/src/mrchem/qmfunctions/OrbitalProjector.cpp
+++ b/src/mrchem/qmfunctions/OrbitalProjector.cpp
@@ -66,7 +66,7 @@ OrbitalVector* OrbitalProjector::operator()(const Nuclei &nucs) {
                     Orbital &phi_i = phi->getOrbital(totOrbs);
 
                     HydrogenicFunction h_func(n, l, m, Z, R);
-		    if (MPI_Orb_rank == nOrbs%MPI_Orb_size) {
+		    if (mpiOrbRank == nOrbs%mpiOrbSize) {
                         phi_i.allocReal();
                         this->project(phi_i.real(), h_func);
                         printout(0, setw(5) << totOrbs);
@@ -103,7 +103,7 @@ void OrbitalProjector::operator()(OrbitalVector &orbs,
         Orbital &mwOrb = orbs.getOrbital(i);
         GaussExp<3> &gtOrb = moExp->getOrbital(i);
         mwOrb.clear(true);
-	if (MPI_Orb_rank == i%MPI_Orb_size) {	
+	if (mpiOrbRank == i%mpiOrbSize) {	
             mwOrb.allocReal();
             this->project(mwOrb.real(), gtOrb);
             printout(0, setw(5) << i);

--- a/src/mrchem/qmfunctions/OrbitalProjector.cpp
+++ b/src/mrchem/qmfunctions/OrbitalProjector.cpp
@@ -66,7 +66,7 @@ OrbitalVector* OrbitalProjector::operator()(const Nuclei &nucs) {
                     Orbital &phi_i = phi->getOrbital(totOrbs);
 
                     HydrogenicFunction h_func(n, l, m, Z, R);
-		    if (MPI_rank == nOrbs%MPI_size) {
+		    if (MPI_Orb_rank == nOrbs%MPI_Orb_size) {
                         phi_i.allocReal();
                         this->project(phi_i.real(), h_func);
                         printout(0, setw(5) << totOrbs);
@@ -103,7 +103,7 @@ void OrbitalProjector::operator()(OrbitalVector &orbs,
         Orbital &mwOrb = orbs.getOrbital(i);
         GaussExp<3> &gtOrb = moExp->getOrbital(i);
         mwOrb.clear(true);
-	if (MPI_rank == i%MPI_size) {	
+	if (MPI_Orb_rank == i%MPI_Orb_size) {	
             mwOrb.allocReal();
             this->project(mwOrb.real(), gtOrb);
             printout(0, setw(5) << i);

--- a/src/mrchem/qmfunctions/OrbitalVector.cpp
+++ b/src/mrchem/qmfunctions/OrbitalVector.cpp
@@ -484,7 +484,7 @@ MatrixXcd OrbitalVector::calcOverlapMatrix() {
     OrbitalVector &bra = *this;
     OrbitalVector &ket = *this;
 
-    if(MPI_size>1){
+    if(MPI_Orb_size>1){
       return bra.calcOverlapMatrix_P_H(ket);
     }else{
       return bra.calcOverlapMatrix(ket);
@@ -524,11 +524,11 @@ MatrixXcd OrbitalVector::calcOverlapMatrix_P(OrbitalVector &ket) {
     int Nj = ket.size();
     //make vector with adresses of own orbitals
     int i = 0;
-    for (int Ix = MPI_rank; Ix < Ni; Ix += MPI_size) {
+    for (int Ix = MPI_Orb_rank; Ix < Ni; Ix += MPI_Orb_size) {
       OrbVecChunk_i.push_back(bra.getOrbital(Ix));//i orbitals
       OrbsIx[i++] = Ix;
     }
-    for (int Ix = MPI_rank; Ix < Nj; Ix += MPI_size)
+    for (int Ix = MPI_Orb_rank; Ix < Nj; Ix += MPI_Orb_size)
       OrbVecChunk_j.push_back(ket.getOrbital(Ix));//j orbitals
     
     for (int iter = 0;  iter >= 0 ; iter++) {
@@ -540,7 +540,7 @@ MatrixXcd OrbitalVector::calcOverlapMatrix_P(OrbitalVector &ket) {
       //overlap between i and j chunks
       for (int i = 0; i < rcvOrbs.size(); i++) {
         for (int j = 0; j < OrbVecChunk_j.size(); j++) {
-          int Jx = MPI_rank+j*MPI_size;
+          int Jx = MPI_Orb_rank+j*MPI_Orb_size;
 	  S_MPI(rcvOrbsIx[i],Jx) = rcvOrbs.getOrbital(i).dot(OrbVecChunk_j.getOrbital(j));
         }
       }
@@ -553,7 +553,7 @@ MatrixXcd OrbitalVector::calcOverlapMatrix_P(OrbitalVector &ket) {
     OrbVecChunk_j.clearVec(false);
     
     MPI_Allreduce(MPI_IN_PLACE, &S_MPI(0,0), Ni*Nj,
-                  MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
+                  MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_Comm_Orb);
     return S_MPI;
 #else
     NOT_REACHED_ABORT;
@@ -579,11 +579,11 @@ MatrixXcd OrbitalVector::calcOverlapMatrix_P_H(OrbitalVector &ket) {
     int Nj = ket.size();
     //make vector with adresses of own orbitals
     int i = 0;
-    for (int Ix = MPI_rank; Ix < Ni; Ix += MPI_size) {
+    for (int Ix = MPI_Orb_rank; Ix < Ni; Ix += MPI_Orb_size) {
       OrbVecChunk_i.push_back(bra.getOrbital(Ix));//i orbitals
       OrbsIx[i++] = Ix;
     }
-    for (int Ix = MPI_rank; Ix < Nj; Ix += MPI_size)
+    for (int Ix = MPI_Orb_rank; Ix < Nj; Ix += MPI_Orb_size)
       OrbVecChunk_j.push_back(ket.getOrbital(Ix));//j orbitals
     
     //NB: last iteration may give empty chunk
@@ -596,9 +596,9 @@ MatrixXcd OrbitalVector::calcOverlapMatrix_P_H(OrbitalVector &ket) {
       //compute overlap between chunks
       for (int i = 0; i < rcvOrbs.size(); i++) {
         for (int j = 0; j < OrbVecChunk_j.size(); j++) {
-	  int Jx = MPI_rank+j*MPI_size;
+	  int Jx = MPI_Orb_rank+j*MPI_Orb_size;
 	  //compute only lower part in own block
-	  if(rcvOrbsIx[i]%MPI_size != MPI_rank or Jx<=rcvOrbsIx[i]){
+	  if(rcvOrbsIx[i]%MPI_Orb_size != MPI_Orb_rank or Jx<=rcvOrbsIx[i]){
 	    S_MPI(rcvOrbsIx[i],Jx) = rcvOrbs.getOrbital(i).dot(OrbVecChunk_j.getOrbital(j));
 	    S_MPI(Jx,rcvOrbsIx[i]) = conj(S_MPI(rcvOrbsIx[i],Jx));//symmetric
 	  }
@@ -613,7 +613,7 @@ MatrixXcd OrbitalVector::calcOverlapMatrix_P_H(OrbitalVector &ket) {
     OrbVecChunk_j.clearVec(false);
     
     MPI_Allreduce(MPI_IN_PLACE, &S_MPI(0,0), Ni*Nj,
-                  MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_COMM_WORLD);
+                  MPI_DOUBLE_COMPLEX, MPI_SUM, MPI_Comm_Orb);
     return S_MPI;
 #else
     NOT_REACHED_ABORT;
@@ -650,7 +650,7 @@ struct Metadata{
 void OrbitalVector::send_OrbVec(int dest, int tag, int* OrbsIx, int start, int maxcount){
 #ifdef HAVE_MPI
   MPI_Status status;
-  MPI_Comm comm=MPI_COMM_WORLD;
+  MPI_Comm comm=MPI_Comm_Orb;
 
   Metadata Orbinfo;
 
@@ -690,7 +690,7 @@ void OrbitalVector::send_OrbVec(int dest, int tag, int* OrbsIx, int start, int m
 //non-blocking send an orbitalvector with MPI
 void OrbitalVector::Isend_OrbVec(int dest, int tag, int* OrbsIx, int start, int maxcount, MPI_Request &request){
   MPI_Status status;
-  MPI_Comm comm=MPI_COMM_WORLD;
+  MPI_Comm comm=MPI_Comm_Orb;
 
   Metadata Orbinfo;
  
@@ -730,7 +730,7 @@ void OrbitalVector::Isend_OrbVec(int dest, int tag, int* OrbsIx, int start, int 
 void OrbitalVector::Rcv_OrbVec(int source, int tag, int* OrbsIx, int& workOrbVecIx){
 #ifdef HAVE_MPI
   MPI_Status status;
-  MPI_Comm comm=MPI_COMM_WORLD;
+  MPI_Comm comm=MPI_Comm_Orb;
   OrbitalVector* workOrbVec_p;//pointer to the workOrbVec to use
   
   if(workOrbVec2.inUse){
@@ -806,15 +806,15 @@ void OrbitalVector::getOrbVecChunk(int* myOrbsIx, OrbitalVector &rcvOrbs, int* r
   int maxOrbs = workOrbVecSize;//max number of orbital to send or receive per iteration
   if(maxOrbs_in>0)maxOrbs = maxOrbs_in;
 
-  int maxsizeperOrbvec = (size + MPI_size-1)/MPI_size;
+  int maxsizeperOrbvec = (size + MPI_Orb_size-1)/MPI_Orb_size;
 
   int RcvOrbVecIx = 0;
 
   /* many index scales:
    * Orbital vector index. max = size
-   * MPI_iter index. The iteration count through all MPI processes. max = MPI_size
+   * MPI_iter index. The iteration count through all MPI processes. max = MPI_Orb_size
    * Index of local orbital (owned by the local MPI process). max = maxsizeperOrbvec
-   * Chunk iteration. max = (maxsizeperOrbvec*MPI_size +  maxOrbs-1)/maxOrbs
+   * Chunk iteration. max = (maxsizeperOrbvec*MPI_Orb_size +  maxOrbs-1)/maxOrbs
    * For accounting, we assume that all MPI are filled with maxsizeperOrbvec;
    * this is in order to know where to restart 
    * Last iteration is for cleanups: clear send and receive vectors and set workOrbVec flag as available.
@@ -832,7 +832,7 @@ void OrbitalVector::getOrbVecChunk(int* myOrbsIx, OrbitalVector &rcvOrbs, int* r
     workOrbVec2.inUse = false;      
   }
 
-  if(MPI_iter0>=MPI_size){
+  if(MPI_iter0>=MPI_Orb_size){
     iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals  
   }
 
@@ -840,16 +840,16 @@ void OrbitalVector::getOrbVecChunk(int* myOrbsIx, OrbitalVector &rcvOrbs, int* r
   for (int MPI_iter = MPI_iter0;  true; MPI_iter++) {
     int maxcount = maxOrbs-(MPI_iter-MPI_iter0)*maxsizeperOrbvec;//place left
     if(maxcount<=0) break;
-    if(MPI_iter>=MPI_size){
+    if(MPI_iter>=MPI_Orb_size){
       iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals  
       break;
     }
-    int rcv_MPI = (MPI_size+MPI_iter-MPI_rank)%MPI_size;//rank of process to communicate with
-    if(MPI_rank > rcv_MPI){
+    int rcv_MPI = (MPI_Orb_size+MPI_iter-MPI_Orb_rank)%MPI_Orb_size;//rank of process to communicate with
+    if(MPI_Orb_rank > rcv_MPI){
       //send first, then receive
       this->send_OrbVec(rcv_MPI, MPI_iter, myOrbsIx, start, maxcount);
       rcvOrbs.Rcv_OrbVec(rcv_MPI, MPI_iter, rcvOrbsIx, RcvOrbVecIx);
-    }else if(MPI_rank < rcv_MPI){
+    }else if(MPI_Orb_rank < rcv_MPI){
       //receive first, then send
       rcvOrbs.Rcv_OrbVec(rcv_MPI,MPI_iter, rcvOrbsIx, RcvOrbVecIx);
       this->send_OrbVec(rcv_MPI, MPI_iter, myOrbsIx, start, maxcount);
@@ -888,7 +888,7 @@ void OrbitalVector::getOrbVecChunk_sym(int* myOrbsIx, OrbitalVector &rcvOrbs, in
   int maxOrbs = workOrbVecSize;//max number of orbital to send or receive per iteration
   if(maxOrbs_in>0)maxOrbs = maxOrbs_in;
 
-  int maxsizeperOrbvec = (size + MPI_size-1)/MPI_size;
+  int maxsizeperOrbvec = (size + MPI_Orb_size-1)/MPI_Orb_size;
 
   int RcvOrbVecIx = 0;
 #ifdef HAVE_MPI
@@ -897,9 +897,9 @@ void OrbitalVector::getOrbVecChunk_sym(int* myOrbsIx, OrbitalVector &rcvOrbs, in
   MPI_Status status;
   /* many index scales:
    * Orbital vector index. max = size
-   * MPI_iter index. The iteration count through all MPI processes. max = MPI_size
+   * MPI_iter index. The iteration count through all MPI processes. max = MPI_Orb_size
    * Index of local orbital (owned by the local MPI process). max = maxsizeperOrbvec
-   * Chunk iteration. max = (maxsizeperOrbvec*MPI_size + maxOrbs-1)/maxOrbs
+   * Chunk iteration. max = (maxsizeperOrbvec*MPI_Orb_size + maxOrbs-1)/maxOrbs
    * For accounting, we assume that all MPI are filled with maxsizeperOrbvec;
    * this is in order to know where to restart 
    */
@@ -915,27 +915,27 @@ void OrbitalVector::getOrbVecChunk_sym(int* myOrbsIx, OrbitalVector &rcvOrbs, in
     workOrbVec2.inUse = false;      
   }
  
-  if(MPI_iter0 >= (MPI_size/2 + 1) ){
+  if(MPI_iter0 >= (MPI_Orb_size/2 + 1) ){
       iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals  
   }
 
   int isnd=0;
-  for (int MPI_iter = MPI_iter0;  MPI_iter < MPI_size; MPI_iter++) {
+  for (int MPI_iter = MPI_iter0;  MPI_iter < MPI_Orb_size; MPI_iter++) {
     int maxcount = maxOrbs-(MPI_iter-MPI_iter0)*maxsizeperOrbvec;//place left
     if(maxcount <= 0)  break;//chunk is full
-    if(MPI_iter >= (MPI_size/2 + 1) ){
+    if(MPI_iter >= (MPI_Orb_size/2 + 1) ){
       iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals  
       break;
     }
-    int rcv_MPI = abs((MPI_size-MPI_iter+MPI_rank)%MPI_size);//rank of process to receive from
-    int snd_MPI = (MPI_size+MPI_iter+MPI_rank)%MPI_size;//rank of process to send to
+    int rcv_MPI = abs((MPI_Orb_size-MPI_iter+MPI_Orb_rank)%MPI_Orb_size);//rank of process to receive from
+    int snd_MPI = (MPI_Orb_size+MPI_iter+MPI_Orb_rank)%MPI_Orb_size;//rank of process to send to
 
     if(rcv_MPI == snd_MPI){
       //only one of them do need to do the job: the one with lowest rank (of course!)
-      if(MPI_rank>rcv_MPI)rcv_MPI = -1;//to indicate receive nothing
-      if(MPI_rank<rcv_MPI)snd_MPI = -1;//to indicate send nothing
+      if(MPI_Orb_rank>rcv_MPI)rcv_MPI = -1;//to indicate receive nothing
+      if(MPI_Orb_rank<rcv_MPI)snd_MPI = -1;//to indicate send nothing
     }
-    if(MPI_rank != rcv_MPI){
+    if(MPI_Orb_rank != rcv_MPI){
       //non-blocking send first, then receive
       if(snd_MPI>=0){
 	for (int i = start;  i < this->size() && (i-start<maxcount) && sndOrbIx!=0 && sndOrbIx!=0; i++){

--- a/src/mrchem/qmfunctions/OrbitalVector.h
+++ b/src/mrchem/qmfunctions/OrbitalVector.h
@@ -71,6 +71,7 @@ public:
     void Rcv_OrbVec(int source, int tag, int* OrbsIx, int& workOrbVecIx);
     void getOrbVecChunk(int* myOrbsIx, OrbitalVector &rcvOrbs, int* rcvOrbsIx, int size, int& iter0);
     void getOrbVecChunk_sym(int* myOrbsIx, OrbitalVector &rcvOrbs, int* rcvOrbsIx, int size, int& iter0);
+    bool inUse=false;
 
     friend std::ostream& operator<<(std::ostream &o, OrbitalVector &orb_set) {
         int oldPrec = TelePrompter::setPrecision(15);

--- a/src/mrchem/qmfunctions/OrbitalVector.h
+++ b/src/mrchem/qmfunctions/OrbitalVector.h
@@ -67,10 +67,13 @@ public:
     int printTreeSizes() const;
 
     void send_OrbVec(int dest, int tag, int* OrbsIx, int start, int maxcount);
-    void Isend_OrbVec(int dest, int tag, int* OrbsIx, int start, int maxcount);
+#ifdef HAVE_MPI
+    void Isend_OrbVec(int dest, int tag, int* OrbsIx, int start, int maxcount, MPI_Request& request);
+#endif
     void Rcv_OrbVec(int source, int tag, int* OrbsIx, int& workOrbVecIx);
-    void getOrbVecChunk(int* myOrbsIx, OrbitalVector &rcvOrbs, int* rcvOrbsIx, int size, int& iter0);
-    void getOrbVecChunk_sym(int* myOrbsIx, OrbitalVector &rcvOrbs, int* rcvOrbsIx, int size, int& iter0);
+    void getOrbVecChunk(int* myOrbsIx, OrbitalVector &rcvOrbs, int* rcvOrbsIx, int size, int& iter0, int maxOrbs_in=-1, int workIx=0);
+    void getOrbVecChunk_sym(int* myOrbsIx, OrbitalVector &rcvOrbs, int* rcvOrbsIx, int size, int& iter0, int* sndtoMPI=0, int* sndOrbIx=0, int maxOrbs_in=-1, int workIx=0);
+
     bool inUse=false;
 
     friend std::ostream& operator<<(std::ostream &o, OrbitalVector &orb_set) {

--- a/src/mrchem/qmoperators/CoulombOperator.h
+++ b/src/mrchem/qmoperators/CoulombOperator.h
@@ -9,14 +9,17 @@ public:
     CoulombOperator(PoissonOperator &P, OrbitalVector &phi)
         : poisson(&P),
           orbitals(&phi),
+#ifdef HAVE_MPI
+          density(false, true){//Use shared memory. 
+#else
           density(false) {
+#endif
     }
     virtual ~CoulombOperator() { }
 
 protected:
     PoissonOperator *poisson;   // Pointer to external object
     OrbitalVector *orbitals;    // Pointer to external object
-
     Density density;            // Density that defines the potential
 };
 

--- a/src/mrchem/qmoperators/ExchangePotential.cpp
+++ b/src/mrchem/qmoperators/ExchangePotential.cpp
@@ -4,8 +4,12 @@
 #include "PoissonOperator.h"
 #include "MWConvolution.h"
 
+
 using namespace std;
 using namespace Eigen;
+
+extern Orbital workOrb;
+extern OrbitalVector workOrbVec2;
 
 ExchangePotential::ExchangePotential(PoissonOperator &P,
                                      OrbitalVector &phi,
@@ -58,6 +62,63 @@ Orbital* ExchangePotential::calcExchange(Orbital &phi_p) {
     vector<Orbital *> orb_vec;
 
     int nOrbs = this->orbitals->size();
+
+    Orbital *ex_p = new Orbital(phi_p);
+
+#ifdef HAVE_MPI
+
+    OrbitalVector OrbVecChunk_i(0);//to store adresses of own i_orbs
+    int OrbsIx[workOrbVecSize];//to store own orbital indices
+    OrbitalVector rcvOrbs(0);//to store adresses of received orbitals
+    int rcvOrbsIx[workOrbVecSize];//to store received orbital indices
+
+    //make vector with adresses of own orbitals
+    int i = 0;
+    for (int Ix = MPI_rank;  Ix < nOrbs; Ix += MPI_size) {
+      OrbVecChunk_i.push_back(this->orbitals->getOrbital(Ix));//i orbitals
+      OrbsIx[i++] = Ix;
+    }
+
+    for (int iter = 0;  iter >= 0; iter++) {
+      //get a new chunk from other processes
+      OrbVecChunk_i.getOrbVecChunk(OrbsIx, rcvOrbs, rcvOrbsIx, nOrbs, iter, workOrbVecSize, 2);
+      for (int i = 0; i<rcvOrbs.size(); i++){
+	Orbital &phi_i = rcvOrbs.getOrbital(i);
+	
+        double spinFactor = phi_i.getExchangeFactor(phi_p);
+        if (IS_EQUAL(spinFactor, 0.0)) continue;
+        Orbital *phi_ip = new Orbital(phi_p);
+        mult.adjoint(*phi_ip, 1.0, phi_i, phi_p);
+
+        Orbital *V_ip = new Orbital(phi_p);
+        if (phi_ip->hasReal()) {
+            V_ip->allocReal();
+            apply(V_ip->real(), P, phi_ip->real());
+        }
+        if (phi_ip->hasImag()) {
+            V_ip->allocImag();
+            apply(V_ip->imag(), P, phi_ip->imag());
+        }
+        delete phi_ip;
+
+        double multFac = - spinFactor * (this->x_factor / phi_i.getSquareNorm());
+        Orbital *phi_iip = new Orbital(phi_p);
+        mult(*phi_iip, multFac, phi_i, *V_ip);
+        delete V_ip;
+
+        coef_vec.push_back(1.0);
+        orb_vec.push_back(phi_iip);
+      }
+    }
+    OrbVecChunk_i.clearVec(false);
+    rcvOrbs.clearVec(false);
+	
+    add(*ex_p, coef_vec, orb_vec, true);
+
+    for (int i = 0; i < orb_vec.size(); i++) delete orb_vec[i];
+    orb_vec.clear();
+
+#else
     for (int i = 0; i < nOrbs; i++) {
         Orbital &phi_i = this->orbitals->getOrbital(i);
 
@@ -86,11 +147,13 @@ Orbital* ExchangePotential::calcExchange(Orbital &phi_p) {
         coef_vec.push_back(1.0);
         orb_vec.push_back(phi_iip);
     }
-    Orbital *ex_p = new Orbital(phi_p);
+
     add(*ex_p, coef_vec, orb_vec, true);
 
     for (int i = 0; i < orb_vec.size(); i++) delete orb_vec[i];
     orb_vec.clear();
+
+#endif
 
     timer.stop();
     double n = ex_p->getNNodes();
@@ -104,20 +167,137 @@ Orbital* ExchangePotential::calcExchange(Orbital &phi_p) {
 void ExchangePotential::calcInternalExchange() {
     Timer timer;
     int nOrbs = this->orbitals->size();
-    for (int i = 0; i < nOrbs; i++) {
-        calcInternal(i);
-        for (int j = 0; j < i; j++) {
-            calcInternal(i,j);
-        }
-    }
-
     int n = 0;
-    for (int i = 0; i < nOrbs; i++) {
+
+    if(MPI_size==1){
+      for (int i = 0; i < nOrbs; i++) {
+        calcInternal(i);
+	for (int j = 0; j < i; j++) {
+	  calcInternal(i,j);
+	}
+      }
+      
+      for (int i = 0; i < nOrbs; i++) {
         Orbital &ex_i = this->exchange.getOrbital(i);
         this->tot_norms(i) = sqrt(ex_i.getSquareNorm());
         n = max(n, ex_i.getNNodes());
-    }
+      }
+    }else{
 
+#ifdef HAVE_MPI
+
+      //use symmetri
+      //send one orbital at a time
+      MPI_Request request=MPI_REQUEST_NULL;
+      MPI_Status status;
+      //has to distribute the calculations evenly among processors
+      OrbitalVector OrbVecChunk_i(0);//to store adresses of own i_orbs
+      int OrbsIx[workOrbVecSize];//to store own orbital indices
+      OrbitalVector rcvOrbs(0);//to store adresses of received orbitals
+      int rcvOrbsIx[workOrbVecSize];//to store received orbital indices
+      
+      int sndtoMPI[workOrbVecSize];//to store rank of MPI where orbitals were sent
+      int sndOrbIx[workOrbVecSize];//to store indices of where orbitals were sent
+      
+      //make vector with adresses of own orbitals
+      int i = 0;
+      for (int Ix = MPI_rank;  Ix < nOrbs; Ix += MPI_size) {
+	OrbVecChunk_i.push_back(this->orbitals->getOrbital(Ix));//i orbitals
+	OrbsIx[i++] = Ix;
+      }
+      
+      OrbitalAdder add(-1.0, this->max_scale);
+      for (int i = 0; i<workOrbVecSize; i++)sndtoMPI[i]=-1;//init
+      int mpiiter = 0;
+      Orbital *phi_iij = 0;
+      Orbital *phi_jji_rcv = 0;	      
+      for (int iter = 0;  iter >= 0; iter++) {
+	mpiiter++;
+	//get a new chunk from other processes
+	sndOrbIx[0]=0;//init
+	sndtoMPI[0]=-1;//init
+	OrbVecChunk_i.getOrbVecChunk_sym(OrbsIx, rcvOrbs, rcvOrbsIx, nOrbs, iter, sndtoMPI, sndOrbIx,1,2);
+	
+	int rcv_left=1;//normally we get one phi_jji per ii, maybe none
+	if(sndtoMPI[0]<0 or sndtoMPI[0]==MPI_rank)rcv_left=0;//we haven't sent anything, will not receive anything back	    
+	//convention: all indices with "i" are owned locally
+	for (int ii = 0; ii<OrbVecChunk_i.size()+1 ; ii++){ //we may have to do one extra iteration to fetch all data
+	  int j=0;//because we limited the size in getOrbVecChunk_sym to 1
+	  int i=ii;
+	  if(ii>=OrbVecChunk_i.size())i=0;//so that phi_i is defined, but will not be used
+	  
+	  Orbital &phi_i = OrbVecChunk_i.getOrbital(i);
+	  if(phi_iij==0) phi_iij = new Orbital(phi_i);
+	  int i_rcv = sndOrbIx[j];
+	  Orbital &phi_i_rcv = this->orbitals->getOrbital(i_rcv);
+	  if(phi_jji_rcv==0) phi_jji_rcv = new Orbital(phi_i_rcv);
+	  if(rcvOrbs.size()>0 and ii<OrbVecChunk_i.size()){
+	    if(OrbsIx[i]==rcvOrbsIx[j]){
+	      //orbital should be own and i and j point to same orbital
+	      calcInternal(OrbsIx[i]);
+	    }else{	    
+	      Orbital &phi_j = rcvOrbs.getOrbital(j);	    
+	      if(rcvOrbsIx[j]%MPI_size != MPI_rank){
+		calcInternal(OrbsIx[i], rcvOrbsIx[j], phi_i, phi_j, phi_iij);
+		//we send back the locally computed result to where j came from 
+		phi_iij->setOccupancy(OrbsIx[i]);//We temporarily use Occupancy to send Orbital rank 
+		phi_iij->setSpin(OrbVecChunk_i.size()-i-1);//We temporarily use Spin to send info about number of transfers left
+		phi_iij->setError( this->part_norms(rcvOrbsIx[j],OrbsIx[i]));//We temporarily use Error to send part_norm
+		phi_iij->Isend_Orbital(rcvOrbsIx[j]%MPI_size, mpiiter%10, request);
+	      }else{
+		//only compute j < i in own block 
+		if(rcvOrbsIx[j]<OrbsIx[i])calcInternal(OrbsIx[i], rcvOrbsIx[j], phi_i, phi_j, phi_iij);
+	      }
+	    }
+	  }
+	  if(rcv_left>0){
+	    //we expect to receive data 
+	    phi_jji_rcv->Rcv_Orbital(sndtoMPI[j], mpiiter%10);//we get back phi_jji from where we sent i
+	  }
+	  if(rcvOrbsIx[j]%MPI_size != MPI_rank and rcvOrbs.size()>0 and ii<OrbVecChunk_i.size()){
+	    MPI_Wait(&request, &status);//do not continue before isend is finished	      
+	  }
+	  if(rcv_left >0){
+	    // phi_jji_rcv is ready
+	    int i_rcv = sndOrbIx[j];
+	    int j_rcv = phi_jji_rcv->getOccupancy();//occupancy was used to send rank!
+	    rcv_left = phi_jji_rcv->getSpin();//occupancy was used to send number of transfers left!
+	    if(i_rcv!=j_rcv){
+	      phi_jji_rcv->setOccupancy(this->orbitals->getOrbital(j_rcv).getOccupancy());//restablish occupancy		
+	      phi_jji_rcv->setSpin(this->orbitals->getOrbital(j_rcv).getSpin());//restablish spin		
+	      this->part_norms(i_rcv,j_rcv) = phi_jji_rcv->getError();//does not seem to matter?
+	      phi_jji_rcv->setError(this->orbitals->getOrbital(j_rcv).getError());//restablish error		
+	      //j_rcv and i_rcv are now the active indices j_rcv is the remote orbital
+	      // compute x_i_rcv += phi_jji_rcv j_rcv is the remote orbital here i_rcv is what has been used to compute phi_jji_rcv
+	      this->part_norms(j_rcv,i_rcv) = sqrt(phi_jji_rcv->getSquareNorm());
+	      Orbital &ex_i_rcv = this->exchange.getOrbital(i_rcv);
+	      Orbital &phi_j_rcv = this->orbitals->getOrbital(j_rcv);
+	      double i_factor_rcv = phi_i_rcv.getExchangeFactor(phi_j_rcv);
+	      add.inPlace(ex_i_rcv, i_factor_rcv, *phi_jji_rcv);
+	    }
+	  }	  
+	}
+	rcvOrbs.clearVec(false);//reset to zero size orbital vector     	
+      }
+      if (phi_jji_rcv != 0) delete phi_jji_rcv;
+      if (phi_iij != 0) delete phi_iij;
+      OrbVecChunk_i.clearVec(false);
+      
+      for (int i = 0; i < nOrbs; i++) {
+	if(i%MPI_size==MPI_rank){
+	  Orbital &ex_i = this->exchange.getOrbital(i);
+	  this->tot_norms(i) = sqrt(ex_i.getSquareNorm());
+	  n = max(n, ex_i.getNNodes());
+	}else{
+	  this->tot_norms(i) = 0.0;
+	}
+      }
+      //tot_norms are used for screening. Since we use symmetri, we might need factors from others
+      MPI_Allreduce(MPI_IN_PLACE, &this->tot_norms(0), nOrbs, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+
+#endif
+    }
+   
     timer.stop();
     double t = timer.getWallTime();
     TelePrompter::printTree(0, "Hartree-Fock exchange", n, t);
@@ -183,7 +363,9 @@ void ExchangePotential::calcInternal(int i, int j) {
         return;
     }
 
-    double prec = getScaledPrecision(i, j);
+    //    double prec = getScaledPrecision(i, j);
+    double prec = std::max(getScaledPrecision(i, j), getScaledPrecision(j, i));
+
     if (prec > 1.0e00) return;
     prec = min(prec, 1.0e-1);
 
@@ -230,13 +412,147 @@ void ExchangePotential::calcInternal(int i, int j) {
     add.inPlace(ex_j, j_factor, *phi_iij);
     if (phi_iij != 0) delete phi_iij;
 }
+//NB: this routine only compute ex_i, never ex_j
+void ExchangePotential::calcInternal(int i, int j, Orbital &phi_i, Orbital &phi_j) {
+    OrbitalAdder add(-1.0, this->max_scale);
+    OrbitalMultiplier mult(-1.0, this->max_scale);
+    MWConvolution<3> apply(-1.0, this->max_scale);
+
+    PoissonOperator &P = *this->poisson;
+    //    Orbital &phi_i = this->orbitals->getOrbital(i);
+    //    Orbital &phi_j = this->orbitals->getOrbital(j);
+
+    double i_factor = phi_i.getExchangeFactor(phi_j);
+    double j_factor = phi_j.getExchangeFactor(phi_i);
+    if (IS_EQUAL(i_factor, 0.0) or IS_EQUAL(j_factor, 0.0)) {
+        this->part_norms(i,j) = 0.0;
+        return;
+    }
+
+    //    double prec = getScaledPrecision(i, j);
+    double prec = std::max(getScaledPrecision(i, j), getScaledPrecision(j, i));
+
+    if (prec > 1.0e00) return;
+    prec = min(prec, 1.0e-1);
+
+    mult.setPrecision(prec);
+    apply.setPrecision(prec);
+
+    // compute phi_ij = phi_i^dag * phi_j
+    Orbital *phi_ij = new Orbital(phi_i);
+    mult.adjoint(*phi_ij, 1.0, phi_i, phi_j);
+
+    // compute V_ij = P[phi_ij]
+    Orbital *V_ij = new Orbital(phi_i);
+    if (phi_ij->hasReal()) {
+        V_ij->allocReal();
+        apply(V_ij->real(), P, phi_ij->real());
+    }
+    if (phi_ij->hasImag()) {
+        V_ij->allocImag();
+        apply(V_ij->imag(), P, phi_ij->imag());
+    }
+    if (phi_ij != 0) delete phi_ij;
+
+    // compute phi_jij = phi_j * V_ij
+    double fac_jij = -(this->x_factor/phi_j.getSquareNorm());
+    Orbital *phi_jij = new Orbital(phi_i);
+    mult(*phi_jij, fac_jij, phi_j, *V_ij);
+    this->part_norms(j,i) = sqrt(phi_jij->getSquareNorm());
+
+    //part_norms(i,j) MUST be computed to use for symmetric screening
+    // compute phi_iij = phi_i * V_ij
+    Orbital *phi_iij = new Orbital(phi_i);
+    double fac_iij = -(this->x_factor/phi_i.getSquareNorm());
+    mult(*phi_iij, fac_iij, phi_i, *V_ij);
+    this->part_norms(i,j) = sqrt(phi_iij->getSquareNorm());
+    if (phi_iij != 0) delete phi_iij;
+
+    if (V_ij != 0) delete V_ij;
+
+    // compute x_i += phi_jij
+    Orbital &ex_i = this->exchange.getOrbital(i);
+    add.inPlace(ex_i, i_factor, *phi_jij);
+    if (phi_jij != 0) delete phi_jij;
+
+}
+
+void ExchangePotential::calcInternal(int i, int j, Orbital &phi_i, Orbital &phi_j, Orbital* phi_iij) {
+  //to check: adjoint or not?
+    OrbitalAdder add(-1.0, this->max_scale);
+    OrbitalMultiplier mult(-1.0, this->max_scale);
+    MWConvolution<3> apply(-1.0, this->max_scale);
+
+    PoissonOperator &P = *this->poisson;
+    //    Orbital &phi_i = this->orbitals->getOrbital(i);
+    //    Orbital &phi_j = this->orbitals->getOrbital(j);
+
+    double i_factor = phi_i.getExchangeFactor(phi_j);
+    double j_factor = phi_j.getExchangeFactor(phi_i);
+    if (IS_EQUAL(i_factor, 0.0) or IS_EQUAL(j_factor, 0.0)) {
+        this->part_norms(i,j) = 0.0;
+        return;
+    }
+
+    //    double prec = getScaledPrecision(i, j);
+    double prec = std::max(getScaledPrecision(i, j), getScaledPrecision(j, i));
+    if (prec > 1.0e00) return;
+    prec = min(prec, 1.0e-1);
+
+    mult.setPrecision(prec);
+    apply.setPrecision(prec);
+
+    // compute phi_ij = phi_i^dag * phi_j
+    Orbital *phi_ij = new Orbital(phi_i);
+    mult.adjoint(*phi_ij, 1.0, phi_i, phi_j);
+
+    // compute V_ij = P[phi_ij]
+    Orbital *V_ij = new Orbital(phi_i);
+    if (phi_ij->hasReal()) {
+        V_ij->allocReal();
+        apply(V_ij->real(), P, phi_ij->real());
+    }
+    if (phi_ij->hasImag()) {
+        V_ij->allocImag();
+        apply(V_ij->imag(), P, phi_ij->imag());
+    }
+    if (phi_ij != 0) delete phi_ij;
+
+    // compute phi_jij = phi_j * V_ij
+    double fac_jij = -(this->x_factor/phi_j.getSquareNorm());
+    Orbital *phi_jij = new Orbital(phi_i);
+    mult(*phi_jij, fac_jij, phi_j, *V_ij);
+    this->part_norms(j,i) = sqrt(phi_jij->getSquareNorm());
+
+    // compute x_i += phi_jij
+    Orbital &ex_i = this->exchange.getOrbital(i);
+    add.inPlace(ex_i, i_factor, *phi_jij);
+    if (phi_jij != 0) delete phi_jij;
+
+
+    //part_norms(i,j) MUST be computed to use for symmetric screening
+    // compute phi_iij = phi_i * V_ij
+    double fac_iij = -(this->x_factor/phi_i.getSquareNorm());
+    mult(*phi_iij, fac_iij, phi_i, *V_ij);
+    this->part_norms(i,j) = sqrt(phi_iij->getSquareNorm());
+
+    if (V_ij != 0) delete V_ij;
+
+    //This part (phi_iij) is sent to owner of j orbital if it is on another MPI
+    if(j%MPI_size==MPI_rank){
+       // compute x_j += phi_iij
+        Orbital &ex_j = this->exchange.getOrbital(j);
+        add.inPlace(ex_j, j_factor, *phi_iij);
+    }
+}
 
 Orbital* ExchangePotential::testPreComputed(Orbital &phi_p) {
     int nOrbs = this->orbitals->size();
+    
     for (int i = 0; i < nOrbs; i++) {
         Orbital &phi_i  = this->orbitals->getOrbital(i);
         Orbital *ex_i = this->exchange[i];
-        if (&phi_i == &phi_p and ex_i != 0) {
+        if (&phi_i == &phi_p and ex_i->getNNodes() != 0) {
             Orbital *result = new Orbital(phi_p);
             // Deep copy of orbital
             OrbitalAdder add(this->apply_prec, this->max_scale);

--- a/src/mrchem/qmoperators/ExchangePotential.cpp
+++ b/src/mrchem/qmoperators/ExchangePotential.cpp
@@ -548,7 +548,8 @@ Orbital* ExchangePotential::testPreComputed(Orbital &phi_p) {
     for (int i = 0; i < nOrbs; i++) {
         Orbital &phi_i  = this->orbitals->getOrbital(i);
         Orbital *ex_i = this->exchange[i];
-        if (&phi_i == &phi_p and ex_i->getNNodes() != 0) {
+	//if (&phi_i == &phi_p and ex_i->getNNodes() != 0) { //cannot be used with MPI, because phi_p is moved
+        if (&phi_i.real() == &phi_p.real() and &phi_i.imag() == &phi_p.imag() and ex_i->getNNodes() != 0) {
             Orbital *result = new Orbital(phi_p);
             // Deep copy of orbital
             OrbitalAdder add(this->apply_prec, this->max_scale);

--- a/src/mrchem/qmoperators/ExchangePotential.h
+++ b/src/mrchem/qmoperators/ExchangePotential.h
@@ -94,6 +94,22 @@ protected:
      * The off-diagonal term X_ij is computed. 
      */
     void calcInternal(int i, int j);
+
+    /*! computes the off-diagonal part of the exchange potential for own orbitals
+     *  \param[in] i first orbital index
+     *  \param[in] j second orbital index
+     *
+     * The off-diagonal term X_ij is computed. 
+     */
+    void calcInternal(int i, int j, Orbital &phi_i, Orbital &phi_j);
+    /*! computes the off-diagonal part of the exchange potential for own orbitals
+     *  and return V_ij for further use
+     *  \param[in] i first orbital index
+     *  \param[in] j second orbital index
+     *
+     * The off-diagonal term X_ij is computed. 
+     */
+    void calcInternal(int i, int j, Orbital &phi_i, Orbital &phi_j, Orbital *V_ij );
 };
 
 #endif // EXCHANGEPOTENTIAL_H

--- a/src/mrchem/qmoperators/FockOperator.cpp
+++ b/src/mrchem/qmoperators/FockOperator.cpp
@@ -126,13 +126,13 @@ MatrixXd FockOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs)
 
     //make vector with adresses of own orbitals
     int i = 0;
-    for (int Ix = MPI_rank; Ix < Ni; Ix += MPI_size) {
+    for (int Ix = MPI_Orb_rank; Ix < Ni; Ix += MPI_Orb_size) {
       OrbVecChunk_i.push_back(i_orbs.getOrbital(Ix));//i orbitals
       OrbsIx[i++] = Ix;
     }
-    for (int Ix = MPI_rank; Ix < Nj; Ix += MPI_size) OrbVecChunk_j.push_back(j_orbs.getOrbital(Ix));//j orbitals
+    for (int Ix = MPI_Orb_rank; Ix < Nj; Ix += MPI_Orb_size) OrbVecChunk_j.push_back(j_orbs.getOrbital(Ix));//j orbitals
     //need to pad OrbVecChunk_j so that all have same size
-    if(OrbVecChunk_j.size()<(Nj+MPI_size-1)/MPI_size)OrbVecChunk_j.push_back(j_orbs.getOrbital(0));
+    if(OrbVecChunk_j.size()<(Nj+MPI_Orb_size-1)/MPI_Orb_size)OrbVecChunk_j.push_back(j_orbs.getOrbital(0));
 
     for (int iter = 0;  iter >= 0 ; iter++) {
       //get a new chunk from other processes
@@ -150,7 +150,7 @@ MatrixXd FockOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs)
 	resultChunk += (*this->K)(rcvOrbs,OrbVecChunk_j);
 	if(rcvOrbs.size()==0 and iter>=0 ){
 	  //we must still go through operator to send own orbitals to others. Just make a fake operation!
-	  rcvOrbs.push_back(i_orbs.getOrbital(MPI_rank));//i orbitals
+	  rcvOrbs.push_back(i_orbs.getOrbital(MPI_Orb_rank));//i orbitals
 	  MatrixXd resultChunk_notused = MatrixXd::Zero(rcvOrbs.size(),OrbVecChunk_j.size());
 	  resultChunk_notused = (*this->K)(rcvOrbs,OrbVecChunk_j);	  
 	}
@@ -159,7 +159,7 @@ MatrixXd FockOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs)
 
       //copy results into final matrix
       int j = 0;
-      for (int Jx = MPI_rank;  Jx < Nj ; Jx += MPI_size) {
+      for (int Jx = MPI_Orb_rank;  Jx < Nj ; Jx += MPI_Orb_size) {
 	for (int ix = 0;  ix<rcvOrbs.size() ; ix++) {
 	  result(rcvOrbsIx[ix],Jx) += resultChunk(ix,j);
 	}
@@ -174,7 +174,7 @@ MatrixXd FockOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs)
 
     //combine results from all processes
     MPI_Allreduce(MPI_IN_PLACE, &result(0,0), Ni*Nj,
-                  MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+                  MPI_DOUBLE, MPI_SUM, MPI_Comm_Orb);
 
 #else
     Timer tot_t;
@@ -223,7 +223,7 @@ MatrixXd FockOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs)
 }
 
 MatrixXd FockOperator::adjoint(OrbitalVector &i_orbs, OrbitalVector &j_orbs) {
-  if(MPI_size>1)cout<<"ERROR"<<endl;
+  if(MPI_Orb_size>1)cout<<"ERROR"<<endl;
     int Ni = i_orbs.size();
     int Nj = j_orbs.size();
     MatrixXd result = MatrixXd::Zero(Ni,Nj);
@@ -254,7 +254,7 @@ Orbital* FockOperator::applyPotential(Orbital &orb_p) {
     timer.stop();
     double time = timer.getWallTime();
     int nNodes = result->getNNodes();
-    if(MPI_size==1)TelePrompter::printTree(1, "Sum potential operator", nNodes, time);
+    if(MPI_Orb_size==1)TelePrompter::printTree(1, "Sum potential operator", nNodes, time);
 
     for (int n = 0; n < orbs.size(); n++) {
         delete orbs[n];
@@ -326,7 +326,7 @@ SCFEnergy FockOperator::trace(OrbitalVector &phi, MatrixXd &F) {
     double E_xc2 = 0.0;
     if (this->XC != 0) E_xc = this->XC->getEnergy();
     for (int i = 0; i < phi.size(); i++) {
-        if (i%MPI_size == MPI_rank) {
+        if (i%MPI_Orb_size == MPI_Orb_rank) {
             Orbital &phi_i = phi.getOrbital(i);
             double occ = (double) phi_i.getOccupancy();
             double e_i = occ*F(i,i);
@@ -358,7 +358,7 @@ SCFEnergy FockOperator::trace(OrbitalVector &phi, MatrixXd &F) {
     tmp[2] = E_ee;
     tmp[3] = E_x;
     tmp[4] = E_xc2;
-    MPI_Allreduce(MPI_IN_PLACE,tmp, 5, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    MPI_Allreduce(MPI_IN_PLACE,tmp, 5, MPI_DOUBLE, MPI_SUM, MPI_Comm_Orb);
     E_orb = tmp[0];
     E_en  = tmp[1];
     E_ee  = tmp[2];

--- a/src/mrchem/qmoperators/QMOperator.cpp
+++ b/src/mrchem/qmoperators/QMOperator.cpp
@@ -28,7 +28,7 @@ double QMOperator::adjoint(Orbital &phi_i, Orbital &phi_j) {
 }
 
 MatrixXd QMOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs) {
-    if (MPI_size == 1) TelePrompter::printHeader(1, "Compute Matrix Element");
+    if (MPI_Orb_size == 1) TelePrompter::printHeader(1, "Compute Matrix Element");
     int Ni = i_orbs.size();
     int Nj = j_orbs.size();
     MatrixXcd result = MatrixXcd::Zero(Ni, Nj);
@@ -44,8 +44,8 @@ MatrixXd QMOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs) {
         }
         delete Ophi_j;
     }
-    if (MPI_size == 1) timer.stop();
-    if (MPI_size == 1) TelePrompter::printFooter(1, timer, 2);
+    if (MPI_Orb_size == 1) timer.stop();
+    if (MPI_Orb_size == 1) TelePrompter::printFooter(1, timer, 2);
 
     if (result.imag().norm() > MachineZero) MSG_ERROR("Should be real");
     return result.real();

--- a/src/mrchem/qmoperators/QMOperator.cpp
+++ b/src/mrchem/qmoperators/QMOperator.cpp
@@ -28,7 +28,7 @@ double QMOperator::adjoint(Orbital &phi_i, Orbital &phi_j) {
 }
 
 MatrixXd QMOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs) {
-    if (MPI_Orb_size == 1) TelePrompter::printHeader(1, "Compute Matrix Element");
+    if (mpiOrbSize == 1) TelePrompter::printHeader(1, "Compute Matrix Element");
     int Ni = i_orbs.size();
     int Nj = j_orbs.size();
     MatrixXcd result = MatrixXcd::Zero(Ni, Nj);
@@ -44,8 +44,8 @@ MatrixXd QMOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs) {
         }
         delete Ophi_j;
     }
-    if (MPI_Orb_size == 1) timer.stop();
-    if (MPI_Orb_size == 1) TelePrompter::printFooter(1, timer, 2);
+    if (mpiOrbSize == 1) timer.stop();
+    if (mpiOrbSize == 1) TelePrompter::printFooter(1, timer, 2);
 
     if (result.imag().norm() > MachineZero) MSG_ERROR("Should be real");
     return result.real();

--- a/src/mrchem/scf_solver/EnergyOptimizer.cpp
+++ b/src/mrchem/scf_solver/EnergyOptimizer.cpp
@@ -82,7 +82,7 @@ bool EnergyOptimizer::optimize() {
 
         // Iterate Helmholtz operators
         this->helmholtz->initialize(F_n.diagonal());
-	if(MPI_size>1){
+	if(MPI_Orb_size>1){
 	  applyHelmholtzOperators_P(phi_np1, F_n, phi_n);
 	}else{
 	  applyHelmholtzOperators(phi_np1, F_n, phi_n);
@@ -92,7 +92,7 @@ bool EnergyOptimizer::optimize() {
         VectorXd errors = dPhi_n.getNorms();
 #ifdef HAVE_MPI
 	//distribute errors among all orbitals
-	MPI_Allgather(MPI_IN_PLACE, 0, MPI_DOUBLE, &errors(0), 1, MPI_DOUBLE, MPI_COMM_WORLD);
+	MPI_Allgather(MPI_IN_PLACE, 0, MPI_DOUBLE, &errors(0), 1, MPI_DOUBLE, MPI_Comm_Orb);
 #endif
 	
         phi_n.setErrors(errors);
@@ -148,7 +148,7 @@ MatrixXd EnergyOptimizer::calcFockMatrixUpdate() {
     Timer timer;
     MatrixXd dS_1;
     MatrixXd dS_2;
-    if(MPI_size>1){
+    if(MPI_Orb_size>1){
       dS_1 = dPhi_n.calcOverlapMatrix_P(phi_n).real();
       dS_2 = phi_np1.calcOverlapMatrix_P(dPhi_n).real();
     }else{
@@ -177,11 +177,11 @@ MatrixXd EnergyOptimizer::calcFockMatrixUpdate() {
       
       //make vector with adresses of own orbitals
       int i = 0;
-      for (int Ix = MPI_rank; Ix < Ni; Ix += MPI_size) {
+      for (int Ix = MPI_Orb_rank; Ix < Ni; Ix += MPI_Orb_size) {
 	OrbVecChunk_i.push_back(phi_np1.getOrbital(Ix));//i orbitals
 	OrbsIx[i++] = Ix;
       }
-      for (int Ix = MPI_rank; Ix < Nj; Ix += MPI_size)
+      for (int Ix = MPI_Orb_rank; Ix < Nj; Ix += MPI_Orb_size)
 	OrbVecChunk_j.push_back(dPhi_n.getOrbital(Ix));//j orbitals
 
       for (int iter = 0;  iter >= 0 ; iter++) {
@@ -195,7 +195,7 @@ MatrixXd EnergyOptimizer::calcFockMatrixUpdate() {
 
 	//copy results into final matrix
 	int j = 0;
-	for (int Jx = MPI_rank;  Jx < Nj; Jx += MPI_size) {
+	for (int Jx = MPI_Orb_rank;  Jx < Nj; Jx += MPI_Orb_size) {
 	  for (int ix = 0;  ix<rcvOrbs.size() ; ix++) {
 	    dV_n(rcvOrbsIx[ix],Jx) += resultChunk(ix,j);
 	  }
@@ -209,7 +209,7 @@ MatrixXd EnergyOptimizer::calcFockMatrixUpdate() {
       OrbVecChunk_j.clearVec(false);
       
       MPI_Allreduce(MPI_IN_PLACE, &dV_n(0,0), Ni*Nj,
-		    MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+		    MPI_DOUBLE, MPI_SUM, MPI_Comm_Orb);
 
 #else
       dV_n = (*v_n)(phi_np1, dPhi_n);

--- a/src/mrchem/scf_solver/EnergyOptimizer.cpp
+++ b/src/mrchem/scf_solver/EnergyOptimizer.cpp
@@ -82,7 +82,7 @@ bool EnergyOptimizer::optimize() {
 
         // Iterate Helmholtz operators
         this->helmholtz->initialize(F_n.diagonal());
-	if(MPI_Orb_size>1){
+	if(mpiOrbSize>1){
 	  applyHelmholtzOperators_P(phi_np1, F_n, phi_n);
 	}else{
 	  applyHelmholtzOperators(phi_np1, F_n, phi_n);
@@ -92,7 +92,7 @@ bool EnergyOptimizer::optimize() {
         VectorXd errors = dPhi_n.getNorms();
 #ifdef HAVE_MPI
 	//distribute errors among all orbitals
-	MPI_Allgather(MPI_IN_PLACE, 0, MPI_DOUBLE, &errors(0), 1, MPI_DOUBLE, MPI_Comm_Orb);
+	MPI_Allgather(MPI_IN_PLACE, 0, MPI_DOUBLE, &errors(0), 1, MPI_DOUBLE, mpiCommOrb);
 #endif
 	
         phi_n.setErrors(errors);
@@ -148,7 +148,7 @@ MatrixXd EnergyOptimizer::calcFockMatrixUpdate() {
     Timer timer;
     MatrixXd dS_1;
     MatrixXd dS_2;
-    if(MPI_Orb_size>1){
+    if(mpiOrbSize>1){
       dS_1 = dPhi_n.calcOverlapMatrix_P(phi_n).real();
       dS_2 = phi_np1.calcOverlapMatrix_P(dPhi_n).real();
     }else{
@@ -177,11 +177,11 @@ MatrixXd EnergyOptimizer::calcFockMatrixUpdate() {
       
       //make vector with adresses of own orbitals
       int i = 0;
-      for (int Ix = MPI_Orb_rank; Ix < Ni; Ix += MPI_Orb_size) {
+      for (int Ix = mpiOrbRank; Ix < Ni; Ix += mpiOrbSize) {
 	OrbVecChunk_i.push_back(phi_np1.getOrbital(Ix));//i orbitals
 	OrbsIx[i++] = Ix;
       }
-      for (int Ix = MPI_Orb_rank; Ix < Nj; Ix += MPI_Orb_size)
+      for (int Ix = mpiOrbRank; Ix < Nj; Ix += mpiOrbSize)
 	OrbVecChunk_j.push_back(dPhi_n.getOrbital(Ix));//j orbitals
 
       for (int iter = 0;  iter >= 0 ; iter++) {
@@ -195,7 +195,7 @@ MatrixXd EnergyOptimizer::calcFockMatrixUpdate() {
 
 	//copy results into final matrix
 	int j = 0;
-	for (int Jx = MPI_Orb_rank;  Jx < Nj; Jx += MPI_Orb_size) {
+	for (int Jx = mpiOrbRank;  Jx < Nj; Jx += mpiOrbSize) {
 	  for (int ix = 0;  ix<rcvOrbs.size() ; ix++) {
 	    dV_n(rcvOrbsIx[ix],Jx) += resultChunk(ix,j);
 	  }
@@ -209,7 +209,7 @@ MatrixXd EnergyOptimizer::calcFockMatrixUpdate() {
       OrbVecChunk_j.clearVec(false);
       
       MPI_Allreduce(MPI_IN_PLACE, &dV_n(0,0), Ni*Nj,
-		    MPI_DOUBLE, MPI_SUM, MPI_Comm_Orb);
+		    MPI_DOUBLE, MPI_SUM, mpiCommOrb);
 
 #else
       dV_n = (*v_n)(phi_np1, dPhi_n);

--- a/src/mrchem/scf_solver/GroundStateSolver.cpp
+++ b/src/mrchem/scf_solver/GroundStateSolver.cpp
@@ -334,7 +334,7 @@ RR::RR(double prec, OrbitalVector &phi) {
     N2h = N*(N-1)/2;
     gradient = VectorXd(N2h);
     hessian = MatrixXd(N2h, N2h);
-    r_i_orig = MatrixXd(N,3*N);
+    r_i_orig = MatrixXd::Zero(N,3*N);
     r_i = MatrixXd(N,3*N);
 
     //Make R matrix
@@ -344,6 +344,49 @@ RR::RR(double prec, OrbitalVector &phi) {
     RankZeroTensorOperator &r_x = r[0];
     RankZeroTensorOperator &r_y = r[1];
     RankZeroTensorOperator &r_z = r[2];
+
+#ifdef HAVE_MPI
+
+    OrbitalVector OrbVecChunk_i(0);//to store adresses of own i_orbs
+    int OrbsIx[workOrbVecSize];//to store own orbital indices
+    OrbitalVector rcvOrbs(0);//to store adresses of received orbitals
+    int rcvOrbsIx[workOrbVecSize];//to store received orbital indices
+
+    //make vector with adresses of own orbitals
+    int i = 0;
+    for (int Ix = MPI_rank;  Ix < N; Ix += MPI_size) {
+      OrbVecChunk_i.push_back(phi.getOrbital(Ix));//i orbitals
+      OrbsIx[i++] = Ix;
+    }
+
+    for (int iter = 0;  iter >= 0; iter++) {
+      //get a new chunk from other processes
+      OrbVecChunk_i.getOrbVecChunk_sym(OrbsIx, rcvOrbs, rcvOrbsIx, N, iter);
+      for (int i = 0; i<OrbVecChunk_i.size(); i++){
+        Orbital &phi_i = OrbVecChunk_i.getOrbital(i);
+        int spin_i = phi_i.getSpin();
+	for (int j = 0; j < rcvOrbs.size(); j++) {
+            Orbital &phi_j = rcvOrbs.getOrbital(j);
+            int spin_j = phi_j.getSpin();
+            if (spin_i != spin_j) {
+	      MSG_ERROR("Spins must be separated before localization");
+            }
+            r_i_orig(OrbsIx[i],rcvOrbsIx[j]) = r_x(phi_i, phi_j);
+            r_i_orig(OrbsIx[i],rcvOrbsIx[j]+N) = r_y(phi_i, phi_j);
+            r_i_orig(OrbsIx[i],rcvOrbsIx[j]+2*N) = r_z(phi_i, phi_j);
+            r_i_orig(rcvOrbsIx[j],OrbsIx[i]) = r_i_orig(OrbsIx[i],rcvOrbsIx[j]);
+            r_i_orig(rcvOrbsIx[j],OrbsIx[i]+N) =  r_i_orig(OrbsIx[i],rcvOrbsIx[j]+N);
+            r_i_orig(rcvOrbsIx[j],OrbsIx[i]+2*N) = r_i_orig(OrbsIx[i],rcvOrbsIx[j]+2*N);
+        }
+      }
+      rcvOrbs.clearVec(false);
+    }
+    OrbVecChunk_i.clearVec(false);
+    //combine results from all processes
+    MPI_Allreduce(MPI_IN_PLACE, &r_i_orig(0,0), N*3*N,
+                  MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+
+#else
 
     for (int i = 0; i < N; i++) {
         Orbital &phi_i = phi.getOrbital(i);
@@ -362,6 +405,7 @@ RR::RR(double prec, OrbitalVector &phi) {
             r_i_orig(j,i+2*N) = r_i_orig(i,j+2*N);
         }
     }
+#endif
     r_x.clear();
     r_y.clear();
     r_z.clear();

--- a/src/mrchem/scf_solver/GroundStateSolver.cpp
+++ b/src/mrchem/scf_solver/GroundStateSolver.cpp
@@ -60,7 +60,7 @@ Orbital* GroundStateSolver::getHelmholtzArgument(int i,
 
     Orbital *part_1 = fock.applyPotential(phi_i);
     Orbital *part_2;
-    if(MPI_size>1){
+    if(MPI_Orb_size>1){
       part_2 = calcMatrixPart_P(i, LmF, phi);
     }else{
       part_2 = calcMatrixPart(i, LmF, phi);
@@ -305,7 +305,7 @@ MatrixXd GroundStateSolver::calcOrthonormalizationMatrix(OrbitalVector &phi) {
     printout(1, "Calculating orthonormalization matrix            ");
 
     MatrixXd S_tilde;
-    if(MPI_size>1){
+    if(MPI_Orb_size>1){
       S_tilde = phi.calcOverlapMatrix_P_H(phi).real();
     }else{
       S_tilde = phi.calcOverlapMatrix().real();
@@ -354,7 +354,7 @@ RR::RR(double prec, OrbitalVector &phi) {
 
     //make vector with adresses of own orbitals
     int i = 0;
-    for (int Ix = MPI_rank;  Ix < N; Ix += MPI_size) {
+    for (int Ix = MPI_Orb_rank;  Ix < N; Ix += MPI_Orb_size) {
       OrbVecChunk_i.push_back(phi.getOrbital(Ix));//i orbitals
       OrbsIx[i++] = Ix;
     }
@@ -373,7 +373,7 @@ RR::RR(double prec, OrbitalVector &phi) {
             }
 	    //NOTE: the "if" should not be necessary, but since outside the required precision
 	    //r_x(phi_i, phi_j) != r_x(phi_j, phi_i), we prefer to have consistent results for
-	    //different MPI_size
+	    //different MPI_Orb_size
 	    if(rcvOrbsIx[j]<=OrbsIx[i]){
 	      r_i_orig(OrbsIx[i],rcvOrbsIx[j]) = r_x(phi_i, phi_j);
 	      r_i_orig(OrbsIx[i],rcvOrbsIx[j]+N) = r_y(phi_i, phi_j);
@@ -382,7 +382,7 @@ RR::RR(double prec, OrbitalVector &phi) {
 	      r_i_orig(rcvOrbsIx[j],OrbsIx[i]+N) =  r_i_orig(OrbsIx[i],rcvOrbsIx[j]+N);
 	      r_i_orig(rcvOrbsIx[j],OrbsIx[i]+2*N) = r_i_orig(OrbsIx[i],rcvOrbsIx[j]+2*N);
 	    }else{
-	      if(rcvOrbsIx[j]%MPI_size != MPI_rank){ //need only compute j<=i in own block
+	      if(rcvOrbsIx[j]%MPI_Orb_size != MPI_Orb_rank){ //need only compute j<=i in own block
 		r_i_orig(rcvOrbsIx[j],OrbsIx[i]) = r_x(phi_j, phi_i);
 		r_i_orig(rcvOrbsIx[j],OrbsIx[i]+N) =  r_y(phi_j, phi_i);
 		r_i_orig(rcvOrbsIx[j],OrbsIx[i]+2*N) = r_z(phi_j, phi_i);
@@ -398,7 +398,7 @@ RR::RR(double prec, OrbitalVector &phi) {
     OrbVecChunk_i.clearVec(false);
     //combine results from all processes
     MPI_Allreduce(MPI_IN_PLACE, &r_i_orig(0,0), N*3*N,
-                  MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+                  MPI_DOUBLE, MPI_SUM, MPI_Comm_Orb);
 
 #else
 

--- a/src/mrchem/scf_solver/OrbitalOptimizer.cpp
+++ b/src/mrchem/scf_solver/OrbitalOptimizer.cpp
@@ -82,7 +82,7 @@ bool OrbitalOptimizer::optimize() {
 		
         // Iterate Helmholtz operators
         this->helmholtz->initialize(F.diagonal());
-	if (MPI_size > 1) {
+	if (MPI_Orb_size > 1) {
 	    applyHelmholtzOperators_P(phi_np1, F, phi_n);
 	}else{
 	    applyHelmholtzOperators(phi_np1, F, phi_n);
@@ -100,13 +100,13 @@ bool OrbitalOptimizer::optimize() {
         // Compute errors
 	int Ni = dPhi_n.size();
         VectorXd errors = VectorXd::Zero(Ni);
-	for (int i = MPI_rank; i < Ni; i += MPI_size){
+	for (int i = MPI_Orb_rank; i < Ni; i += MPI_Orb_size){
 	    errors(i) = sqrt(dPhi_n.getOrbital(i).getSquareNorm());
 	}
 #ifdef HAVE_MPI
 	//distribute errors among all orbitals
 	//could use reduce or gather also here
-	MPI_Allreduce(MPI_IN_PLACE, &errors(0), Ni, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+	MPI_Allreduce(MPI_IN_PLACE, &errors(0), Ni, MPI_DOUBLE, MPI_SUM, MPI_Comm_Orb);
 #endif
         err_o = errors.maxCoeff();
         err_t = sqrt(errors.dot(errors));

--- a/src/mrchem/scf_solver/OrbitalOptimizer.cpp
+++ b/src/mrchem/scf_solver/OrbitalOptimizer.cpp
@@ -82,7 +82,7 @@ bool OrbitalOptimizer::optimize() {
 		
         // Iterate Helmholtz operators
         this->helmholtz->initialize(F.diagonal());
-	if (MPI_Orb_size > 1) {
+	if (mpiOrbSize > 1) {
 	    applyHelmholtzOperators_P(phi_np1, F, phi_n);
 	}else{
 	    applyHelmholtzOperators(phi_np1, F, phi_n);
@@ -100,13 +100,13 @@ bool OrbitalOptimizer::optimize() {
         // Compute errors
 	int Ni = dPhi_n.size();
         VectorXd errors = VectorXd::Zero(Ni);
-	for (int i = MPI_Orb_rank; i < Ni; i += MPI_Orb_size){
+	for (int i = mpiOrbRank; i < Ni; i += mpiOrbSize){
 	    errors(i) = sqrt(dPhi_n.getOrbital(i).getSquareNorm());
 	}
 #ifdef HAVE_MPI
 	//distribute errors among all orbitals
 	//could use reduce or gather also here
-	MPI_Allreduce(MPI_IN_PLACE, &errors(0), Ni, MPI_DOUBLE, MPI_SUM, MPI_Comm_Orb);
+	MPI_Allreduce(MPI_IN_PLACE, &errors(0), Ni, MPI_DOUBLE, MPI_SUM, mpiCommOrb);
 #endif
         err_o = errors.maxCoeff();
         err_t = sqrt(errors.dot(errors));

--- a/src/mrchem/scf_solver/SCF.cpp
+++ b/src/mrchem/scf_solver/SCF.cpp
@@ -128,7 +128,7 @@ double SCF::getUpdate(const vector<double> &vec, int i, bool absPrec) const {
 }
 
 void SCF::printOrbitals(const VectorXd &epsilon, const OrbitalVector &phi, int flag) const {
-  if (MPI_rank == 0) {
+  if (MPI_Orb_rank == 0) {
     TelePrompter::printHeader(0, "Orbitals");
     if (flag == 0) println(0, " Orb    F(i,i)        Error         nNodes  Spin  Occ  Done ");
     if (flag == 1) println(0, " Orb    Norm          Error         nNodes  Spin  Occ  Done ");
@@ -242,7 +242,7 @@ void SCF::applyHelmholtzOperators(OrbitalVector &phi_np1,
         Orbital &nPhi_i = phi_n.getOrbital(i);
         Orbital &np1Phi_i = phi_np1.getOrbital(i);
 
-	if (i%MPI_size == MPI_rank) {
+	if (i%MPI_Orb_size == MPI_Orb_rank) {
 	    //in charge for this orbital
 	    Orbital *arg_i = getHelmholtzArgument(i, F_n, phi_n, adjoint);
 	    H(i, np1Phi_i, *arg_i);
@@ -298,7 +298,7 @@ void SCF::applyHelmholtzOperators_P(OrbitalVector &phi_np1,
       
       //make vector with adresses of own orbitals
       int i = 0;
-      for (int Ix = MPI_rank; Ix < Ni; Ix += MPI_size) {
+      for (int Ix = MPI_Orb_rank; Ix < Ni; Ix += MPI_Orb_size) {
 	OrbVecChunk_i.push_back(phi_n.getOrbital(Ix));//i orbitals
 	OrbsIx[i++] = Ix;
       }
@@ -309,12 +309,12 @@ void SCF::applyHelmholtzOperators_P(OrbitalVector &phi_np1,
 	//get a new chunk from other processes
 	OrbVecChunk_i.getOrbVecChunk(OrbsIx, rcvOrbs, rcvOrbsIx, Ni, iter);
 	Orbital *arg_i_1;
-	for (int i = MPI_rank;  i<Ni ; i += MPI_size) {
+	for (int i = MPI_Orb_rank;  i<Ni ; i += MPI_Orb_size) {
 	  Orbital &phi_i = phi_n.getOrbital(i);
 	  if(first_iter){	    
 	    arg_i_1 = getHelmholtzArgument_1(phi_i);
 	  }else{
-	    arg_i_1 = arg_i_vec[i/MPI_size];//set to part_1 + chunks so far
+	    arg_i_1 = arg_i_vec[i/MPI_Orb_size];//set to part_1 + chunks so far
 	  }
 	  double coef_part1 = 1.0;
 	  if(first_iter)coef_part1= -1.0/(2.0*pi);//only include factor once
@@ -322,7 +322,7 @@ void SCF::applyHelmholtzOperators_P(OrbitalVector &phi_np1,
 	  if(first_iter){
 	    arg_i_vec.push_back(arg_i);
 	  }else{
-	    arg_i_vec[i/MPI_size]=arg_i;
+	    arg_i_vec[i/MPI_Orb_size]=arg_i;
 	  }
 	}
 	first_iter = false;
@@ -330,10 +330,10 @@ void SCF::applyHelmholtzOperators_P(OrbitalVector &phi_np1,
       }
       OrbVecChunk_i.clearVec(false);
 
-      for (int i = MPI_rank;  i<Ni ; i += MPI_size) {
+      for (int i = MPI_Orb_rank;  i<Ni ; i += MPI_Orb_size) {
 	  Timer timer;
 	  Orbital &np1Phi_i = phi_np1.getOrbital(i);
-	  arg_i = arg_i_vec[i/MPI_size];
+	  arg_i = arg_i_vec[i/MPI_Orb_size];
 	  H(i, np1Phi_i, *arg_i);
 	  delete arg_i;
 	
@@ -401,26 +401,26 @@ Orbital* SCF::calcMatrixPart_P(int i_Orb, MatrixXd &M, OrbitalVector &phi) {
     int orbVecIx = 0;
 
     int nOrbs = phi.size();
-    for (int iter = 0;  iter<MPI_size ; iter++) {
-      int j_MPI=(MPI_size+iter-MPI_rank)%MPI_size;
-      for (int j_Orb = j_MPI;  j_Orb < phi.size(); j_Orb+=MPI_size) {
+    for (int iter = 0;  iter<MPI_Orb_size ; iter++) {
+      int j_MPI=(MPI_Orb_size+iter-MPI_Orb_rank)%MPI_Orb_size;
+      for (int j_Orb = j_MPI;  j_Orb < phi.size(); j_Orb+=MPI_Orb_size) {
 	
 	//    for (int j = 0; j < nOrbs; j++) {
-	if(MPI_rank > j_MPI){
+	if(MPI_Orb_rank > j_MPI){
 	  //send first bra, then receive ket
 	  if (fabs(M(j_Orb,i_Orb)) > MachineZero)phi.getOrbital(i_Orb).send_Orbital(j_MPI, i_Orb);
 	  if (fabs(M(i_Orb,j_Orb)) > MachineZero)workOrbVec.getOrbital(orbVecIx).Rcv_Orbital(j_MPI, j_Orb);
-	}else if(MPI_rank < j_MPI){
+	}else if(MPI_Orb_rank < j_MPI){
 	  if (fabs(M(i_Orb,j_Orb)) > MachineZero)workOrbVec.getOrbital(orbVecIx).Rcv_Orbital(j_MPI, j_Orb);
 	  if (fabs(M(j_Orb,i_Orb)) > MachineZero)phi.getOrbital(i_Orb).send_Orbital(j_MPI, i_Orb);
-	}else if(MPI_rank == j_MPI){//use phi directly
+	}else if(MPI_Orb_rank == j_MPI){//use phi directly
 	}
 	double coef = M(i_Orb,j_Orb);
 	// Linear scaling screening inserted here
 	if (fabs(coef) > MachineZero) {
 	  //Orbital &phi_j = out.getOrbital(j_Orb);
 	  double norm_j;
-	  if(MPI_rank == j_MPI){
+	  if(MPI_Orb_rank == j_MPI){
 	    norm_j = sqrt(phi.getOrbital(j_Orb).getSquareNorm());
 	  }else{
 	    norm_j = sqrt(workOrbVec.getOrbital(orbVecIx).getSquareNorm());
@@ -430,14 +430,14 @@ Orbital* SCF::calcMatrixPart_P(int i_Orb, MatrixXd &M, OrbitalVector &phi) {
 	    //orbs.push_back(&workOrbVec.getOrbital(j_Orb));
 	    
 	    //push orbital in vector (chunk)
-	    if(MPI_rank == j_MPI){
+	    if(MPI_Orb_rank == j_MPI){
 	      orbChunk.push_back(&phi.getOrbital(j_Orb));
 	    }else{
 	      orbChunk.push_back(&workOrbVec.getOrbital(orbVecIx++));
 	    }
 	    U_Chunk.push_back(coef);	
 	  }
-	  if(orbChunk.size()>=workOrbVecSize or iter >= MPI_size-1){
+	  if(orbChunk.size()>=workOrbVecSize or iter >= MPI_Orb_size-1){
 	    //Do the work for the chunk	  	  
 	    this->add.inPlace(*result,U_Chunk, orbChunk, false);//can start with empty orbital
 	    U_Chunk.clear();

--- a/src/mrchem/scf_solver/SCF.cpp
+++ b/src/mrchem/scf_solver/SCF.cpp
@@ -128,7 +128,7 @@ double SCF::getUpdate(const vector<double> &vec, int i, bool absPrec) const {
 }
 
 void SCF::printOrbitals(const VectorXd &epsilon, const OrbitalVector &phi, int flag) const {
-  if (MPI_Orb_rank == 0) {
+  if (mpiOrbRank == 0) {
     TelePrompter::printHeader(0, "Orbitals");
     if (flag == 0) println(0, " Orb    F(i,i)        Error         nNodes  Spin  Occ  Done ");
     if (flag == 1) println(0, " Orb    Norm          Error         nNodes  Spin  Occ  Done ");
@@ -242,7 +242,7 @@ void SCF::applyHelmholtzOperators(OrbitalVector &phi_np1,
         Orbital &nPhi_i = phi_n.getOrbital(i);
         Orbital &np1Phi_i = phi_np1.getOrbital(i);
 
-	if (i%MPI_Orb_size == MPI_Orb_rank) {
+	if (i%mpiOrbSize == mpiOrbRank) {
 	    //in charge for this orbital
 	    Orbital *arg_i = getHelmholtzArgument(i, F_n, phi_n, adjoint);
 	    H(i, np1Phi_i, *arg_i);
@@ -298,7 +298,7 @@ void SCF::applyHelmholtzOperators_P(OrbitalVector &phi_np1,
       
       //make vector with adresses of own orbitals
       int i = 0;
-      for (int Ix = MPI_Orb_rank; Ix < Ni; Ix += MPI_Orb_size) {
+      for (int Ix = mpiOrbRank; Ix < Ni; Ix += mpiOrbSize) {
 	OrbVecChunk_i.push_back(phi_n.getOrbital(Ix));//i orbitals
 	OrbsIx[i++] = Ix;
       }
@@ -309,12 +309,12 @@ void SCF::applyHelmholtzOperators_P(OrbitalVector &phi_np1,
 	//get a new chunk from other processes
 	OrbVecChunk_i.getOrbVecChunk(OrbsIx, rcvOrbs, rcvOrbsIx, Ni, iter);
 	Orbital *arg_i_1;
-	for (int i = MPI_Orb_rank;  i<Ni ; i += MPI_Orb_size) {
+	for (int i = mpiOrbRank;  i<Ni ; i += mpiOrbSize) {
 	  Orbital &phi_i = phi_n.getOrbital(i);
 	  if(first_iter){	    
 	    arg_i_1 = getHelmholtzArgument_1(phi_i);
 	  }else{
-	    arg_i_1 = arg_i_vec[i/MPI_Orb_size];//set to part_1 + chunks so far
+	    arg_i_1 = arg_i_vec[i/mpiOrbSize];//set to part_1 + chunks so far
 	  }
 	  double coef_part1 = 1.0;
 	  if(first_iter)coef_part1= -1.0/(2.0*pi);//only include factor once
@@ -322,7 +322,7 @@ void SCF::applyHelmholtzOperators_P(OrbitalVector &phi_np1,
 	  if(first_iter){
 	    arg_i_vec.push_back(arg_i);
 	  }else{
-	    arg_i_vec[i/MPI_Orb_size]=arg_i;
+	    arg_i_vec[i/mpiOrbSize]=arg_i;
 	  }
 	}
 	first_iter = false;
@@ -330,10 +330,10 @@ void SCF::applyHelmholtzOperators_P(OrbitalVector &phi_np1,
       }
       OrbVecChunk_i.clearVec(false);
 
-      for (int i = MPI_Orb_rank;  i<Ni ; i += MPI_Orb_size) {
+      for (int i = mpiOrbRank;  i<Ni ; i += mpiOrbSize) {
 	  Timer timer;
 	  Orbital &np1Phi_i = phi_np1.getOrbital(i);
-	  arg_i = arg_i_vec[i/MPI_Orb_size];
+	  arg_i = arg_i_vec[i/mpiOrbSize];
 	  H(i, np1Phi_i, *arg_i);
 	  delete arg_i;
 	
@@ -401,26 +401,26 @@ Orbital* SCF::calcMatrixPart_P(int i_Orb, MatrixXd &M, OrbitalVector &phi) {
     int orbVecIx = 0;
 
     int nOrbs = phi.size();
-    for (int iter = 0;  iter<MPI_Orb_size ; iter++) {
-      int j_MPI=(MPI_Orb_size+iter-MPI_Orb_rank)%MPI_Orb_size;
-      for (int j_Orb = j_MPI;  j_Orb < phi.size(); j_Orb+=MPI_Orb_size) {
+    for (int iter = 0;  iter<mpiOrbSize ; iter++) {
+      int j_MPI=(mpiOrbSize+iter-mpiOrbRank)%mpiOrbSize;
+      for (int j_Orb = j_MPI;  j_Orb < phi.size(); j_Orb+=mpiOrbSize) {
 	
 	//    for (int j = 0; j < nOrbs; j++) {
-	if(MPI_Orb_rank > j_MPI){
+	if(mpiOrbRank > j_MPI){
 	  //send first bra, then receive ket
 	  if (fabs(M(j_Orb,i_Orb)) > MachineZero)phi.getOrbital(i_Orb).send_Orbital(j_MPI, i_Orb);
 	  if (fabs(M(i_Orb,j_Orb)) > MachineZero)workOrbVec.getOrbital(orbVecIx).Rcv_Orbital(j_MPI, j_Orb);
-	}else if(MPI_Orb_rank < j_MPI){
+	}else if(mpiOrbRank < j_MPI){
 	  if (fabs(M(i_Orb,j_Orb)) > MachineZero)workOrbVec.getOrbital(orbVecIx).Rcv_Orbital(j_MPI, j_Orb);
 	  if (fabs(M(j_Orb,i_Orb)) > MachineZero)phi.getOrbital(i_Orb).send_Orbital(j_MPI, i_Orb);
-	}else if(MPI_Orb_rank == j_MPI){//use phi directly
+	}else if(mpiOrbRank == j_MPI){//use phi directly
 	}
 	double coef = M(i_Orb,j_Orb);
 	// Linear scaling screening inserted here
 	if (fabs(coef) > MachineZero) {
 	  //Orbital &phi_j = out.getOrbital(j_Orb);
 	  double norm_j;
-	  if(MPI_Orb_rank == j_MPI){
+	  if(mpiOrbRank == j_MPI){
 	    norm_j = sqrt(phi.getOrbital(j_Orb).getSquareNorm());
 	  }else{
 	    norm_j = sqrt(workOrbVec.getOrbital(orbVecIx).getSquareNorm());
@@ -430,14 +430,14 @@ Orbital* SCF::calcMatrixPart_P(int i_Orb, MatrixXd &M, OrbitalVector &phi) {
 	    //orbs.push_back(&workOrbVec.getOrbital(j_Orb));
 	    
 	    //push orbital in vector (chunk)
-	    if(MPI_Orb_rank == j_MPI){
+	    if(mpiOrbRank == j_MPI){
 	      orbChunk.push_back(&phi.getOrbital(j_Orb));
 	    }else{
 	      orbChunk.push_back(&workOrbVec.getOrbital(orbVecIx++));
 	    }
 	    U_Chunk.push_back(coef);	
 	  }
-	  if(orbChunk.size()>=workOrbVecSize or iter >= MPI_Orb_size-1){
+	  if(orbChunk.size()>=workOrbVecSize or iter >= mpiOrbSize-1){
 	    //Do the work for the chunk	  	  
 	    this->add.inPlace(*result,U_Chunk, orbChunk, false);//can start with empty orbital
 	    U_Chunk.clear();

--- a/src/mrcpp/TelePrompter.cpp
+++ b/src/mrcpp/TelePrompter.cpp
@@ -72,7 +72,7 @@ void TelePrompter::init(int printLevel, bool teletype, const char *fil) {
     SET_PRINT_PRECISION(15);
     cout << scientific << setprecision(14);
 
-    int rank=MPI_rank;
+    int rank=MPI_Orb_rank;
     int world_size = 1;
     SET_PRINT_LEVEL(printLevel);
     if (teletype and fil != 0) {

--- a/src/mrcpp/TelePrompter.cpp
+++ b/src/mrcpp/TelePrompter.cpp
@@ -72,7 +72,7 @@ void TelePrompter::init(int printLevel, bool teletype, const char *fil) {
     SET_PRINT_PRECISION(15);
     cout << scientific << setprecision(14);
 
-    int rank=MPI_Orb_rank;
+    int rank=mpiOrbRank;
     int world_size = 1;
     SET_PRINT_LEVEL(printLevel);
     if (teletype and fil != 0) {

--- a/src/mrcpp/mwtrees/FunctionTree.cpp
+++ b/src/mrcpp/mwtrees/FunctionTree.cpp
@@ -23,7 +23,19 @@ FunctionTree<D>::FunctionTree(const MultiResolutionAnalysis<D> &mra, int max_nod
     this->resetEndNodeTable();
 }
 
-/** FunctionTree destructor. */
+/** FunctionTree constructor for Serial Tree using shared memory.
+  * */
+template<int D>
+FunctionTree<D>::FunctionTree(const MultiResolutionAnalysis<D> &mra, SharedMemory* &shMem, int max_nodes)
+        : MWTree<D> (mra) {
+    this->serialTree_p = new SerialFunctionTree<D>(this, max_nodes);
+    this->serialTree_p->isShared = true;
+    this->serialTree_p->shMem = shMem;    
+    this->serialTree_p->allocRoots(*this);
+    this->resetEndNodeTable();
+}
+
+//** FunctionTree destructor. */
 template<int D>
 FunctionTree<D>::~FunctionTree() {
     for (int i = 0; i < this->rootBox.size(); i++) {

--- a/src/mrcpp/mwtrees/FunctionTree.h
+++ b/src/mrcpp/mwtrees/FunctionTree.h
@@ -22,6 +22,8 @@ class FunctionTree: public MWTree<D> {
 public:
     FunctionTree(const MultiResolutionAnalysis<D> &mra,
                  int max_nodes = MaxAllocNodes);
+    FunctionTree(const MultiResolutionAnalysis<D> &mra,
+                 SharedMemory* &shMem, int max_nodes = MaxAllocNodes);
     virtual ~FunctionTree();
 
     void clear();

--- a/src/mrcpp/mwtrees/MWNode.h
+++ b/src/mrcpp/mwtrees/MWNode.h
@@ -23,6 +23,7 @@
 #define SET_NODE_LOCK() omp_set_lock(&this->node_lock)
 #define UNSET_NODE_LOCK() omp_unset_lock(&this->node_lock)
 #define TEST_NODE_LOCK() omp_test_lock(&this->node_lock)
+
 #else
 #define SET_NODE_LOCK()
 #define UNSET_NODE_LOCK()
@@ -136,6 +137,7 @@ public:
     friend class MWTree<D>;
     friend class FunctionTree<D>;
     friend class OperatorTree;
+    friend class Density;
 
 protected:
     MWTree<D> *tree;

--- a/src/mrcpp/mwtrees/SerialFunctionTree.cpp
+++ b/src/mrcpp/mwtrees/SerialFunctionTree.cpp
@@ -31,7 +31,7 @@ SerialFunctionTree<D>::SerialFunctionTree(FunctionTree<D> *tree, int max_nodes)
     this->nNodes = 0;
 
     NFtrees++;
-    if(MPI_Orb_rank==0 and NFtrees%10==1) println(10," N Function trees created: "<<NFtrees<<" max_nodes = " << max_nodes<<" dim = "<<D);
+    if(mpiOrbRank==0 and NFtrees%10==1) println(10," N Function trees created: "<<NFtrees<<" max_nodes = " << max_nodes<<" dim = "<<D);
 
     //Size for GenNodes chunks. ProjectedNodes will be 8 times larger
     this->sizeGenNodeCoeff = this->tree_p->getKp1_d();//One block
@@ -279,7 +279,7 @@ ProjectedNode<D>* SerialFunctionTree<D>::allocNodes(int nAlloc, int *serialIx, d
 	    double *sNodesCoeff;		
 	    if (this->isShared) {
 		//for coefficients, take from the shared memory block
-		//if (MPI_SH_rank !=0) MSG_FATAL("Only master can claim shared memory");
+		//if (mpiShRank !=0) MSG_FATAL("Only master can claim shared memory");
 		sNodesCoeff = this->shMem->sh_end_ptr;		
 		this->shMem->sh_end_ptr += (this->sizeNodeCoeff*this->maxNodesPerChunk)/sizeof(double);
 		//may increase size dynamically in the future

--- a/src/mrcpp/mwtrees/SerialFunctionTree.cpp
+++ b/src/mrcpp/mwtrees/SerialFunctionTree.cpp
@@ -266,7 +266,7 @@ ProjectedNode<D>* SerialFunctionTree<D>::allocNodes(int nAlloc, int *serialIx, d
             MSG_FATAL("maxNodes exceeded " << this->maxNodes);
         }
 
-        //we want nodes allocated simultaneously to be allocated on the same pice.
+        //we want nodes allocated simultaneously to be allocated on the same piece.
         //possibly jump over the last nodes from the old chunk
         this->nNodes = this->maxNodesPerChunk*((this->nNodes+nAlloc-1)/this->maxNodesPerChunk);//start of next chunk
 

--- a/src/mrcpp/mwtrees/SerialOperatorTree.cpp
+++ b/src/mrcpp/mwtrees/SerialOperatorTree.cpp
@@ -30,7 +30,7 @@ SerialOperatorTree::SerialOperatorTree(OperatorTree *tree, int max_nodes)
     this->maxNodesPerChunk = 64;
     int sizePerChunk = this->maxNodesPerChunk*this->sizeNodeCoeff;
    
-    if(MPI_Orb_rank==0 and NOtrees%100==1)println(10, " max_nodes = " << max_nodes << ", nodes per chunk = " << this->maxNodesPerChunk<<" sizePerChunk "<<sizePerChunk<<" N Op trees: "<<NOtrees);
+    if(mpiOrbRank==0 and NOtrees%100==1)println(10, " max_nodes = " << max_nodes << ", nodes per chunk = " << this->maxNodesPerChunk<<" sizePerChunk "<<sizePerChunk<<" N Op trees: "<<NOtrees);
 
     //indicate occupation of nodes
     this->nodeStackStatus = new int[this->maxNodes + 1];

--- a/src/mrcpp/mwtrees/SerialOperatorTree.cpp
+++ b/src/mrcpp/mwtrees/SerialOperatorTree.cpp
@@ -30,7 +30,7 @@ SerialOperatorTree::SerialOperatorTree(OperatorTree *tree, int max_nodes)
     this->maxNodesPerChunk = 64;
     int sizePerChunk = this->maxNodesPerChunk*this->sizeNodeCoeff;
    
-    if(MPI_rank==0 and NOtrees%100==1)println(10, " max_nodes = " << max_nodes << ", nodes per chunk = " << this->maxNodesPerChunk<<" sizePerChunk "<<sizePerChunk<<" N Op trees: "<<NOtrees);
+    if(MPI_Orb_rank==0 and NOtrees%100==1)println(10, " max_nodes = " << max_nodes << ", nodes per chunk = " << this->maxNodesPerChunk<<" sizePerChunk "<<sizePerChunk<<" N Op trees: "<<NOtrees);
 
     //indicate occupation of nodes
     this->nodeStackStatus = new int[this->maxNodes + 1];

--- a/src/mrcpp/mwtrees/SerialTree.h
+++ b/src/mrcpp/mwtrees/SerialTree.h
@@ -12,6 +12,8 @@
 #pragma GCC system_header
 #include <Eigen/Core>
 
+#include "parallel.h"
+
 template<int D> class MWTree;
 template<int D> class MWNode;
 
@@ -40,6 +42,8 @@ public:
     double **coeffStack;
     int maxNodes;               //max number of nodes that can be defined
     bool isShared;              //The coefficients are stored in shared memory
+    SharedMemory* shMem;
+    
 
 protected:
     MWTree<D> *tree_p;

--- a/src/mrcpp/mwtrees/SerialTree.h
+++ b/src/mrcpp/mwtrees/SerialTree.h
@@ -1,11 +1,10 @@
 /**
-*
-*
-*  \date Jul, 2016
-*  \author Peter Wind <peter.wind@uit.no> \n
-*  CTCC, University of Tromsø
-*
-*/
+ *
+ *  \date July, 2016
+ *  \author Peter Wind <peter.wind@uit.no> \n
+ *  CTCC, University of Tromsø
+ *
+ */
 
 #ifndef SERIALTREE_H_
 #define SERIALTREE_H_
@@ -19,7 +18,7 @@ template<int D> class MWNode;
 template<int D>
 class SerialTree {
 public:
-    SerialTree(MWTree<D> *tree) : tree_p(tree) { }
+    SerialTree(MWTree<D> *tree) : tree_p(tree), isShared(false) { }
     virtual ~SerialTree() { }
 
     MWTree<D>* getTree() { return this->tree_p; }
@@ -40,9 +39,9 @@ public:
     int sizeNodeCoeff;          //size of coeff for one node
     double **coeffStack;
     int maxNodes;               //max number of nodes that can be defined
+    bool isShared;              //The coefficients are stored in shared memory
 
 protected:
-
     MWTree<D> *tree_p;
 };
 

--- a/src/mrcpp/mwtrees/SerialTree.h
+++ b/src/mrcpp/mwtrees/SerialTree.h
@@ -39,9 +39,9 @@ public:
     int *nodeStackStatus;
     int sizeNodeCoeff;          //size of coeff for one node
     double **coeffStack;
+    int maxNodes;               //max number of nodes that can be defined
 
 protected:
-    int maxNodes;               //max number of nodes that can be defined
 
     MWTree<D> *tree_p;
 };

--- a/src/mrcpp/parallel.cpp
+++ b/src/mrcpp/parallel.cpp
@@ -57,7 +57,7 @@ void Send_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI_
 
 #ifdef HAVE_MPI
 template<int D>
-void ISend_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI_Comm comm){
+void ISend_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI_Comm comm, MPI_Request& request){
   MPI_Status status;
   Timer timer;
   SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
@@ -65,7 +65,6 @@ void ISend_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI
   println(10,MPI_rank<<" STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" sending to "<<dest);
   int count = 1;
   int STreeMeta[count];
-  MPI_Request request;
 
   timer.start();
   for(int ichunk = 0 ; ichunk <Nchunks ; ichunk++){
@@ -75,9 +74,9 @@ void ISend_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI
     for (int i = 0; i < STree->maxNodesPerChunk; i++){
       if(STree->nodeStackStatus[ishift+i]!=1)(STree->nodeChunks[ichunk])[i].setSerialIx(-1);
     }
-    MPI_Isend(STree->nodeChunks[ichunk], count, MPI_BYTE, dest, tag+1+ichunk, comm,&request);
+    MPI_Isend(STree->nodeChunks[ichunk], count, MPI_BYTE, dest, tag+1+ichunk, comm, &request);
     count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
-    MPI_Isend(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, dest, tag+ichunk*1000, comm,&request);
+    MPI_Isend(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, dest, tag+ichunk*1000, comm, &request);
   }
   timer.stop();
   println(10, " time send     " << timer); 
@@ -135,7 +134,7 @@ void IRcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MP
   int count = 1;
   int STreeMeta[count];
 
-  MPI_Request request;
+  MPI_Request request=MPI_REQUEST_NULL;
 
     timer.start();
     for(int ichunk = 0 ; ichunk <Nchunks ; ichunk++){
@@ -469,8 +468,8 @@ template void Send_SerialTree<3>(FunctionTree<3>* STree, int Nchunks, int dest, 
 template void IRcv_SerialTree<1>(FunctionTree<1>* STree, int Nchunks, int source, int tag, MPI_Comm comm);
 template void IRcv_SerialTree<2>(FunctionTree<2>* STree, int Nchunks, int source, int tag, MPI_Comm comm);
 template void IRcv_SerialTree<3>(FunctionTree<3>* STree, int Nchunks, int source, int tag, MPI_Comm comm);
-template void ISend_SerialTree<1>(FunctionTree<1>* STree, int Nchunks, int dest, int tag, MPI_Comm comm);
-template void ISend_SerialTree<2>(FunctionTree<2>* STree, int Nchunks, int dest, int tag, MPI_Comm comm);
-template void ISend_SerialTree<3>(FunctionTree<3>* STree, int Nchunks, int dest, int tag, MPI_Comm comm);
+template void ISend_SerialTree<1>(FunctionTree<1>* STree, int Nchunks, int dest, int tag, MPI_Comm comm, MPI_Request& request);
+template void ISend_SerialTree<2>(FunctionTree<2>* STree, int Nchunks, int dest, int tag, MPI_Comm comm, MPI_Request& request);
+template void ISend_SerialTree<3>(FunctionTree<3>* STree, int Nchunks, int dest, int tag, MPI_Comm comm, MPI_Request& request);
 #endif
 

--- a/src/mrcpp/parallel.cpp
+++ b/src/mrcpp/parallel.cpp
@@ -424,21 +424,24 @@ void define_groups(){
   
 }
 
+#ifdef HAVE_MPI
 /** Define MPI groups that share the same compute-node i.e. the same memory and array with shared memory between
- * sh_size is size in Bytes
- * returns a pointer to the shared memory
-void Share_memory(MPI_Comm ncomm, MPI_Comm ncomm_sh, int sh_size, double * d_ptr){
+ * sh_size is size in MBytes
+ * returns a pointer to the shared memory*/
+void Share_memory(MPI_Comm ncomm, MPI_Comm& ncomm_sh, int sh_size, double * d_ptr){
 
   //split ncomm into groups that can share memory
+
   MPI_Comm_split_type(ncomm, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &ncomm_sh);
 
   int shrank;
   MPI_Comm_rank(ncomm_sh, &shrank);
-  MPI_Aint size = (shrank==0) ? sh_size : 0;//rank 0 defines length of segment 
+  //MPI_Aint types are used for adresses (can be larger than int).
+  MPI_Aint size = (shrank==0) ? 1024*1024*sh_size : 0;//rank 0 defines length of segment 
   MPI_Win win = MPI_WIN_NULL;
   int disp_unit = 16;//in order for the compiler to keep aligned. 
-  //sh_size is in bytes
-  MPI_Win_allocate_shared(sh_size, disp_unit, MPI_INFO_NULL, ncomm_sh, &d_ptr, &win);
+  //size is in bytes
+  MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, ncomm_sh, &d_ptr, &win);
 
   MPI_Win_fence(0, win);//wait until finished
 
@@ -446,17 +449,16 @@ void Share_memory(MPI_Comm ncomm, MPI_Comm ncomm_sh, int sh_size, double * d_ptr
   int qdisp = 0;
   int * qbase = NULL;
   MPI_Win_shared_query(win, 0, &qsize, &qdisp, &d_ptr);
-  printf("me = %d, allocated: size=%zu, bytes at = %p\n", shrank, qsize, d_ptr);
-
-  qbase[shrank]=shrank;
+  //printf("me = %d, allocated: size=%zu, bytes at = %p\n", shrank, qsize, d_ptr);
   MPI_Barrier(ncomm);
-  for (int i=0; i<sh_size; i++){
-    printf("shared: me=%d, i=%d, val=%d\n", shrank, i, qbase[i]);
-  }
+  //if(MPI_rank==0)d_ptr[18]=2.34;
+  //printf("shared: me=%d,  val=%lf\n", shrank, d_ptr[18]);
+
   //MPI_Win_free(&win);//to include at the end of the program
   //MPI_Comm_free(&ncomm_sh);//to include at the end of the program?
 
-} */
+} 
+#endif
 
 #ifdef HAVE_MPI
 template void Rcv_SerialTree<1>(FunctionTree<1>* STree, int Nchunks, int source, int tag, MPI_Comm comm);

--- a/src/mrcpp/parallel.cpp
+++ b/src/mrcpp/parallel.cpp
@@ -12,112 +12,123 @@
 
 using namespace std;
 
-int MPI_rank = 0;
-int MPI_size = 1;
+int MPI_Orb_rank = 0;
+int MPI_Orb_size = 1;
+int MPI_SH_rank = 0;
+int MPI_SH_size = 1;
+int MPI_SH_group_rank = 0;
+int MPI_SH_group_size = 1;
+
+#ifdef HAVE_MPI
+MPI_Comm MPI_Comm_Orb;
+MPI_Comm MPI_Comm_SH;
+MPI_Comm MPI_Comm_SH_group;
+#endif
 
 /** Send or receive a serial tree using MPI
  */
 void MPI_Initializations(){
 
 #ifdef HAVE_MPI
-  MPI_Comm_rank(MPI_COMM_WORLD, &MPI_rank);
-  MPI_Comm_size(MPI_COMM_WORLD, &MPI_size);
+    MPI_Init(NULL, NULL);
+    define_MPI_groups();
 #endif
-
 }
 
 #ifdef HAVE_MPI
 template<int D>
 void Send_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI_Comm comm){
-  MPI_Status status;
-  Timer timer;
-  SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
+    MPI_Status status;
+    Timer timer;
+    SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
   
-  println(10," STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" sending to "<<dest);
-  int count = 1;
-  int STreeMeta[count];
+    println(10," STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" sending to "<<dest);
+    int count = 1;
+    int STreeMeta[count];
   
-  timer.start();
-  for(int ichunk = 0 ; ichunk <Nchunks ; ichunk++){
-    count=STree->maxNodesPerChunk*sizeof(ProjectedNode<D>);
-    //set serialIx of the unused nodes to -1
-    int ishift = ichunk*STree->maxNodesPerChunk;
-    for (int i = 0; i < STree->maxNodesPerChunk; i++){
-      if(STree->nodeStackStatus[ishift+i]!=1)(STree->nodeChunks[ichunk])[i].setSerialIx(-1);
+    timer.start();
+    for(int ichunk = 0 ; ichunk <Nchunks ; ichunk++){
+	count=STree->maxNodesPerChunk*sizeof(ProjectedNode<D>);
+	//set serialIx of the unused nodes to -1
+	int ishift = ichunk*STree->maxNodesPerChunk;
+	for (int i = 0; i < STree->maxNodesPerChunk; i++){
+	    if(STree->nodeStackStatus[ishift+i]!=1)(STree->nodeChunks[ichunk])[i].setSerialIx(-1);
+	}
+	MPI_Send(STree->nodeChunks[ichunk], count, MPI_BYTE, dest, tag+1+ichunk, comm);
+	count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
+	if (not STree->isShared or MPI_SH_group_rank != dest/MPI_SH_size){
+	    MPI_Send(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, dest, tag+ichunk*1000, comm);}
     }
-    MPI_Send(STree->nodeChunks[ichunk], count, MPI_BYTE, dest, tag+1+ichunk, comm);
-    count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
-    MPI_Send(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, dest, tag+ichunk*1000, comm);
-  }
   
-  timer.stop();
-  println(10," time send     " << timer); 
+    timer.stop();
+    println(10," time send     " << timer); 
 }
 #endif
 
 #ifdef HAVE_MPI
 template<int D>
 void ISend_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI_Comm comm, MPI_Request& request){
-  MPI_Status status;
-  Timer timer;
-  SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
+    MPI_Status status;
+    Timer timer;
+    SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
   
-  println(10,MPI_rank<<" STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" sending to "<<dest);
-  int count = 1;
-  int STreeMeta[count];
+    println(10,MPI_Orb_rank<<" STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" sending to "<<dest);
+    int count = 1;
+    int STreeMeta[count];
 
-  timer.start();
-  for(int ichunk = 0 ; ichunk <Nchunks ; ichunk++){
-    count=STree->maxNodesPerChunk*sizeof(ProjectedNode<D>);
-    //set serialIx of the unused nodes to -1
-    int ishift = ichunk*STree->maxNodesPerChunk;
-    for (int i = 0; i < STree->maxNodesPerChunk; i++){
-      if(STree->nodeStackStatus[ishift+i]!=1)(STree->nodeChunks[ichunk])[i].setSerialIx(-1);
+    timer.start();
+    for (int ichunk = 0 ; ichunk < Nchunks ; ichunk++){
+	count=STree->maxNodesPerChunk*sizeof(ProjectedNode<D>);
+	//set serialIx of the unused nodes to -1
+	int ishift = ichunk*STree->maxNodesPerChunk;
+	for (int i = 0; i < STree->maxNodesPerChunk; i++){
+	    if (STree->nodeStackStatus[ishift+i] != 1)(STree->nodeChunks[ichunk])[i].setSerialIx(-1);
+	}
+	MPI_Isend(STree->nodeChunks[ichunk], count, MPI_BYTE, dest, tag+1+ichunk, comm, &request);
+	count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
+	if (not STree->isShared or MPI_SH_group_rank != dest/MPI_SH_size){
+	    MPI_Isend(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, dest, tag+ichunk*1000, comm, &request);}
     }
-    MPI_Isend(STree->nodeChunks[ichunk], count, MPI_BYTE, dest, tag+1+ichunk, comm, &request);
-    count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
-    MPI_Isend(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, dest, tag+ichunk*1000, comm, &request);
-  }
-  timer.stop();
-  println(10, " time send     " << timer); 
+    timer.stop();
+    println(10, " time send     " << timer); 
 }
 #endif
 
 #ifdef HAVE_MPI
 template<int D>
 void Rcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MPI_Comm comm){
-  MPI_Status status;
-  Timer timer;
-  SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
+    MPI_Status status;
+    Timer timer;
+    SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
   
-
-  println(10, MPI_rank<<" STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" receiving from "<<source);
-  int count = 1;
-  int STreeMeta[count];
+    println(10, MPI_Orb_rank<<" STree  at "<<STree<<" receiving  "<<Nchunks<<" chunks from "<<source);
+    int count = 1;
+    int STreeMeta[count];
 
     timer.start();
     for(int ichunk = 0 ; ichunk <Nchunks ; ichunk++){
-      if(ichunk<STree->nodeChunks.size()){
-	STree->sNodes = STree->nodeChunks[ichunk];
-      }else{
-        double *sNodesCoeff = new double[STree->sizeNodeCoeff*STree->maxNodesPerChunk];
-        STree->nodeCoeffChunks.push_back(sNodesCoeff);
-	STree->sNodes = (ProjectedNode<D>*) new char[STree->maxNodesPerChunk*sizeof(ProjectedNode<D>)];
-	STree->nodeChunks.push_back(STree->sNodes);
-      }      
-      count=STree->maxNodesPerChunk*sizeof(ProjectedNode<D>);
-      MPI_Recv(STree->nodeChunks[ichunk], count, MPI_BYTE, source, tag+1+ichunk, comm, &status);
-      println(10, MPI_rank<<" received  "<<count/1024<<" kB with ProjectedNodes from "<<source);
-      count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
-      MPI_Recv(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, source, tag+ichunk*1000, comm, &status);
-      println(10, " received  "<<count<<" coefficients from "<<source);
+	if(ichunk<STree->nodeChunks.size()){
+	    STree->sNodes = STree->nodeChunks[ichunk];
+	}else{
+	    double *sNodesCoeff = new double[STree->sizeNodeCoeff*STree->maxNodesPerChunk];
+	    STree->nodeCoeffChunks.push_back(sNodesCoeff);
+	    STree->sNodes = (ProjectedNode<D>*) new char[STree->maxNodesPerChunk*sizeof(ProjectedNode<D>)];
+	    STree->nodeChunks.push_back(STree->sNodes);
+	}      
+	count=STree->maxNodesPerChunk*sizeof(ProjectedNode<D>);
+	MPI_Recv(STree->nodeChunks[ichunk], count, MPI_BYTE, source, tag+1+ichunk, comm, &status);
+	println(10, MPI_Orb_rank<<" received  "<<count/1024<<" kB with ProjectedNodes from "<<source);
+	count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
+	if( not STree->isShared or MPI_SH_group_rank != source/MPI_SH_size){
+	    MPI_Recv(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, source, tag+ichunk*1000, comm, &status);}
+	println(10, " received  "<<count<<" coefficients from "<<source);
     }
     timer.stop();
     println(10, " time receive  " << timer);
     timer.start();
     STree->rewritePointers(Nchunks);
     timer.stop();
-	    println(10, " time rewrite pointers  " << timer);
+    println(10, " time rewrite pointers  " << timer);
 
 }
 #endif
@@ -125,33 +136,34 @@ void Rcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MPI
 #ifdef HAVE_MPI
 template<int D>
 void IRcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MPI_Comm comm){
-  MPI_Status status;
-  Timer timer;
-  SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
+    MPI_Status status;
+    Timer timer;
+    SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
   
 
-  println(10, MPI_rank<<" STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" receiving from "<<source);
-  int count = 1;
-  int STreeMeta[count];
+    println(10, MPI_Orb_rank<<" STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" receiving from "<<source);
+    int count = 1;
+    int STreeMeta[count];
 
-  MPI_Request request=MPI_REQUEST_NULL;
+    MPI_Request request=MPI_REQUEST_NULL;
 
     timer.start();
     for(int ichunk = 0 ; ichunk <Nchunks ; ichunk++){
-      if(ichunk<STree->nodeChunks.size()){
-	STree->sNodes = STree->nodeChunks[ichunk];
-      }else{
-        double *sNodesCoeff = new double[STree->sizeNodeCoeff*STree->maxNodesPerChunk];
-        STree->nodeCoeffChunks.push_back(sNodesCoeff);
-	STree->sNodes = (ProjectedNode<D>*) new char[STree->maxNodesPerChunk*sizeof(ProjectedNode<D>)];
-	STree->nodeChunks.push_back(STree->sNodes);
-      }      
-      count=STree->maxNodesPerChunk*sizeof(ProjectedNode<D>);
-      MPI_Irecv(STree->nodeChunks[ichunk], count, MPI_BYTE, source, tag+1+ichunk, comm, &request);
-      println(10, MPI_rank<<" received  "<<count/1024<<" kB with ProjectedNodes from "<<source);
-      count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
-      MPI_Irecv(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, source, tag+ichunk*1000, comm, &request);
-      println(10, MPI_rank<<" received  "<<count<<" coefficients from "<<source);
+	if(ichunk<STree->nodeChunks.size()){
+	    STree->sNodes = STree->nodeChunks[ichunk];
+	}else{
+	    double *sNodesCoeff = new double[STree->sizeNodeCoeff*STree->maxNodesPerChunk];
+	    STree->nodeCoeffChunks.push_back(sNodesCoeff);
+	    STree->sNodes = (ProjectedNode<D>*) new char[STree->maxNodesPerChunk*sizeof(ProjectedNode<D>)];
+	    STree->nodeChunks.push_back(STree->sNodes);
+	}      
+	count=STree->maxNodesPerChunk*sizeof(ProjectedNode<D>);
+	MPI_Irecv(STree->nodeChunks[ichunk], count, MPI_BYTE, source, tag+1+ichunk, comm, &request);
+	println(10, MPI_Orb_rank<<" received  "<<count/1024<<" kB with ProjectedNodes from "<<source);
+	count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
+	if (not STree->isShared or MPI_SH_group_rank != source/MPI_SH_size){
+	    MPI_Irecv(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, source, tag+ichunk*1000, comm, &request);}
+	println(10, MPI_Orb_rank<<" received  "<<count<<" coefficients from "<<source);
     }
 
 
@@ -175,126 +187,126 @@ void IRcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MP
  * output: 
  * which (i,j) pair to compute next
  * to whom send own data, from who receive data
- * NB: does not work for N even when N is not a multiple of MPI_size
+ * NB: does not work for N even when N is not a multiple of MPI_Orb_size
  */
 void Assign_NxN_sym(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb, int* MaxIter){
-  int iter = 0;
-  int NBlock=N/MPI_size;//number of subblocks
-  int M = N%MPI_size; //number of lines and column left after subblocks are taken out
-  int Maxiter=-1;
-  int iter_base;
-  int iBlock = 0;
-  int jBlock = 0;
+    int iter = 0;
+    int NBlock=N/MPI_Orb_size;//number of subblocks
+    int M = N%MPI_Orb_size; //number of lines and column left after subblocks are taken out
+    int Maxiter=-1;
+    int iter_base;
+    int iBlock = 0;
+    int jBlock = 0;
 
-  if(N%2==0 and N%MPI_size!=0 )MSG_FATAL("Assign_NxN_sym not implemented for this case");
-  for (iter = 0; iter < *MaxIter; iter++) {
-    doi[iter] = -1;
-    doj[iter] = -1;
-    sendto[iter] = -1;
-    sendorb[iter] = -1;
-    rcvorb[iter] = -1;
-  }
-
-  for (int dBlock = 0; dBlock < (N+MPI_size-1)/MPI_size; dBlock++) {
-    //treat diagonal block first
-    int imax=MPI_size;//size of the diagonal block
-    if(dBlock==NBlock)imax=M;
-    int jmax=MPI_size;
-    if(dBlock==NBlock)jmax=M;
-    for (int i = 0; i < imax; i++) {
-      for (int j = 0; j < jmax; j++) {
-
-	//used in a diagonal block: 1+MPI_size/2 
-	//used in a block below diagonal: (1+MPI_size)*0.5
-	//   if even MPI_rank: 1+MPI_size/2 if even block, and MPI_size/2 if odd block, 0.5*(1+MPI_size) on average, 
-	//used in a block over diagonal: (1+MPI_size)*0.5-1
-	//number of entire blocks in a column: N/MPI_size 
-        //possibly used in lowest reduced block in column: M/2
-	//used in all blocks in one column d (starting at 0): (1+(N/MPI_size)*(1+MPI_size))/2-d+M/2
-	//used in all blocks up to column d, without d: d*(1+(N/MPI_size)*(1+MPI_size))/2-(d*(d-1))/2+d*M/2
-
-
-	//(MPI_size+j-i)%MPI_size : for one block
-        //((N+MPI_size-1)/MPI_size) : number of blocks in one column
-        //-dBlock: The diagonal is not counted again in each block
-	iter_base = (MPI_size+j-i)%MPI_size * ((N+MPI_size-1)/MPI_size)-dBlock;
-	if(i==j)iter_base = 0;
-	//the last block may be smaller
-	if(dBlock==NBlock)iter_base = (imax+j-i)%M * ((N+MPI_size-1)/MPI_size);
-	//Shift for all the columns already taken into account
-	iter = iter_base + dBlock*((1+((N+MPI_size-1)/MPI_size)*(1+MPI_size))/2) - (dBlock*(dBlock-1))/2 + dBlock*M/2;
-
-	if( (imax+j-i)%imax<=imax/2 ){
-	int i_glob = i + dBlock*MPI_size;
-	int j_glob = j + dBlock*MPI_size;
-
-	if(i==MPI_rank and ( imax%2!=0 or (imax+j-i)%imax<imax/2 or i<j )) {
-	  if(iter>Maxiter)Maxiter=iter;
-	  doi[iter]=i_glob;
-	  doj[iter]=j_glob;
-	  if(i!=j)rcvorb[iter]=j_glob;
-	  if(imax%2==0 and (imax+j-i)%imax==imax/2 and i<j){
-	    sendto[iter]=j;
-	    sendorb[iter]=i_glob;	    
-	  }
-	}else if(j==MPI_rank and ( imax%2!=0 or (imax+j-i)%imax<imax/2 or i<j )){
-	  sendto[iter]=i;
-	  sendorb[iter]=j_glob;
-	  if(imax%2==0 and (imax+j-i)%imax==imax/2 and i<j){
-	    rcvorb[iter]=i;
-	  }
-	}
-
-	//all columns that can be generated from received data.	
-	if((i==MPI_rank and (i<=j or (MPI_size%2==0 and (imax+j-i)%imax==imax/2) ))){
-	  for (int icol = i; icol < N; icol+=MPI_size) {
-	    iBlock=icol/MPI_size;
-	    if((i!=j or iBlock>dBlock) and  (MPI_size%2!=0 or ((imax+j-i)%imax<imax/2) or ((iBlock+dBlock)%2!=0 and i>j) or ((iBlock+dBlock)%2==0 and i<j)  )){
-	    if(iBlock!=dBlock){
-	      int sh=1;//diagonal block is the first
-	      if(iBlock>dBlock)sh=0;//diagonal block accounted for
-	      if(i==j)sh=-dBlock;//only below diagonal are counted
-	      if(MPI_size%2==0 and (imax+j-i)%imax==imax/2)sh=-(iBlock+1)/2;//only half are present
-	      if(MPI_size%2==0 and (imax+j-i)%imax==imax/2 and (dBlock%2==0 and iBlock==0))sh=1;//same iter as diagonalblock
-	      if(MPI_size%2==0 and (imax+j-i)%imax==imax/2 and (dBlock%2!=0 and iBlock==1))sh=1;//iBlock=0 same iter as diagonal block, start next iter
-	      int i_glob = i + iBlock*MPI_size;
-	      int j_glob = j + dBlock*MPI_size;
-	      if((imax+j-i)%imax<=imax/2 ){
-	      doi[iter+iBlock+sh] = i_glob;
-	      doj[iter+iBlock+sh] = j_glob;}
-	      //rcvorb[iter+iBlock+sh]=-1;//indicates "use same as before"
-	      //sendorb[iter+iBlock+sh]=-1;//indicates "do not send anything"
-	      //sendto[iter+iBlock+sh]=-1;//indicates "do not send anything"
-	      if(iter+iBlock+sh>Maxiter)Maxiter=iter+iBlock+sh;
-	    }
-	  }
-	  }
-	}else if(i==MPI_rank){
-	  //part of blocks below blockdiagonal
-	  //for (jBlock = 0; jBlock < NBlock; jBlock++) {
-	  for (int jrow = j; jrow < N; jrow+=MPI_size) {
-	    jBlock=jrow/MPI_size;
-	    if(jBlock!=dBlock  and (MPI_size%2 or (imax+j-i)%imax<(imax)/2 or (jBlock%2==0))){
-	      int sh=1;
-	      if(jBlock>dBlock)sh=0;//not very elegant
-	    int i_glob = i + dBlock*MPI_size;
-	    int j_glob = j + jBlock*MPI_size;
-	  if((imax+j-i)%imax<(imax+1)/2){
-	    doi[iter+jBlock+sh] = i_glob;
-	    doj[iter+jBlock+sh] = j_glob;}
-	    //rcvorb[iter+jBlock+sh]=-1;//indicates "use same as before"
-	    //sendorb[iter+jBlock+sh]=-1;//indicates "do not send anything"
-	    //sendto[iter+jBlock+sh]=-1;//indicates "do not send anything"
-	    if(iter+jBlock+sh>Maxiter)Maxiter=iter+jBlock+sh;
-	    }
-	  }
-	}
-	}
-      }
+    if(N%2==0 and N%MPI_Orb_size!=0 )MSG_FATAL("Assign_NxN_sym not implemented for this case");
+    for (iter = 0; iter < *MaxIter; iter++) {
+	doi[iter] = -1;
+	doj[iter] = -1;
+	sendto[iter] = -1;
+	sendorb[iter] = -1;
+	rcvorb[iter] = -1;
     }
-  }
 
-  *MaxIter = Maxiter;
+    for (int dBlock = 0; dBlock < (N+MPI_Orb_size-1)/MPI_Orb_size; dBlock++) {
+	//treat diagonal block first
+	int imax=MPI_Orb_size;//size of the diagonal block
+	if(dBlock==NBlock)imax=M;
+	int jmax=MPI_Orb_size;
+	if(dBlock==NBlock)jmax=M;
+	for (int i = 0; i < imax; i++) {
+	    for (int j = 0; j < jmax; j++) {
+
+		//used in a diagonal block: 1+MPI_Orb_size/2 
+		//used in a block below diagonal: (1+MPI_Orb_size)*0.5
+		//   if even MPI_Orb_rank: 1+MPI_Orb_size/2 if even block, and MPI_Orb_size/2 if odd block, 0.5*(1+MPI_Orb_size) on average, 
+		//used in a block over diagonal: (1+MPI_Orb_size)*0.5-1
+		//number of entire blocks in a column: N/MPI_Orb_size 
+		//possibly used in lowest reduced block in column: M/2
+		//used in all blocks in one column d (starting at 0): (1+(N/MPI_Orb_size)*(1+MPI_Orb_size))/2-d+M/2
+		//used in all blocks up to column d, without d: d*(1+(N/MPI_Orb_size)*(1+MPI_Orb_size))/2-(d*(d-1))/2+d*M/2
+
+
+		//(MPI_Orb_size+j-i)%MPI_Orb_size : for one block
+		//((N+MPI_Orb_size-1)/MPI_Orb_size) : number of blocks in one column
+		//-dBlock: The diagonal is not counted again in each block
+		iter_base = (MPI_Orb_size+j-i)%MPI_Orb_size * ((N+MPI_Orb_size-1)/MPI_Orb_size)-dBlock;
+		if(i==j)iter_base = 0;
+		//the last block may be smaller
+		if(dBlock==NBlock)iter_base = (imax+j-i)%M * ((N+MPI_Orb_size-1)/MPI_Orb_size);
+		//Shift for all the columns already taken into account
+		iter = iter_base + dBlock*((1+((N+MPI_Orb_size-1)/MPI_Orb_size)*(1+MPI_Orb_size))/2) - (dBlock*(dBlock-1))/2 + dBlock*M/2;
+
+		if( (imax+j-i)%imax<=imax/2 ){
+		    int i_glob = i + dBlock*MPI_Orb_size;
+		    int j_glob = j + dBlock*MPI_Orb_size;
+
+		    if(i==MPI_Orb_rank and ( imax%2!=0 or (imax+j-i)%imax<imax/2 or i<j )) {
+			if(iter>Maxiter)Maxiter=iter;
+			doi[iter]=i_glob;
+			doj[iter]=j_glob;
+			if(i!=j)rcvorb[iter]=j_glob;
+			if(imax%2==0 and (imax+j-i)%imax==imax/2 and i<j){
+			    sendto[iter]=j;
+			    sendorb[iter]=i_glob;	    
+			}
+		    }else if(j==MPI_Orb_rank and ( imax%2!=0 or (imax+j-i)%imax<imax/2 or i<j )){
+			sendto[iter]=i;
+			sendorb[iter]=j_glob;
+			if(imax%2==0 and (imax+j-i)%imax==imax/2 and i<j){
+			    rcvorb[iter]=i;
+			}
+		    }
+
+		    //all columns that can be generated from received data.	
+		    if((i==MPI_Orb_rank and (i<=j or (MPI_Orb_size%2==0 and (imax+j-i)%imax==imax/2) ))){
+			for (int icol = i; icol < N; icol+=MPI_Orb_size) {
+			    iBlock=icol/MPI_Orb_size;
+			    if((i!=j or iBlock>dBlock) and  (MPI_Orb_size%2!=0 or ((imax+j-i)%imax<imax/2) or ((iBlock+dBlock)%2!=0 and i>j) or ((iBlock+dBlock)%2==0 and i<j)  )){
+				if(iBlock!=dBlock){
+				    int sh=1;//diagonal block is the first
+				    if(iBlock>dBlock)sh=0;//diagonal block accounted for
+				    if(i==j)sh=-dBlock;//only below diagonal are counted
+				    if(MPI_Orb_size%2==0 and (imax+j-i)%imax==imax/2)sh=-(iBlock+1)/2;//only half are present
+				    if(MPI_Orb_size%2==0 and (imax+j-i)%imax==imax/2 and (dBlock%2==0 and iBlock==0))sh=1;//same iter as diagonalblock
+				    if(MPI_Orb_size%2==0 and (imax+j-i)%imax==imax/2 and (dBlock%2!=0 and iBlock==1))sh=1;//iBlock=0 same iter as diagonal block, start next iter
+				    int i_glob = i + iBlock*MPI_Orb_size;
+				    int j_glob = j + dBlock*MPI_Orb_size;
+				    if((imax+j-i)%imax<=imax/2 ){
+					doi[iter+iBlock+sh] = i_glob;
+					doj[iter+iBlock+sh] = j_glob;}
+				    //rcvorb[iter+iBlock+sh]=-1;//indicates "use same as before"
+				    //sendorb[iter+iBlock+sh]=-1;//indicates "do not send anything"
+				    //sendto[iter+iBlock+sh]=-1;//indicates "do not send anything"
+				    if(iter+iBlock+sh>Maxiter)Maxiter=iter+iBlock+sh;
+				}
+			    }
+			}
+		    }else if(i==MPI_Orb_rank){
+			//part of blocks below blockdiagonal
+			//for (jBlock = 0; jBlock < NBlock; jBlock++) {
+			for (int jrow = j; jrow < N; jrow+=MPI_Orb_size) {
+			    jBlock=jrow/MPI_Orb_size;
+			    if(jBlock!=dBlock  and (MPI_Orb_size%2 or (imax+j-i)%imax<(imax)/2 or (jBlock%2==0))){
+				int sh=1;
+				if(jBlock>dBlock)sh=0;//not very elegant
+				int i_glob = i + dBlock*MPI_Orb_size;
+				int j_glob = j + jBlock*MPI_Orb_size;
+				if((imax+j-i)%imax<(imax+1)/2){
+				    doi[iter+jBlock+sh] = i_glob;
+				    doj[iter+jBlock+sh] = j_glob;}
+				//rcvorb[iter+jBlock+sh]=-1;//indicates "use same as before"
+				//sendorb[iter+jBlock+sh]=-1;//indicates "do not send anything"
+				//sendto[iter+jBlock+sh]=-1;//indicates "do not send anything"
+				if(iter+jBlock+sh>Maxiter)Maxiter=iter+jBlock+sh;
+			    }
+			}
+		    }
+		}
+	    }
+	}
+    }
+
+    *MaxIter = Maxiter;
 }
 
 
@@ -309,117 +321,136 @@ void Assign_NxN_sym(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rc
  * to whom send own data, from who receive data
  */
 void Assign_NxN(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb, int* MaxIter){
-  int iter = 0;
-  int NBlock=N/MPI_size;//number of subblocks
-  int M = N%MPI_size; //number of lines and column left after subblocks are taken out
-  int Maxiter = -1;
-  int iter_base;
-  int iBlock = 0;
-  int jBlock = 0;
+    int iter = 0;
+    int NBlock=N/MPI_Orb_size;//number of subblocks
+    int M = N%MPI_Orb_size; //number of lines and column left after subblocks are taken out
+    int Maxiter = -1;
+    int iter_base;
+    int iBlock = 0;
+    int jBlock = 0;
 
-  for (iter = 0; iter < *MaxIter; iter++) {
-    doi[iter] = -1;
-    doj[iter] = -1;
-    sendto[iter] = -1;
-    sendorb[iter] = -1;
-    rcvorb[iter] = -1;
-  }
-
-  for (int dBlock = 0; dBlock < (N+MPI_size-1)/MPI_size; dBlock++) {
-
-  //1)  //diagonal block
-    int imax=MPI_size;
-    if(dBlock==NBlock)imax=M;
-    int jmax=MPI_size;
-    if(dBlock==NBlock)jmax=M;
-    for (int i = 0; i < imax; i++) {
-      for (int j = 0; j < jmax; j++) {
-	iter_base = (i+j)%MPI_size * ((N+MPI_size-1)/MPI_size);
-	if(dBlock==NBlock)iter_base = (i+j)%M * ((N+MPI_size-1)/MPI_size);
-	iter = iter_base + dBlock*MPI_size*((N+MPI_size-1)/MPI_size);
-	int i_glob = i + dBlock*MPI_size;
-	int j_glob = j + dBlock*MPI_size;
-	if(i==MPI_rank){
-	  //this processor receive orbital j_glob from MPIrank=j, and send its own orbital i_glob to MPIrank=j.
-	  if(iter>Maxiter)Maxiter=iter;
-	  doi[iter]=i_glob;
-	  doj[iter]=j_glob;
-	  if(i==j){
-	    sendto[iter]=-1;
-	    sendorb[iter]=-1;
-	    rcvorb[iter]=-1;
-	  }else{
-	    sendto[iter]=j;
-	    sendorb[iter]=i_glob;
-	    rcvorb[iter]=j_glob;}// contains info both which orbital and indirectly who from
-	}
-  //2)	//treat all rows and columns that can be generated from received data	
-	if(i<=j and i==MPI_rank){
-	  //do the corresponding column 
-	  //for (iBlock = 0; iBlock < NBlock; iBlock++) {
-	  for (int icol = i; icol < N; icol+=MPI_size) {
-	    iBlock=icol/MPI_size;
-	    if(iBlock!=dBlock){
-	      int sh=1;
-	      if(iBlock>dBlock)sh=0;//not very elegant
-	      int i_glob = i + iBlock*MPI_size;
-	      int j_glob = j + dBlock*MPI_size;
-	      doi[iter+iBlock+sh] = i_glob;
-	      doj[iter+iBlock+sh] = j_glob;
-	      rcvorb[iter+iBlock+sh]=-1;//indicates "use same as before"
-	      sendorb[iter+iBlock+sh]=-1;//indicates "do not send anything"
-	      sendto[iter+iBlock+sh]=-1;//indicates "do not send anything"
-	      if(iter+iBlock+sh>Maxiter)Maxiter=iter+iBlock+sh;
-	    }
-	  }
-	}else if(i==MPI_rank){
-	  //do the corresponding row
-	  //for (jBlock = 0; jBlock < NBlock; jBlock++) {
-	  for (int jrow = j; jrow < N; jrow+=MPI_size) {
-	    jBlock=jrow/MPI_size;
-	    if(jBlock!=dBlock){
-	      int sh=1;
-	      if(jBlock>dBlock)sh=0;//not very elegant
-	    int i_glob = i + dBlock*MPI_size;
-	    int j_glob = j + jBlock*MPI_size;
-	    
-	    doi[iter+jBlock+sh] = i_glob;
-	    doj[iter+jBlock+sh] = j_glob;
-	    rcvorb[iter+jBlock+sh]=-1;//indicates "use same as before"
-	    sendorb[iter+jBlock+sh]=-1;//indicates "do not send anything"
-	    sendto[iter+jBlock+sh]=-1;//indicates "do not send anything"
-	    if(iter+jBlock+sh>Maxiter)Maxiter=iter+jBlock+sh;
-	    }
-	  }
-	}
-      }
+    for (iter = 0; iter < *MaxIter; iter++) {
+	doi[iter] = -1;
+	doj[iter] = -1;
+	sendto[iter] = -1;
+	sendorb[iter] = -1;
+	rcvorb[iter] = -1;
     }
-  }
-    int NiterMax = ((N+MPI_size-1)/MPI_size)*((N+MPI_size-1)/MPI_size)*MPI_size;
+
+    for (int dBlock = 0; dBlock < (N+MPI_Orb_size-1)/MPI_Orb_size; dBlock++) {
+
+	//1)  //diagonal block
+	int imax=MPI_Orb_size;
+	if(dBlock==NBlock)imax=M;
+	int jmax=MPI_Orb_size;
+	if(dBlock==NBlock)jmax=M;
+	for (int i = 0; i < imax; i++) {
+	    for (int j = 0; j < jmax; j++) {
+		iter_base = (i+j)%MPI_Orb_size * ((N+MPI_Orb_size-1)/MPI_Orb_size);
+		if(dBlock==NBlock)iter_base = (i+j)%M * ((N+MPI_Orb_size-1)/MPI_Orb_size);
+		iter = iter_base + dBlock*MPI_Orb_size*((N+MPI_Orb_size-1)/MPI_Orb_size);
+		int i_glob = i + dBlock*MPI_Orb_size;
+		int j_glob = j + dBlock*MPI_Orb_size;
+		if(i==MPI_Orb_rank){
+		    //this processor receive orbital j_glob from MPIrank=j, and send its own orbital i_glob to MPIrank=j.
+		    if(iter>Maxiter)Maxiter=iter;
+		    doi[iter]=i_glob;
+		    doj[iter]=j_glob;
+		    if(i==j){
+			sendto[iter]=-1;
+			sendorb[iter]=-1;
+			rcvorb[iter]=-1;
+		    }else{
+			sendto[iter]=j;
+			sendorb[iter]=i_glob;
+			rcvorb[iter]=j_glob;}// contains info both which orbital and indirectly who from
+		}
+		//2)	//treat all rows and columns that can be generated from received data	
+		if(i<=j and i==MPI_Orb_rank){
+		    //do the corresponding column 
+		    //for (iBlock = 0; iBlock < NBlock; iBlock++) {
+		    for (int icol = i; icol < N; icol+=MPI_Orb_size) {
+			iBlock=icol/MPI_Orb_size;
+			if(iBlock!=dBlock){
+			    int sh=1;
+			    if(iBlock>dBlock)sh=0;//not very elegant
+			    int i_glob = i + iBlock*MPI_Orb_size;
+			    int j_glob = j + dBlock*MPI_Orb_size;
+			    doi[iter+iBlock+sh] = i_glob;
+			    doj[iter+iBlock+sh] = j_glob;
+			    rcvorb[iter+iBlock+sh]=-1;//indicates "use same as before"
+			    sendorb[iter+iBlock+sh]=-1;//indicates "do not send anything"
+			    sendto[iter+iBlock+sh]=-1;//indicates "do not send anything"
+			    if(iter+iBlock+sh>Maxiter)Maxiter=iter+iBlock+sh;
+			}
+		    }
+		}else if(i==MPI_Orb_rank){
+		    //do the corresponding row
+		    //for (jBlock = 0; jBlock < NBlock; jBlock++) {
+		    for (int jrow = j; jrow < N; jrow+=MPI_Orb_size) {
+			jBlock=jrow/MPI_Orb_size;
+			if(jBlock!=dBlock){
+			    int sh=1;
+			    if(jBlock>dBlock)sh=0;//not very elegant
+			    int i_glob = i + dBlock*MPI_Orb_size;
+			    int j_glob = j + jBlock*MPI_Orb_size;
+	    
+			    doi[iter+jBlock+sh] = i_glob;
+			    doj[iter+jBlock+sh] = j_glob;
+			    rcvorb[iter+jBlock+sh]=-1;//indicates "use same as before"
+			    sendorb[iter+jBlock+sh]=-1;//indicates "do not send anything"
+			    sendto[iter+jBlock+sh]=-1;//indicates "do not send anything"
+			    if(iter+jBlock+sh>Maxiter)Maxiter=iter+jBlock+sh;
+			}
+		    }
+		}
+	    }
+	}
+    }
+    int NiterMax = ((N+MPI_Orb_size-1)/MPI_Orb_size)*((N+MPI_Orb_size-1)/MPI_Orb_size)*MPI_Orb_size;
     if(Maxiter>NiterMax)cout<<"CHECK Assign_NxN "<<endl;
     *MaxIter = Maxiter;
 }
 
 /** Define all the different MPI groups
  */
-void define_groups(){
+void define_MPI_groups(){
 
 #ifdef HAVE_MPI
-  int MPI_worldsize;
-  MPI_Comm_size(MPI_COMM_WORLD, &MPI_worldsize);
-  int MPI_orbital_group_size = MPI_worldsize;//temporary definition
-  println(0,"MPI world size: "<< MPI_worldsize ); 
-  int MPI_worldrank;
-  MPI_Comm_rank(MPI_COMM_WORLD, &MPI_worldrank);
-  int i = (MPI_worldrank) % MPI_orbital_group_size;
+    int MPI_worldsize;
+    MPI_Comm_size(MPI_COMM_WORLD, &MPI_worldsize);
+    println(10,"MPI world size: "<< MPI_worldsize ); 
+    int MPI_worldrank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &MPI_worldrank);
 
-  //divide the world into groups
-  //NB: each group has its own group communicator definition!
-  MPI_Comm MPI_Comm_Orbital;
-  MPI_Comm_split(MPI_COMM_WORLD, 0, i, &MPI_Comm_Orbital);//0 is color (same color->in same group), i is key (orders rank in the group)
-  MPI_Comm_size(MPI_COMM_WORLD, &MPI_worldsize);
-  MPI_Comm_size(MPI_COMM_WORLD, &MPI_orbital_group_size);
-  println(0,"orbital group size: "<< MPI_orbital_group_size); 
+    //divide the world into groups
+    //each group has its own group communicator definition
+ 
+    //split world into groups that can share memory
+    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &MPI_Comm_SH);
+
+    MPI_Comm_rank(MPI_Comm_SH, &MPI_SH_rank);//rank in the SH group
+    MPI_Comm_size(MPI_Comm_SH, &MPI_SH_size);
+    println(10,"MPI SH size: "<< MPI_SH_size ); 
+
+    //define a rank of the group. NB: we assume for now that all groups have same size
+    MPI_Comm MPI_Comm_SH_group;
+    MPI_Comm_split(MPI_COMM_WORLD, MPI_SH_rank, MPI_worldrank, &MPI_Comm_SH_group);//MPI_SH_rank is color (same color->in same group),  MPI_worldrank is key (orders rank within the groups)
+
+    //we define a new orbital rank, so that the orbitals within a shared memory group, have consecutive ranks.
+    MPI_Comm_rank(MPI_Comm_SH_group, &MPI_SH_group_rank);//rank in the SH group
+    MPI_Comm_size(MPI_Comm_SH_group, &MPI_SH_group_size);
+    if(MPI_worldsize != MPI_SH_size*MPI_SH_group_size )MSG_FATAL("all MPI SH groups must be of same size");
+    println(10,"MPI SH group size: "<< MPI_SH_group_size ); 
+    MPI_Orb_rank = MPI_SH_rank + MPI_SH_group_rank*MPI_SH_size ;
+
+    MPI_Comm_split(MPI_COMM_WORLD, 0, MPI_Orb_rank, &MPI_Comm_Orb);//0 is color (same color->in same group), MPI_Orb_rank is key (orders rank in the group)
+    int MPI_Orb_rank;
+    MPI_Comm_rank(MPI_Comm_Orb, &MPI_Orb_rank);//should be the same
+    MPI_Comm_size(MPI_Comm_Orb, &MPI_Orb_size);
+    println(10,"orbital group size: "<< MPI_Orb_size); 
+    //    cout<<"world rank="<<MPI_worldrank<<"  Orbital rank="<<MPI_Orb_rank<<"  Shared mem rank="<<MPI_SH_rank<<"  Shared memory group rank="<<MPI_SH_group_rank<<endl;
+
 #endif
   
 }
@@ -428,34 +459,27 @@ void define_groups(){
 /** Define MPI groups that share the same compute-node i.e. the same memory and array with shared memory between
  * sh_size is size in MBytes
  * returns a pointer to the shared memory*/
-void Share_memory(MPI_Comm ncomm, MPI_Comm& ncomm_sh, int sh_size, double * d_ptr){
+void Share_memory(int sh_size, double * &d_ptr, MPI_Win &win){
 
-  //split ncomm into groups that can share memory
+    //MPI_Aint types are used for adresses (can be larger than int).
+    MPI_Aint size = (MPI_SH_rank==0) ? 1024*1024*sh_size : 0;//rank 0 defines length of segment 
+    //MPI_Win win = MPI_WIN_NULL;
+    int disp_unit = 16;//in order for the compiler to keep aligned. 
+    //size is in bytes
+    MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, MPI_Comm_SH, &d_ptr, &win);
 
-  MPI_Comm_split_type(ncomm, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &ncomm_sh);
+    MPI_Win_fence(0, win);//wait until finished
 
-  int shrank;
-  MPI_Comm_rank(ncomm_sh, &shrank);
-  //MPI_Aint types are used for adresses (can be larger than int).
-  MPI_Aint size = (shrank==0) ? 1024*1024*sh_size : 0;//rank 0 defines length of segment 
-  MPI_Win win = MPI_WIN_NULL;
-  int disp_unit = 16;//in order for the compiler to keep aligned. 
-  //size is in bytes
-  MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, ncomm_sh, &d_ptr, &win);
+    MPI_Aint qsize = 0;
+    int qdisp = 0;
+    int * qbase = NULL;
+    MPI_Win_shared_query(win, 0, &qsize, &qdisp, &d_ptr);
+    //printf("me = %d, allocated: size=%zu, bytes at = %p\n", shrank, qsize, d_ptr);
+    MPI_Win_fence(0, win);
+    //if(MPI_Orb_rank==0)d_ptr[18]=2.34;
+    //printf("shared: me=%d,  val=%lf\n", shrank, d_ptr[18]);
 
-  MPI_Win_fence(0, win);//wait until finished
-
-  MPI_Aint qsize = 0;
-  int qdisp = 0;
-  int * qbase = NULL;
-  MPI_Win_shared_query(win, 0, &qsize, &qdisp, &d_ptr);
-  //printf("me = %d, allocated: size=%zu, bytes at = %p\n", shrank, qsize, d_ptr);
-  MPI_Barrier(ncomm);
-  //if(MPI_rank==0)d_ptr[18]=2.34;
-  //printf("shared: me=%d,  val=%lf\n", shrank, d_ptr[18]);
-
-  //MPI_Win_free(&win);//to include at the end of the program
-  //MPI_Comm_free(&ncomm_sh);//to include at the end of the program?
+    //MPI_Win_free(&win);//to include in destructor
 
 } 
 #endif

--- a/src/mrcpp/parallel.cpp
+++ b/src/mrcpp/parallel.cpp
@@ -12,17 +12,14 @@
 
 using namespace std;
 
-int MPI_Orb_rank = 0;
-int MPI_Orb_size = 1;
-int MPI_SH_rank = 0;
-int MPI_SH_size = 1;
-int MPI_SH_group_rank = 0;
-int MPI_SH_group_size = 1;
+int mpiOrbRank = 0;
+int mpiOrbSize = 1;
+int mpiShRank = 0;
+int mpiShSize = 1;
 
 #ifdef HAVE_MPI
-MPI_Comm MPI_Comm_Orb;
-MPI_Comm MPI_Comm_SH;
-MPI_Comm MPI_Comm_SH_group;
+MPI_Comm mpiCommOrb;
+MPI_Comm mpiCommSh;
 #endif
 
 /** sh_size in MB
@@ -40,20 +37,20 @@ SharedMemory::~SharedMemory(){
 void SharedMemory::allocShmem(int sh_size){
 #ifdef HAVE_MPI
     //MPI_Aint types are used for adresses (can be larger than int).
-    MPI_Aint size = (MPI_SH_rank==0) ? 1024*1024*sh_size : 0;//rank 0 defines length of segment 
+    MPI_Aint size = (mpiShRank==0) ? 1024*1024*sh_size : 0;//rank 0 defines length of segment 
     int disp_unit = 16;//in order for the compiler to keep aligned. 
     //size is in bytes
-    MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, MPI_Comm_SH, &this->sh_start_ptr, &this->sh_win);
+    MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, mpiCommSh, &this->sh_start_ptr, &this->sh_win);
     MPI_Win_fence(0, this->sh_win);//wait until finished
     MPI_Aint qsize = 0;
     int qdisp = 0;
     MPI_Win_shared_query(this->sh_win, 0, &qsize, &qdisp, &this->sh_start_ptr);
-    //    printf("me = %d, allocated: size=%zu, bytes at = %p %d\n", MPI_SH_rank, qsize, this->sh_start_ptr, this->sh_start_ptr );
+    //    printf("me = %d, allocated: size=%zu, bytes at = %p %d\n", mpiShRank, qsize, this->sh_start_ptr, this->sh_start_ptr );
     MPI_Win_fence(0, this->sh_win);
     this->sh_max_ptr = this->sh_start_ptr + qsize/sizeof(double);
-    //printf("me = %d, start = %p, max  = %p diff %d\n", MPI_SH_rank, this->sh_start_ptr, this->sh_max_ptr, this->sh_max_ptr-this->sh_start_ptr);
+    //printf("me = %d, start = %p, max  = %p diff %d\n", mpiShRank, this->sh_start_ptr, this->sh_max_ptr, this->sh_max_ptr-this->sh_start_ptr);
     this->sh_end_ptr = this->sh_start_ptr;
-    //if(MPI_Orb_rank==0)d_ptr[18]=2.34;
+    //if(mpiOrbRank==0)d_ptr[18]=2.34;
     //printf("shared: me=%d,  val=%lf\n", shrank, d_ptr[18]);
 #endif
 }
@@ -86,11 +83,11 @@ void Send_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI_
 	//set serialIx of the unused nodes to -1
 	int ishift = ichunk*STree->maxNodesPerChunk;
 	for (int i = 0; i < STree->maxNodesPerChunk; i++){
-	    if(STree->nodeStackStatus[ishift+i]!=1)(STree->nodeChunks[ichunk])[i].setSerialIx(-1);
+	    if(STree->nodeStackStatus[ishift+i] !=1 )(STree->nodeChunks[ichunk])[i].setSerialIx(-1);
 	}
 	MPI_Send(STree->nodeChunks[ichunk], count, MPI_BYTE, dest, tag+1+ichunk, comm);
 	count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
-	if (not STree->isShared or MPI_SH_group_rank != dest/MPI_SH_size){
+	if (not STree->isShared or not orbIsSh(dest)){
 	    MPI_Send(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, dest, tag+ichunk*1000, comm);}
     }
   
@@ -106,7 +103,7 @@ void ISend_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI
     Timer timer;
     SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
   
-    println(10,MPI_Orb_rank<<" STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" sending to "<<dest);
+    println(10,mpiOrbRank<<" STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" sending to "<<dest);
     int count = 1;
     int STreeMeta[count];
 
@@ -120,7 +117,7 @@ void ISend_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI
 	}
 	MPI_Isend(STree->nodeChunks[ichunk], count, MPI_BYTE, dest, tag+1+ichunk, comm, &request);
 	count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
-	if (not STree->isShared or MPI_SH_group_rank != dest/MPI_SH_size){
+	if (not STree->isShared or not orbIsSh(dest)){
 	    MPI_Isend(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, dest, tag+ichunk*1000, comm, &request);}
     }
     timer.stop();
@@ -135,13 +132,13 @@ void Rcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MPI
     Timer timer;
     SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
   
-    println(10, MPI_Orb_rank<<" STree  at "<<STree<<" receiving  "<<Nchunks<<" chunks from "<<source);
+    println(10, mpiOrbRank<<" STree  at "<<STree<<" receiving  "<<Nchunks<<" chunks from "<<source);
     int count = 1;
     int STreeMeta[count];
 
     timer.start();
     for(int ichunk = 0 ; ichunk <Nchunks ; ichunk++){
-	if(ichunk<STree->nodeChunks.size()){
+	if (ichunk<STree->nodeChunks.size()) {
 	    STree->sNodes = STree->nodeChunks[ichunk];
 	}else{
 	    double *sNodesCoeff = new double[STree->sizeNodeCoeff*STree->maxNodesPerChunk];
@@ -151,9 +148,9 @@ void Rcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MPI
 	}      
 	count=STree->maxNodesPerChunk*sizeof(ProjectedNode<D>);
 	MPI_Recv(STree->nodeChunks[ichunk], count, MPI_BYTE, source, tag+1+ichunk, comm, &status);
-	println(10, MPI_Orb_rank<<" received  "<<count/1024<<" kB with ProjectedNodes from "<<source);
+	println(10, mpiOrbRank<<" received  "<<count/1024<<" kB with ProjectedNodes from "<<source);
 	count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
-	if( not STree->isShared or MPI_SH_group_rank != source/MPI_SH_size){
+	if( not STree->isShared or not orbIsSh(source)) {
 	    MPI_Recv(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, source, tag+ichunk*1000, comm, &status);}
 	println(10, " received  "<<count<<" coefficients from "<<source);
     }
@@ -175,7 +172,7 @@ void IRcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MP
     SerialFunctionTree<D>* STree = Tree->getSerialFunctionTree();
   
 
-    println(10, MPI_Orb_rank<<" STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" receiving from "<<source);
+    println(10, mpiOrbRank<<" STree  at "<<STree<<" number of nodes = "<<STree->nNodes<<" receiving from "<<source);
     int count = 1;
     int STreeMeta[count];
 
@@ -183,7 +180,7 @@ void IRcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MP
 
     timer.start();
     for(int ichunk = 0 ; ichunk <Nchunks ; ichunk++){
-	if(ichunk<STree->nodeChunks.size()){
+	if (ichunk<STree->nodeChunks.size()) {
 	    STree->sNodes = STree->nodeChunks[ichunk];
 	}else{
 	    double *sNodesCoeff = new double[STree->sizeNodeCoeff*STree->maxNodesPerChunk];
@@ -193,11 +190,11 @@ void IRcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MP
 	}      
 	count=STree->maxNodesPerChunk*sizeof(ProjectedNode<D>);
 	MPI_Irecv(STree->nodeChunks[ichunk], count, MPI_BYTE, source, tag+1+ichunk, comm, &request);
-	println(10, MPI_Orb_rank<<" received  "<<count/1024<<" kB with ProjectedNodes from "<<source);
+	println(10, mpiOrbRank<<" received  "<<count/1024<<" kB with ProjectedNodes from "<<source);
 	count=STree->sizeNodeCoeff*STree->maxNodesPerChunk;
-	if (not STree->isShared or MPI_SH_group_rank != source/MPI_SH_size){
+	if (not STree->isShared or mpiOrbRank/mpiShSize != source/mpiShSize){
 	    MPI_Irecv(STree->nodeCoeffChunks[ichunk], count, MPI_DOUBLE, source, tag+ichunk*1000, comm, &request);}
-	println(10, MPI_Orb_rank<<" received  "<<count<<" coefficients from "<<source);
+	println(10, mpiOrbRank<<" received  "<<count<<" coefficients from "<<source);
     }
 
 
@@ -221,18 +218,18 @@ void IRcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MP
  * output: 
  * which (i,j) pair to compute next
  * to whom send own data, from who receive data
- * NB: does not work for N even when N is not a multiple of MPI_Orb_size
+ * NB: does not work for N even when N is not a multiple of mpiOrbSize
  */
 void Assign_NxN_sym(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb, int* MaxIter){
     int iter = 0;
-    int NBlock=N/MPI_Orb_size;//number of subblocks
-    int M = N%MPI_Orb_size; //number of lines and column left after subblocks are taken out
+    int NBlock=N/mpiOrbSize;//number of subblocks
+    int M = N%mpiOrbSize; //number of lines and column left after subblocks are taken out
     int Maxiter=-1;
     int iter_base;
     int iBlock = 0;
     int jBlock = 0;
 
-    if(N%2==0 and N%MPI_Orb_size!=0 )MSG_FATAL("Assign_NxN_sym not implemented for this case");
+    if(N%2==0 and N%mpiOrbSize!=0 ) MSG_FATAL("Assign_NxN_sym not implemented for this case");
     for (iter = 0; iter < *MaxIter; iter++) {
 	doi[iter] = -1;
 	doj[iter] = -1;
@@ -241,90 +238,90 @@ void Assign_NxN_sym(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rc
 	rcvorb[iter] = -1;
     }
 
-    for (int dBlock = 0; dBlock < (N+MPI_Orb_size-1)/MPI_Orb_size; dBlock++) {
+    for (int dBlock = 0; dBlock < (N+mpiOrbSize-1)/mpiOrbSize; dBlock++) {
 	//treat diagonal block first
-	int imax=MPI_Orb_size;//size of the diagonal block
-	if(dBlock==NBlock)imax=M;
-	int jmax=MPI_Orb_size;
-	if(dBlock==NBlock)jmax=M;
+	int imax=mpiOrbSize;//size of the diagonal block
+	if(dBlock == NBlock) imax=M;
+	int jmax=mpiOrbSize;
+	if(dBlock == NBlock) jmax=M;
 	for (int i = 0; i < imax; i++) {
 	    for (int j = 0; j < jmax; j++) {
 
-		//used in a diagonal block: 1+MPI_Orb_size/2 
-		//used in a block below diagonal: (1+MPI_Orb_size)*0.5
-		//   if even MPI_Orb_rank: 1+MPI_Orb_size/2 if even block, and MPI_Orb_size/2 if odd block, 0.5*(1+MPI_Orb_size) on average, 
-		//used in a block over diagonal: (1+MPI_Orb_size)*0.5-1
-		//number of entire blocks in a column: N/MPI_Orb_size 
+		//used in a diagonal block: 1+mpiOrbSize/2 
+		//used in a block below diagonal: (1+mpiOrbSize)*0.5
+		//   if even mpiOrbRank: 1+mpiOrbSize/2 if even block, and mpiOrbSize/2 if odd block, 0.5*(1+mpiOrbSize) on average, 
+		//used in a block over diagonal: (1+mpiOrbSize)*0.5-1
+		//number of entire blocks in a column: N/mpiOrbSize 
 		//possibly used in lowest reduced block in column: M/2
-		//used in all blocks in one column d (starting at 0): (1+(N/MPI_Orb_size)*(1+MPI_Orb_size))/2-d+M/2
-		//used in all blocks up to column d, without d: d*(1+(N/MPI_Orb_size)*(1+MPI_Orb_size))/2-(d*(d-1))/2+d*M/2
+		//used in all blocks in one column d (starting at 0): (1+(N/mpiOrbSize)*(1+mpiOrbSize))/2-d+M/2
+		//used in all blocks up to column d, without d: d*(1+(N/mpiOrbSize)*(1+mpiOrbSize))/2-(d*(d-1))/2+d*M/2
 
 
-		//(MPI_Orb_size+j-i)%MPI_Orb_size : for one block
-		//((N+MPI_Orb_size-1)/MPI_Orb_size) : number of blocks in one column
+		//(mpiOrbSize+j-i)%mpiOrbSize : for one block
+		//((N+mpiOrbSize-1)/mpiOrbSize) : number of blocks in one column
 		//-dBlock: The diagonal is not counted again in each block
-		iter_base = (MPI_Orb_size+j-i)%MPI_Orb_size * ((N+MPI_Orb_size-1)/MPI_Orb_size)-dBlock;
-		if(i==j)iter_base = 0;
+		iter_base = (mpiOrbSize+j-i)%mpiOrbSize * ((N+mpiOrbSize-1)/mpiOrbSize)-dBlock;
+		if( i == j ) iter_base = 0;
 		//the last block may be smaller
-		if(dBlock==NBlock)iter_base = (imax+j-i)%M * ((N+MPI_Orb_size-1)/MPI_Orb_size);
+		if( dBlock == NBlock )iter_base = (imax+j-i)%M * ((N+mpiOrbSize-1)/mpiOrbSize);
 		//Shift for all the columns already taken into account
-		iter = iter_base + dBlock*((1+((N+MPI_Orb_size-1)/MPI_Orb_size)*(1+MPI_Orb_size))/2) - (dBlock*(dBlock-1))/2 + dBlock*M/2;
+		iter = iter_base + dBlock*((1+((N+mpiOrbSize-1)/mpiOrbSize)*(1+mpiOrbSize))/2) - (dBlock*(dBlock-1))/2 + dBlock*M/2;
 
-		if( (imax+j-i)%imax<=imax/2 ){
-		    int i_glob = i + dBlock*MPI_Orb_size;
-		    int j_glob = j + dBlock*MPI_Orb_size;
+		if( (imax+j-i)%imax <= imax/2 ){
+		    int i_glob = i + dBlock*mpiOrbSize;
+		    int j_glob = j + dBlock*mpiOrbSize;
 
-		    if(i==MPI_Orb_rank and ( imax%2!=0 or (imax+j-i)%imax<imax/2 or i<j )) {
-			if(iter>Maxiter)Maxiter=iter;
+		    if(i == mpiOrbRank and ( imax%2!=0 or (imax+j-i)%imax < imax/2 or i < j )) {
+			if(iter > Maxiter) Maxiter = iter;
 			doi[iter]=i_glob;
 			doj[iter]=j_glob;
 			if(i!=j)rcvorb[iter]=j_glob;
-			if(imax%2==0 and (imax+j-i)%imax==imax/2 and i<j){
-			    sendto[iter]=j;
-			    sendorb[iter]=i_glob;	    
+			if(imax%2 == 0 and (imax+j-i)%imax == imax/2 and i < j) {
+			    sendto[iter] = j;
+			    sendorb[iter] = i_glob;	    
 			}
-		    }else if(j==MPI_Orb_rank and ( imax%2!=0 or (imax+j-i)%imax<imax/2 or i<j )){
-			sendto[iter]=i;
-			sendorb[iter]=j_glob;
-			if(imax%2==0 and (imax+j-i)%imax==imax/2 and i<j){
-			    rcvorb[iter]=i;
+		    }else if(j == mpiOrbRank and ( imax%2 != 0 or (imax+j-i)%imax < imax/2 or i < j )){
+			sendto[iter] = i;
+			sendorb[iter] = j_glob;
+			if(imax%2 == 0 and (imax+j-i)%imax == imax/2 and i < j){
+			    rcvorb[iter] = i;
 			}
 		    }
 
 		    //all columns that can be generated from received data.	
-		    if((i==MPI_Orb_rank and (i<=j or (MPI_Orb_size%2==0 and (imax+j-i)%imax==imax/2) ))){
-			for (int icol = i; icol < N; icol+=MPI_Orb_size) {
-			    iBlock=icol/MPI_Orb_size;
-			    if((i!=j or iBlock>dBlock) and  (MPI_Orb_size%2!=0 or ((imax+j-i)%imax<imax/2) or ((iBlock+dBlock)%2!=0 and i>j) or ((iBlock+dBlock)%2==0 and i<j)  )){
-				if(iBlock!=dBlock){
+		    if ((i == mpiOrbRank and (i <= j or (mpiOrbSize%2 == 0 and (imax+j-i)%imax == imax/2) ))){
+			for (int icol = i; icol < N; icol+=mpiOrbSize) {
+			    iBlock = icol/mpiOrbSize;
+			    if ((i != j or iBlock > dBlock) and  (mpiOrbSize%2 != 0 or ((imax+j-i)%imax < imax/2) or ((iBlock+dBlock)%2 != 0 and i > j) or ((iBlock+dBlock)%2 == 0 and i < j)  )){
+				if (iBlock != dBlock) {
 				    int sh=1;//diagonal block is the first
 				    if(iBlock>dBlock)sh=0;//diagonal block accounted for
 				    if(i==j)sh=-dBlock;//only below diagonal are counted
-				    if(MPI_Orb_size%2==0 and (imax+j-i)%imax==imax/2)sh=-(iBlock+1)/2;//only half are present
-				    if(MPI_Orb_size%2==0 and (imax+j-i)%imax==imax/2 and (dBlock%2==0 and iBlock==0))sh=1;//same iter as diagonalblock
-				    if(MPI_Orb_size%2==0 and (imax+j-i)%imax==imax/2 and (dBlock%2!=0 and iBlock==1))sh=1;//iBlock=0 same iter as diagonal block, start next iter
-				    int i_glob = i + iBlock*MPI_Orb_size;
-				    int j_glob = j + dBlock*MPI_Orb_size;
-				    if((imax+j-i)%imax<=imax/2 ){
+				    if(mpiOrbSize%2 == 0 and (imax+j-i)%imax == imax/2) sh = -(iBlock+1)/2;//only half are present
+				    if(mpiOrbSize%2 == 0 and (imax+j-i)%imax == imax/2 and (dBlock%2 == 0 and iBlock == 0)) sh = 1;//same iter as diagonalblock
+				    if(mpiOrbSize%2 == 0 and (imax+j-i)%imax == imax/2 and (dBlock%2 != 0 and iBlock == 1)) sh = 1;//iBlock=0 same iter as diagonal block, start next iter
+				    int i_glob = i + iBlock*mpiOrbSize;
+				    int j_glob = j + dBlock*mpiOrbSize;
+				    if ((imax+j-i)%imax <= imax/2 ) {
 					doi[iter+iBlock+sh] = i_glob;
 					doj[iter+iBlock+sh] = j_glob;}
 				    //rcvorb[iter+iBlock+sh]=-1;//indicates "use same as before"
 				    //sendorb[iter+iBlock+sh]=-1;//indicates "do not send anything"
 				    //sendto[iter+iBlock+sh]=-1;//indicates "do not send anything"
-				    if(iter+iBlock+sh>Maxiter)Maxiter=iter+iBlock+sh;
+				    if(iter+iBlock+sh > Maxiter) Maxiter = iter+iBlock+sh;
 				}
 			    }
 			}
-		    }else if(i==MPI_Orb_rank){
+		    }else if(i == mpiOrbRank) {
 			//part of blocks below blockdiagonal
 			//for (jBlock = 0; jBlock < NBlock; jBlock++) {
-			for (int jrow = j; jrow < N; jrow+=MPI_Orb_size) {
-			    jBlock=jrow/MPI_Orb_size;
-			    if(jBlock!=dBlock  and (MPI_Orb_size%2 or (imax+j-i)%imax<(imax)/2 or (jBlock%2==0))){
-				int sh=1;
-				if(jBlock>dBlock)sh=0;//not very elegant
-				int i_glob = i + dBlock*MPI_Orb_size;
-				int j_glob = j + jBlock*MPI_Orb_size;
+			for (int jrow = j; jrow < N; jrow+=mpiOrbSize) {
+			    jBlock = jrow/mpiOrbSize;
+			    if(jBlock != dBlock  and (mpiOrbSize%2 or (imax+j-i)%imax < (imax)/2 or (jBlock%2 == 0))){
+				int sh = 1;
+				if(jBlock > dBlock) sh = 0;//not very elegant
+				int i_glob = i + dBlock*mpiOrbSize;
+				int j_glob = j + jBlock*mpiOrbSize;
 				if((imax+j-i)%imax<(imax+1)/2){
 				    doi[iter+jBlock+sh] = i_glob;
 				    doj[iter+jBlock+sh] = j_glob;}
@@ -356,8 +353,8 @@ void Assign_NxN_sym(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rc
  */
 void Assign_NxN(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb, int* MaxIter){
     int iter = 0;
-    int NBlock=N/MPI_Orb_size;//number of subblocks
-    int M = N%MPI_Orb_size; //number of lines and column left after subblocks are taken out
+    int NBlock=N/mpiOrbSize;//number of subblocks
+    int M = N%mpiOrbSize; //number of lines and column left after subblocks are taken out
     int Maxiter = -1;
     int iter_base;
     int iBlock = 0;
@@ -371,21 +368,21 @@ void Assign_NxN(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb
 	rcvorb[iter] = -1;
     }
 
-    for (int dBlock = 0; dBlock < (N+MPI_Orb_size-1)/MPI_Orb_size; dBlock++) {
+    for (int dBlock = 0; dBlock < (N+mpiOrbSize-1)/mpiOrbSize; dBlock++) {
 
 	//1)  //diagonal block
-	int imax=MPI_Orb_size;
+	int imax=mpiOrbSize;
 	if(dBlock==NBlock)imax=M;
-	int jmax=MPI_Orb_size;
+	int jmax=mpiOrbSize;
 	if(dBlock==NBlock)jmax=M;
 	for (int i = 0; i < imax; i++) {
 	    for (int j = 0; j < jmax; j++) {
-		iter_base = (i+j)%MPI_Orb_size * ((N+MPI_Orb_size-1)/MPI_Orb_size);
-		if(dBlock==NBlock)iter_base = (i+j)%M * ((N+MPI_Orb_size-1)/MPI_Orb_size);
-		iter = iter_base + dBlock*MPI_Orb_size*((N+MPI_Orb_size-1)/MPI_Orb_size);
-		int i_glob = i + dBlock*MPI_Orb_size;
-		int j_glob = j + dBlock*MPI_Orb_size;
-		if(i==MPI_Orb_rank){
+		iter_base = (i+j)%mpiOrbSize * ((N+mpiOrbSize-1)/mpiOrbSize);
+		if(dBlock==NBlock)iter_base = (i+j)%M * ((N+mpiOrbSize-1)/mpiOrbSize);
+		iter = iter_base + dBlock*mpiOrbSize*((N+mpiOrbSize-1)/mpiOrbSize);
+		int i_glob = i + dBlock*mpiOrbSize;
+		int j_glob = j + dBlock*mpiOrbSize;
+		if(i==mpiOrbRank){
 		    //this processor receive orbital j_glob from MPIrank=j, and send its own orbital i_glob to MPIrank=j.
 		    if(iter>Maxiter)Maxiter=iter;
 		    doi[iter]=i_glob;
@@ -400,16 +397,16 @@ void Assign_NxN(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb
 			rcvorb[iter]=j_glob;}// contains info both which orbital and indirectly who from
 		}
 		//2)	//treat all rows and columns that can be generated from received data	
-		if(i<=j and i==MPI_Orb_rank){
+		if(i<=j and i==mpiOrbRank){
 		    //do the corresponding column 
 		    //for (iBlock = 0; iBlock < NBlock; iBlock++) {
-		    for (int icol = i; icol < N; icol+=MPI_Orb_size) {
-			iBlock=icol/MPI_Orb_size;
+		    for (int icol = i; icol < N; icol+=mpiOrbSize) {
+			iBlock=icol/mpiOrbSize;
 			if(iBlock!=dBlock){
 			    int sh=1;
 			    if(iBlock>dBlock)sh=0;//not very elegant
-			    int i_glob = i + iBlock*MPI_Orb_size;
-			    int j_glob = j + dBlock*MPI_Orb_size;
+			    int i_glob = i + iBlock*mpiOrbSize;
+			    int j_glob = j + dBlock*mpiOrbSize;
 			    doi[iter+iBlock+sh] = i_glob;
 			    doj[iter+iBlock+sh] = j_glob;
 			    rcvorb[iter+iBlock+sh]=-1;//indicates "use same as before"
@@ -418,16 +415,16 @@ void Assign_NxN(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb
 			    if(iter+iBlock+sh>Maxiter)Maxiter=iter+iBlock+sh;
 			}
 		    }
-		}else if(i==MPI_Orb_rank){
+		}else if(i==mpiOrbRank){
 		    //do the corresponding row
 		    //for (jBlock = 0; jBlock < NBlock; jBlock++) {
-		    for (int jrow = j; jrow < N; jrow+=MPI_Orb_size) {
-			jBlock=jrow/MPI_Orb_size;
+		    for (int jrow = j; jrow < N; jrow+=mpiOrbSize) {
+			jBlock=jrow/mpiOrbSize;
 			if(jBlock!=dBlock){
 			    int sh=1;
 			    if(jBlock>dBlock)sh=0;//not very elegant
-			    int i_glob = i + dBlock*MPI_Orb_size;
-			    int j_glob = j + jBlock*MPI_Orb_size;
+			    int i_glob = i + dBlock*mpiOrbSize;
+			    int j_glob = j + jBlock*mpiOrbSize;
 	    
 			    doi[iter+jBlock+sh] = i_glob;
 			    doj[iter+jBlock+sh] = j_glob;
@@ -441,7 +438,7 @@ void Assign_NxN(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb
 	    }
 	}
     }
-    int NiterMax = ((N+MPI_Orb_size-1)/MPI_Orb_size)*((N+MPI_Orb_size-1)/MPI_Orb_size)*MPI_Orb_size;
+    int NiterMax = ((N+mpiOrbSize-1)/mpiOrbSize)*((N+mpiOrbSize-1)/mpiOrbSize)*mpiOrbSize;
     if(Maxiter>NiterMax)cout<<"CHECK Assign_NxN "<<endl;
     *MaxIter = Maxiter;
 }
@@ -461,32 +458,36 @@ void define_MPI_groups(){
     //each group has its own group communicator definition
  
     //split world into groups that can share memory
-    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &MPI_Comm_SH);
+    MPI_Comm_split_type(MPI_COMM_WORLD, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL, &mpiCommSh);
 
-    MPI_Comm_rank(MPI_Comm_SH, &MPI_SH_rank);//rank in the SH group
-    MPI_Comm_size(MPI_Comm_SH, &MPI_SH_size);
-    println(10,"MPI SH size: "<< MPI_SH_size ); 
+    MPI_Comm_rank(mpiCommSh, &mpiShRank);//rank in the Sh group
+    MPI_Comm_size(mpiCommSh, &mpiShSize);
+    println(10,"MPI SH size: "<< mpiShSize ); 
 
-    //define a rank of the group. NB: we assume for now that all groups have same size
-    MPI_Comm MPI_Comm_SH_group;
-    MPI_Comm_split(MPI_COMM_WORLD, MPI_SH_rank, MPI_worldrank, &MPI_Comm_SH_group);//MPI_SH_rank is color (same color->in same group),  MPI_worldrank is key (orders rank within the groups)
-
+    //define a rank of the group. 
+    MPI_Comm mpiCommSh_group;
+    MPI_Comm_split(MPI_COMM_WORLD, mpiShRank, MPI_worldrank, &mpiCommSh_group);//mpiShRank is color (same color->in same group),  MPI_worldrank is key (orders rank within the groups)
+    int MPI_SH_group_rank;
     //we define a new orbital rank, so that the orbitals within a shared memory group, have consecutive ranks.
-    MPI_Comm_rank(MPI_Comm_SH_group, &MPI_SH_group_rank);//rank in the SH group
-    MPI_Comm_size(MPI_Comm_SH_group, &MPI_SH_group_size);
-    if(MPI_worldsize != MPI_SH_size*MPI_SH_group_size )MSG_FATAL("all MPI SH groups must be of same size");
-    println(10,"MPI SH group size: "<< MPI_SH_group_size ); 
-    MPI_Orb_rank = MPI_SH_rank + MPI_SH_group_rank*MPI_SH_size ;
+    MPI_Comm_rank(mpiCommSh_group, &MPI_SH_group_rank);//
+    mpiOrbRank = mpiShRank + MPI_SH_group_rank*MPI_worldsize;//NB: not consecutive numbers
 
-    MPI_Comm_split(MPI_COMM_WORLD, 0, MPI_Orb_rank, &MPI_Comm_Orb);//0 is color (same color->in same group), MPI_Orb_rank is key (orders rank in the group)
-    int MPI_Orb_rank;
-    MPI_Comm_rank(MPI_Comm_Orb, &MPI_Orb_rank);//should be the same
-    MPI_Comm_size(MPI_Comm_Orb, &MPI_Orb_size);
-    println(10,"orbital group size: "<< MPI_Orb_size); 
-    //    cout<<"world rank="<<MPI_worldrank<<"  Orbital rank="<<MPI_Orb_rank<<"  Shared mem rank="<<MPI_SH_rank<<"  Shared memory group rank="<<MPI_SH_group_rank<<endl;
+    MPI_Comm_split(MPI_COMM_WORLD, 0, mpiOrbRank, &mpiCommOrb);//0 is color (same color->in same group), mpiOrbRank is key (orders rank in the group)
+    MPI_Comm_rank(mpiCommOrb, &mpiOrbRank);
+    MPI_Comm_size(mpiCommOrb, &mpiOrbSize);
+    println(10,"orbital group size: "<< mpiOrbSize); 
+    //        cout<<"world rank="<<MPI_worldrank<<"  Orbital rank="<<mpiOrbRank<<"  Shared mem rank="<<mpiShRank<<"  Shared memory group rank="<<MPI_SH_group_rank<<endl;
 
 #endif
   
+}
+/** Tells whether an orbital is in the same shared memory group as the calling process
+*   Assumes that orbital ranks within a shared memory group are consecutive
+*/
+bool orbIsSh(int orbRank){
+    if (orbRank < mpiOrbRank-mpiShRank or  orbRank >= mpiOrbRank-mpiShRank + mpiShSize) {
+	return false;
+    } else { return true; }
 }
 
 #ifdef HAVE_MPI
@@ -496,11 +497,11 @@ void define_MPI_groups(){
 void Share_memory(int sh_size, double * &d_ptr, MPI_Win &win){
 
     //MPI_Aint types are used for adresses (can be larger than int).
-    MPI_Aint size = (MPI_SH_rank==0) ? 1024*1024*sh_size : 0;//rank 0 defines length of segment 
+    MPI_Aint size = (mpiShRank==0) ? 1024*1024*sh_size : 0;//rank 0 defines length of segment 
     //MPI_Win win = MPI_WIN_NULL;
     int disp_unit = 16;//in order for the compiler to keep aligned. 
     //size is in bytes
-    MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, MPI_Comm_SH, &d_ptr, &win);
+    MPI_Win_allocate_shared(size, disp_unit, MPI_INFO_NULL, mpiCommSh, &d_ptr, &win);
 
     MPI_Win_fence(0, win);//wait until finished
 
@@ -508,9 +509,9 @@ void Share_memory(int sh_size, double * &d_ptr, MPI_Win &win){
     int qdisp = 0;
     int * qbase = NULL;
     MPI_Win_shared_query(win, 0, &qsize, &qdisp, &d_ptr);
-    printf("me = %d, allocated: size=%zu, bytes at = %p %d\n", MPI_SH_rank, qsize, d_ptr, d_ptr);
+    printf("me = %d, allocated: size=%zu, bytes at = %p %d\n", mpiShRank, qsize, d_ptr, d_ptr);
     MPI_Win_fence(0, win);
-    //if(MPI_Orb_rank==0)d_ptr[18]=2.34;
+    //if(mpiOrbRank==0)d_ptr[18]=2.34;
     //printf("shared: me=%d,  val=%lf\n", shrank, d_ptr[18]);
 
     //MPI_Win_free(&win);//to include in destructor

--- a/src/mrcpp/parallel.h
+++ b/src/mrcpp/parallel.h
@@ -38,7 +38,7 @@ void Send_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI_
 template<int D>
 void IRcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MPI_Comm comm);
 template<int D>
-void ISend_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI_Comm comm);
+void ISend_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI_Comm comm, MPI_Request& request);
 template<int D>
 void Rcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MPI_Comm comm);
 void Assign_NxN(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb, int* MaxIter);

--- a/src/mrcpp/parallel.h
+++ b/src/mrcpp/parallel.h
@@ -42,6 +42,22 @@ extern MPI_Comm MPI_Comm_Orb;
 extern MPI_Comm MPI_Comm_SH;
 extern MPI_Comm MPI_Comm_SH_group;
 
+
+/** Share memory within a compute node
+ */
+class SharedMemory {
+public:    
+    SharedMemory(int sh_size);
+    ~SharedMemory();
+    void allocShmem(int sh_size);
+    double * sh_start_ptr; //start of shared block
+    double * sh_max_ptr; //end of shared block
+    double * sh_end_ptr; //end of used part
+#ifdef HAVE_MPI
+    MPI_Win sh_win; //MPI window object 
+#endif
+};
+
 template<int D>
 void Send_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI_Comm comm);
 template<int D>

--- a/src/mrcpp/parallel.h
+++ b/src/mrcpp/parallel.h
@@ -23,24 +23,25 @@ class Orbital;
 
 #endif
 
-extern int MPI_Orb_rank;
-extern int MPI_Orb_size;
-extern int MPI_SH_rank;
-extern int MPI_SH_size;
+extern int mpiOrbRank;
+extern int mpiOrbSize;
+extern int mpiShRank;
+extern int mpiShSize;
 extern int MPI_SH_group_rank;
 extern int MPI_SH_group_size;
 
 
-void define_MPI_groups();
 void MPI_Initializations();
+void define_MPI_groups();
+bool orbIsSh(int orbRank);
 
 
 #ifdef HAVE_MPI
 #include <mpi.h>
 
-extern MPI_Comm MPI_Comm_Orb;
-extern MPI_Comm MPI_Comm_SH;
-extern MPI_Comm MPI_Comm_SH_group;
+extern MPI_Comm mpiCommOrb;
+extern MPI_Comm mpiCommSh;
+extern MPI_Comm mpiCommSh_group;
 
 
 /** Share memory within a compute node

--- a/src/mrcpp/parallel.h
+++ b/src/mrcpp/parallel.h
@@ -44,7 +44,7 @@ void Rcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MPI
 void Assign_NxN(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb, int* MaxIter);
 void Assign_NxN_sym(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb, int* MaxIter);
 
-//void Share_memory(MPI_Comm ncomm, MPI_Comm ncomm_sh, int sh_size, double * d_ptr);
+void Share_memory(MPI_Comm ncomm, MPI_Comm& ncomm_sh, int sh_size, double * d_ptr);
 
 #else
 

--- a/src/mrcpp/parallel.h
+++ b/src/mrcpp/parallel.h
@@ -23,15 +23,24 @@ class Orbital;
 
 #endif
 
-extern int MPI_rank;
-extern int MPI_size;
+extern int MPI_Orb_rank;
+extern int MPI_Orb_size;
+extern int MPI_SH_rank;
+extern int MPI_SH_size;
+extern int MPI_SH_group_rank;
+extern int MPI_SH_group_size;
 
-void define_groups();
+
+void define_MPI_groups();
 void MPI_Initializations();
 
 
 #ifdef HAVE_MPI
 #include <mpi.h>
+
+extern MPI_Comm MPI_Comm_Orb;
+extern MPI_Comm MPI_Comm_SH;
+extern MPI_Comm MPI_Comm_SH_group;
 
 template<int D>
 void Send_SerialTree(FunctionTree<D>* Tree, int Nchunks, int dest, int tag, MPI_Comm comm);
@@ -44,7 +53,7 @@ void Rcv_SerialTree(FunctionTree<D>* Tree, int Nchunks, int source, int tag, MPI
 void Assign_NxN(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb, int* MaxIter);
 void Assign_NxN_sym(int N, int* doi, int*doj, int* sendto, int* sendorb, int* rcvorb, int* MaxIter);
 
-void Share_memory(MPI_Comm ncomm, MPI_Comm& ncomm_sh, int sh_size, double * d_ptr);
+void Share_memory(int sh_size, double * &d_ptr, MPI_Win & MPI_win);
 
 #else
 


### PR DESCRIPTION
There are several issues we should discuss. Before accepting the pull request, you should at least check these points, as they concern the non-MPI section too:

1) I changed the "screening" precision in internal Exchange: it was  prec = getScaledPrecision(i, j) modified to  prec = std::max(getScaledPrecision(i, j), getScaledPrecision(j, i)).
The former did use the "i" precision also for the "j" orbital. Meaning that a different result can be obtained if the order of the orbitals is modified.
There are other ways of defining this too.

2)  In the testPreComputed I modified   (ex_i != 0) to (ex_i->getNNodes() != 0) as the former is never true (ex_i is defined, even if empty) . This condition was not used anyway I think.

3) I didn't modify this, by it seems to me that the adjoint of Vij must be used for calculating ex_j. As long as we have only real orbitals it does not matter.

The parallel exchange does give the same result within the precision, but not behind. This is possibly due to non-symmetry in parts of the code, i.e. for example that doing <i|O j> or <j|O i> can be different even if the operator formally is symmetrical. We should discuss this.
