### PR TITLE
maxAllocNodes removed! stackStatus now vector

### DIFF
--- a/src/mrchem/qmoperators/ExchangePotential.cpp
+++ b/src/mrchem/qmoperators/ExchangePotential.cpp
@@ -207,22 +207,21 @@ void ExchangePotential::calcInternalExchange() {
       }
       
       OrbitalAdder add(-1.0, this->max_scale);
-      for (int i = 0; i<workOrbVecSize; i++)sndtoMPI[i]=-1;//init
+      for (int i = 0; i < workOrbVecSize; i++) sndtoMPI[i]=-1;//init
       int mpiiter = 0;
       for (int iter = 0;  iter >= 0; iter++) {
 	mpiiter++;
 	//get a new chunk from other processes
-	sndOrbIx[0]=0;//init
-	sndtoMPI[0]=-1;//init
+	sndOrbIx[0] = 0;//init
+	sndtoMPI[0] = -1;//init
 	OrbVecChunk_i.getOrbVecChunk_sym(OrbsIx, rcvOrbs, rcvOrbsIx, nOrbs, iter, sndtoMPI, sndOrbIx,1,2);
-	
-	int rcv_left=1;//normally we get one phi_jji per ii, maybe none
-	if(sndtoMPI[0]<0 or sndtoMPI[0]==mpiOrbRank)rcv_left=0;//we haven't sent anything, will not receive anything back	    
+	int rcv_left = 1;//normally we get one phi_jji per ii, maybe none
+	if (sndtoMPI[0] < 0 or sndtoMPI[0] == mpiOrbRank) rcv_left = 0;//we haven't sent anything, will not receive anything back	    
 	//convention: all indices with "i" are owned locally
-	for (int ii = 0; ii<OrbVecChunk_i.size()+1 ; ii++){ //we may have to do one extra iteration to fetch all data
-	  int j=0;//because we limited the size in getOrbVecChunk_sym to 1
-	  int i=ii;
-	  if(ii>=OrbVecChunk_i.size())i=0;//so that phi_i is defined, but will not be used
+	for (int ii = 0; ii < OrbVecChunk_i.size()+1 ; ii++){ //we may have to do one extra iteration to fetch all data
+	  int j = 0;//because we limited the size in getOrbVecChunk_sym to 1
+	  int i = ii;
+	  if(ii >= OrbVecChunk_i.size()) i = 0;//so that phi_i is defined, but will not be used
 	  
 	  Orbital &phi_i = OrbVecChunk_i.getOrbital(i);
 	  Orbital *phi_iij = new Orbital(phi_i);
@@ -230,7 +229,7 @@ void ExchangePotential::calcInternalExchange() {
 	  Orbital &phi_i_rcv = this->orbitals->getOrbital(i_rcv);
 	  Orbital *phi_jji_rcv = new Orbital(phi_i_rcv);	      
 	  if(rcvOrbs.size()>0 and ii<OrbVecChunk_i.size()){
-	    if(OrbsIx[i]==rcvOrbsIx[j]){
+	    if(OrbsIx[i] == rcvOrbsIx[j]) {
 	      //orbital should be own and i and j point to same orbital
 	      calcInternal(OrbsIx[i]);
 	    }else{	    
@@ -244,18 +243,18 @@ void ExchangePotential::calcInternalExchange() {
 		phi_iij->Isend_Orbital(rcvOrbsIx[j]%mpiOrbSize, mpiiter%10, request);
 	      }else{
 		//only compute j < i in own block 
-		if(rcvOrbsIx[j]<OrbsIx[i])calcInternal(OrbsIx[i], rcvOrbsIx[j], phi_i, phi_j, phi_iij);
+		if(rcvOrbsIx[j] < OrbsIx[i]) calcInternal(OrbsIx[i], rcvOrbsIx[j], phi_i, phi_j, phi_iij);
 	      }
 	    }
 	  }
-	  if(rcv_left>0){
+	  if (rcv_left > 0) {
 	    //we expect to receive data 
 	    phi_jji_rcv->Rcv_Orbital(sndtoMPI[j], mpiiter%10);//we get back phi_jji from where we sent i
 	  }
-	  if(rcvOrbsIx[j]%mpiOrbSize != mpiOrbRank and rcvOrbs.size()>0 and ii<OrbVecChunk_i.size()){
+	  if (rcvOrbsIx[j]%mpiOrbSize != mpiOrbRank and rcvOrbs.size() > 0 and ii < OrbVecChunk_i.size()){
 	    MPI_Wait(&request, &status);//do not continue before isend is finished	      
 	  }
-	  if(rcv_left >0){
+	  if (rcv_left > 0) {
 	    // phi_jji_rcv is ready
 	    int i_rcv = sndOrbIx[j];
 	    int j_rcv = phi_jji_rcv->getOccupancy();//occupancy was used to send rank!
@@ -283,7 +282,7 @@ void ExchangePotential::calcInternalExchange() {
 	OrbVecChunk_i.clearVec(false);
 
       for (int i = 0; i < nOrbs; i++) {
-	if(i%mpiOrbSize==mpiOrbRank){
+	if (i%mpiOrbSize == mpiOrbRank) {
 	  Orbital &ex_i = this->exchange.getOrbital(i);
 	  this->tot_norms(i) = sqrt(ex_i.getSquareNorm());
 	  n = max(n, ex_i.getNNodes());

--- a/src/mrcpp/constants.h
+++ b/src/mrcpp/constants.h
@@ -13,9 +13,6 @@ const int MaxDepth = 30; ///< Maximum depth of trees
 const int MaxScale = 31; ///< Maximum scale of trees
 const int MinScale = -31; ///< Minimum scale of trees
 const int MaxSepRank = 1000;
-const int MaxAllocNodes = 256*1024;
-const int MaxAllocOperNodes = 8*1024;
-const int MaxAllocNodes1D = 8*1024;
 //Max number of orbitals stored temporarily. Larger->more memory
 //Also max size of orbitalvector that can be sent with send_OrbVec
 const int workOrbVecSize = 10;

--- a/src/mrcpp/mwoperators/ABGVOperator.h
+++ b/src/mrcpp/mwoperators/ABGVOperator.h
@@ -28,7 +28,7 @@ protected:
         ABGVCalculator calculator(basis, a, b);
         BandWidthAdaptor adaptor(bw, max_scale);
 
-        OperatorTree *o_tree = new OperatorTree(this->oper_mra, MachineZero, MaxAllocOperNodes);
+        OperatorTree *o_tree = new OperatorTree(this->oper_mra, MachineZero);
         builder.build(*o_tree, calculator, adaptor, -1);
 
         Timer trans_t;

--- a/src/mrcpp/mwoperators/ConvolutionOperator.cpp
+++ b/src/mrcpp/mwoperators/ConvolutionOperator.cpp
@@ -35,12 +35,12 @@ void ConvolutionOperator<D>::initializeOperator(GreensKernel &greens_kernel) {
 
     for (int i = 0; i < greens_kernel.size(); i++) {
         Gaussian<1> &k_func = *greens_kernel[i];
-        FunctionTree<1> *k_tree = new FunctionTree<1>(this->kern_mra, MaxAllocNodes1D);
+        FunctionTree<1> *k_tree = new FunctionTree<1>(this->kern_mra);
         G(*k_tree, k_func); //Generate empty grid to hold narrow Gaussian
         Q(*k_tree, k_func); //Project Gaussian starting from the empty grid
         CrossCorrelationCalculator calculator(*k_tree);
 
-        OperatorTree *o_tree = new OperatorTree(this->oper_mra, this->prec, MaxAllocOperNodes);
+        OperatorTree *o_tree = new OperatorTree(this->oper_mra, this->prec);
         builder.build(*o_tree, calculator, adaptor, -1); //Expand 1D kernel into 2D operator
 
         Timer trans_t;

--- a/src/mrcpp/mwoperators/PHOperator.h
+++ b/src/mrcpp/mwoperators/PHOperator.h
@@ -26,7 +26,7 @@ protected:
         PHCalculator calculator(basis, order);
         BandWidthAdaptor adaptor(bw, max_scale);
 
-        OperatorTree *o_tree = new OperatorTree(this->oper_mra, MachineZero, MaxAllocOperNodes);
+        OperatorTree *o_tree = new OperatorTree(this->oper_mra, MachineZero);
         builder.build(*o_tree, calculator, adaptor, -1);
 
         Timer trans_t;

--- a/src/mrcpp/mwtrees/FunctionTree.cpp
+++ b/src/mrcpp/mwtrees/FunctionTree.cpp
@@ -16,9 +16,9 @@ using namespace Eigen;
 /** FunctionTree constructor for Serial Tree.
   * */
 template<int D>
-FunctionTree<D>::FunctionTree(const MultiResolutionAnalysis<D> &mra, int max_nodes)
+FunctionTree<D>::FunctionTree(const MultiResolutionAnalysis<D> &mra)
         : MWTree<D> (mra) {
-    this->serialTree_p = new SerialFunctionTree<D>(this, max_nodes);
+    this->serialTree_p = new SerialFunctionTree<D>(this);
     this->serialTree_p->allocRoots(*this);
     this->resetEndNodeTable();
 }
@@ -26,9 +26,9 @@ FunctionTree<D>::FunctionTree(const MultiResolutionAnalysis<D> &mra, int max_nod
 /** FunctionTree constructor for Serial Tree using shared memory.
   * */
 template<int D>
-FunctionTree<D>::FunctionTree(const MultiResolutionAnalysis<D> &mra, SharedMemory* &shMem, int max_nodes)
+FunctionTree<D>::FunctionTree(const MultiResolutionAnalysis<D> &mra, SharedMemory* &shMem)
         : MWTree<D> (mra) {
-    this->serialTree_p = new SerialFunctionTree<D>(this, max_nodes);
+    this->serialTree_p = new SerialFunctionTree<D>(this);
     this->serialTree_p->isShared = true;
     this->serialTree_p->shMem = shMem;    
     this->serialTree_p->allocRoots(*this);

--- a/src/mrcpp/mwtrees/FunctionTree.h
+++ b/src/mrcpp/mwtrees/FunctionTree.h
@@ -21,10 +21,8 @@ class Orbital;
 template<int D>
 class FunctionTree: public MWTree<D> {
 public:
-    FunctionTree(const MultiResolutionAnalysis<D> &mra,
-                 int max_nodes = MaxAllocNodes);
-    FunctionTree(const MultiResolutionAnalysis<D> &mra,
-                 SharedMemory* &shMem, int max_nodes = MaxAllocNodes);
+    FunctionTree(const MultiResolutionAnalysis<D> &mra);
+    FunctionTree(const MultiResolutionAnalysis<D> &mra, SharedMemory* &shMem);
     virtual ~FunctionTree();
 
     void clear();

--- a/src/mrcpp/mwtrees/OperatorTree.cpp
+++ b/src/mrcpp/mwtrees/OperatorTree.cpp
@@ -8,7 +8,7 @@
 using namespace Eigen;
 using namespace std;
 
-OperatorTree::OperatorTree(const MultiResolutionAnalysis<2> &mra, double np, int max_nodes)
+OperatorTree::OperatorTree(const MultiResolutionAnalysis<2> &mra, double np)
         : MWTree<2>(mra),
           normPrec(np),
           bandWidth(0),
@@ -16,7 +16,7 @@ OperatorTree::OperatorTree(const MultiResolutionAnalysis<2> &mra, double np, int
           nodePtrAccess(0) {
     if (this->normPrec < 0.0) MSG_FATAL("Negative prec");
 
-    this->serialTree_p = new SerialOperatorTree(this, max_nodes);
+    this->serialTree_p = new SerialOperatorTree(this);
     this->serialTree_p->allocRoots(*this);
     this->resetEndNodeTable();
 }

--- a/src/mrcpp/mwtrees/OperatorTree.h
+++ b/src/mrcpp/mwtrees/OperatorTree.h
@@ -6,7 +6,7 @@
 class OperatorTree: public MWTree<2> {
 public:
     OperatorTree(const MultiResolutionAnalysis<2> &mra,
-                 double np, int max_nodes = MaxAllocOperNodes);
+                 double np);
     virtual ~OperatorTree();
 
     double getNormPrecision() const { return this->normPrec; }

--- a/src/mrcpp/mwtrees/SerialFunctionTree.h
+++ b/src/mrcpp/mwtrees/SerialFunctionTree.h
@@ -22,7 +22,7 @@ template<int D> class GenNode;
 template<int D>
 class SerialFunctionTree : public SerialTree<D> {
 public:
-    SerialFunctionTree(FunctionTree<D> *tree, int max_nodes);
+    SerialFunctionTree(FunctionTree<D> *tree);
     virtual ~SerialFunctionTree();
 
     virtual void allocRoots(MWTree<D> &tree);
@@ -45,7 +45,8 @@ public:
 
     double **genCoeffStack;
 
-    int *genNodeStackStatus;
+    //    int *genNodeStackStatus;
+    std::vector<int> genNodeStackStatus;
 
     void rewritePointers(int nChunks);
 

--- a/src/mrcpp/mwtrees/SerialOperatorTree.h
+++ b/src/mrcpp/mwtrees/SerialOperatorTree.h
@@ -20,7 +20,7 @@ class OperatorNode;
 
 class SerialOperatorTree : public SerialTree<2> {
 public:
-    SerialOperatorTree(OperatorTree *tree, int max_nodes);
+    SerialOperatorTree(OperatorTree *tree);
     virtual ~SerialOperatorTree();
 
     virtual void allocRoots(MWTree<2> &tree);

--- a/src/mrcpp/mwtrees/SerialTree.h
+++ b/src/mrcpp/mwtrees/SerialTree.h
@@ -11,6 +11,7 @@
 
 #pragma GCC system_header
 #include <Eigen/Core>
+#include <vector>
 
 #include "parallel.h"
 
@@ -37,7 +38,6 @@ public:
 
     int nNodes;                 //number of Nodes already defined
     int maxNodesPerChunk;
-    //    int *nodeStackStatus;
     std::vector<int> nodeStackStatus;
     int sizeNodeCoeff;          //size of coeff for one node
     double **coeffStack;

--- a/src/mrcpp/mwtrees/SerialTree.h
+++ b/src/mrcpp/mwtrees/SerialTree.h
@@ -37,7 +37,8 @@ public:
 
     int nNodes;                 //number of Nodes already defined
     int maxNodesPerChunk;
-    int *nodeStackStatus;
+    //    int *nodeStackStatus;
+    std::vector<int> nodeStackStatus;
     int sizeNodeCoeff;          //size of coeff for one node
     double **coeffStack;
     int maxNodes;               //max number of nodes that can be defined


### PR DESCRIPTION
Not really a significant performance improvement, but much cleaner.

(Simple, but this change was not possible in earlier versions, as we needed control of the position in memory for "stackstatus", which is not the case for vectors (they can be relocated))