### PR TITLE
Bug fix, orbsIx changed, delete genchunks and small adjustements for multi-computenodes runs

### DIFF
--- a/src/mrchem/qmfunctions/Density.cpp
+++ b/src/mrchem/qmfunctions/Density.cpp
@@ -16,8 +16,8 @@ Density::Density(bool spin, bool shared)
       dens_s(0),
       dens_a(0),
       dens_b(0) {
-    if(this->is_shared and mpiShSize>1){
-	this->shMem = new SharedMemory(500);//initiate up to 500MB shared memory
+    if(this->is_shared){
+	if(mpiShSize>1)this->shMem = new SharedMemory(500);//initiate up to 500MB shared memory
     }else{
 	this->setIsShared(false);//at least 2 processes for sharing
     }

--- a/src/mrchem/qmfunctions/Density.cpp
+++ b/src/mrchem/qmfunctions/Density.cpp
@@ -16,8 +16,8 @@ Density::Density(bool spin, bool shared)
       dens_s(0),
       dens_a(0),
       dens_b(0) {
-    if(this->is_shared){
-	if(mpiShSize>1)this->shMem = new SharedMemory(500);//initiate up to 500MB shared memory
+    if(shared and mpiShSize>1){
+	this->shMem = new SharedMemory(500);//initiate up to 500MB shared memory
     }else{
 	this->setIsShared(false);//at least 2 processes for sharing
     }

--- a/src/mrchem/qmfunctions/OrbitalAdder.cpp
+++ b/src/mrchem/qmfunctions/OrbitalAdder.cpp
@@ -204,21 +204,20 @@ void OrbitalAdder::rotate_P(OrbitalVector &out, const MatrixXd &U, OrbitalVector
 
     int Ni = phi.size();
     OrbitalVector OrbVecChunk_i(0);//to store adresses of own i_orbs
-    int OrbsIx[workOrbVecSize];//to store own orbital indices
+    vector<int> orbsIx;     //to store own orbital indices
     OrbitalVector rcvOrbs(0);//to store adresses of received orbitals
     int rcvOrbsIx[workOrbVecSize];//to store received orbital indices
     
     //make vector with adresses of own orbitals
-    int i = 0;
     for (int Ix = mpiOrbRank;  Ix < Ni; Ix += mpiOrbSize) {
       OrbVecChunk_i.push_back(phi.getOrbital(Ix));//i orbitals
       out.getOrbital(Ix).clear(true);
-      OrbsIx[i++] = Ix;
+      orbsIx.push_back(Ix);
     }
     
      for (int iter = 0;  iter >= 0; iter++) {
       //get a new chunk from other processes
-      OrbVecChunk_i.getOrbVecChunk(OrbsIx, rcvOrbs, rcvOrbsIx, Ni, iter);
+      OrbVecChunk_i.getOrbVecChunk(orbsIx, rcvOrbs, rcvOrbsIx, Ni, iter);
       //Update only own orbitals	
       int j = 0;
       for (int Jx = mpiOrbRank;  Jx < Ni; Jx += mpiOrbSize) {

--- a/src/mrchem/qmfunctions/OrbitalAdder.cpp
+++ b/src/mrchem/qmfunctions/OrbitalAdder.cpp
@@ -8,7 +8,7 @@ using namespace Eigen;
 OrbitalAdder::OrbitalAdder(double prec, int max_scale)
     : add(prec, max_scale),
       grid(max_scale) {
-}
+      }
 
 void OrbitalAdder::operator()(Orbital &phi_ab,
                               complex<double> a, Orbital &phi_a,
@@ -210,22 +210,21 @@ void OrbitalAdder::rotate_P(OrbitalVector &out, const MatrixXd &U, OrbitalVector
     
     //make vector with adresses of own orbitals
     for (int Ix = mpiOrbRank;  Ix < Ni; Ix += mpiOrbSize) {
-      OrbVecChunk_i.push_back(phi.getOrbital(Ix));//i orbitals
-      out.getOrbital(Ix).clear(true);
-      orbsIx.push_back(Ix);
+	OrbVecChunk_i.push_back(phi.getOrbital(Ix));//i orbitals
+	out.getOrbital(Ix).clear(true);
+	orbsIx.push_back(Ix);
     }
     
-     for (int iter = 0;  iter >= 0; iter++) {
-      //get a new chunk from other processes
-      OrbVecChunk_i.getOrbVecChunk(orbsIx, rcvOrbs, rcvOrbsIx, Ni, iter);
-      //Update only own orbitals	
-      int j = 0;
-      for (int Jx = mpiOrbRank;  Jx < Ni; Jx += mpiOrbSize) {
-	VectorXd U_Chunk(rcvOrbs.size());
-	for (int ix = 0; ix<rcvOrbs.size(); ix++)U_Chunk(ix)=U(Jx,rcvOrbsIx[ix]);
-	this->inPlace(out.getOrbital(Jx),U_Chunk, rcvOrbs, false);//can start with empty orbital
-      }
-      rcvOrbs.clearVec(false);//reset to zero size orbital vector
+    for (int iter = 0;  iter >= 0; iter++) {
+	//get a new chunk from other processes
+	OrbVecChunk_i.getOrbVecChunk(orbsIx, rcvOrbs, rcvOrbsIx, Ni, iter);
+	//Update only own orbitals	
+	for (int Jx = mpiOrbRank;  Jx < Ni; Jx += mpiOrbSize) {
+	    VectorXd U_Chunk(rcvOrbs.size());
+	    for (int ix = 0; ix<rcvOrbs.size(); ix++)U_Chunk(ix)=U(Jx,rcvOrbsIx[ix]);
+	    this->inPlace(out.getOrbital(Jx),U_Chunk, rcvOrbs, false);//can start with empty orbital
+	}
+	rcvOrbs.clearVec(false);//reset to zero size orbital vector
     }
     
     //clear orbital adresses, not the orbitals
@@ -236,24 +235,24 @@ void OrbitalAdder::rotate_P(OrbitalVector &out, const MatrixXd &U, OrbitalVector
 void OrbitalAdder::rotate(OrbitalVector &out, const MatrixXd &U, OrbitalVector &inp) {
     if (U.cols() != inp.size()) MSG_ERROR("Invalid arguments");
     if (U.rows() < out.size()) MSG_ERROR("Invalid arguments");
-    if(mpiOrbSize>1){
-      rotate_P(out, U, inp);
+    if( mpiOrbSize > 1) {
+	rotate_P(out, U, inp);
     }else{
-      for (int i = 0; i < out.size(); i++) {
-        const VectorXd &c = U.row(i);
-        Orbital &out_i = out.getOrbital(i);
-        (*this)(out_i, c, inp, false); // Adaptive grids
-      }
+	for (int i = 0; i < out.size(); i++) {
+	    const VectorXd &c = U.row(i);
+	    Orbital &out_i = out.getOrbital(i);
+	    (*this)(out_i, c, inp, false); // Adaptive grids
+	}
     }
 }
 
 /** In place rotation of orbital vector */
 void OrbitalAdder::rotate(OrbitalVector &out, const MatrixXd &U) {
     OrbitalVector tmp(out);
-    if(mpiOrbSize>1){
-      rotate_P(tmp, U, out);
+    if( mpiOrbSize > 1) {
+	rotate_P(tmp, U, out);
     }else{
-      rotate(tmp, U, out);
+	rotate(tmp, U, out);
     }
     out.clear(true);      // Delete pointers
     out.shallowCopy(tmp); // Copy pointers
@@ -285,7 +284,7 @@ void OrbitalAdder::inPlace(Orbital &out,
 }
 
 void OrbitalAdder::inPlace(Orbital &out, const VectorXd &c, OrbitalVector &inp,
-                              bool union_grid) {
+			   bool union_grid) {
 
     VectorXd c_extended(c.size()+1);
     for (int i = 0; i < c.size(); i++)c_extended(i)=c(i);

--- a/src/mrchem/qmfunctions/OrbitalVector.cpp
+++ b/src/mrchem/qmfunctions/OrbitalVector.cpp
@@ -690,6 +690,7 @@ void OrbitalVector::getOrbVecChunk(vector<int> &myOrbsIx, OrbitalVector &rcvOrbs
 
     int MPI_iter0 = (iter0*maxOrbs)/maxsizeperOrbvec;//which MPI_iter to start with
     int start = (iter0*maxOrbs)%maxsizeperOrbvec;//where to start in the first iteration
+    int start0 = start;//save
 
     rcvOrbs.clearVec(false);//we restart from beginning of vector
 
@@ -704,9 +705,9 @@ void OrbitalVector::getOrbVecChunk(vector<int> &myOrbsIx, OrbitalVector &rcvOrbs
 	iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals  
     }
 
-
     for (int MPI_iter = MPI_iter0;  true; MPI_iter++) {
-	int maxcount = maxOrbs-(MPI_iter-MPI_iter0)*maxsizeperOrbvec;//place left
+	int maxcount = maxOrbs;//place left first iteration
+	if (MPI_iter > MPI_iter0) maxcount = maxOrbs+start0-(MPI_iter-MPI_iter0)*maxsizeperOrbvec;//place left after first iteration
 	if(maxcount<=0) break;
 	if(MPI_iter>=mpiOrbSize){
 	    iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals  
@@ -774,6 +775,7 @@ void OrbitalVector::getOrbVecChunk_sym(vector<int> &myOrbsIx, OrbitalVector &rcv
 
     int MPI_iter0 = (iter0*maxOrbs)/maxsizeperOrbvec;//which MPI_iter to start with
     int start = (iter0*maxOrbs)%maxsizeperOrbvec;//where to start in the first iteration
+    int start0 = start;//save
     rcvOrbs.clearVec(false);//we restart from beginning of vector
 
     workOrbVec.inUse = true;
@@ -789,7 +791,8 @@ void OrbitalVector::getOrbVecChunk_sym(vector<int> &myOrbsIx, OrbitalVector &rcv
 
     int isnd=0;
     for (int MPI_iter = MPI_iter0;  MPI_iter < mpiOrbSize; MPI_iter++) {
-	int maxcount = maxOrbs-(MPI_iter-MPI_iter0)*maxsizeperOrbvec;//place left
+	int maxcount = maxOrbs;//place left
+	if (MPI_iter > MPI_iter0) maxcount = maxOrbs+start0-(MPI_iter-MPI_iter0)*maxsizeperOrbvec;//place left
 	if(maxcount <= 0)  break;//chunk is full
 	if(MPI_iter >= (mpiOrbSize/2 + 1) ){
 	    iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals  

--- a/src/mrchem/qmfunctions/OrbitalVector.h
+++ b/src/mrchem/qmfunctions/OrbitalVector.h
@@ -7,6 +7,7 @@
 #include <Eigen/Eigenvalues>
 
 #include <vector>
+using std::vector;
 
 #include "Orbital.h"
 
@@ -64,13 +65,13 @@ public:
 
     int printTreeSizes() const;
 
-    void send_OrbVec(int dest, int tag, int* OrbsIx, int start, int maxcount);
+    void send_OrbVec(int dest, int tag, vector<int> &orbsIx, int start, int maxcount);
 #ifdef HAVE_MPI
-    void Isend_OrbVec(int dest, int tag, int* OrbsIx, int start, int maxcount, MPI_Request& request);
+    void Isend_OrbVec(int dest, int tag, vector<int> &orbsIx, int start, int maxcount, MPI_Request& request);
 #endif
-    void Rcv_OrbVec(int source, int tag, int* OrbsIx, int& workOrbVecIx);
-    void getOrbVecChunk(int* myOrbsIx, OrbitalVector &rcvOrbs, int* rcvOrbsIx, int size, int& iter0, int maxOrbs_in=-1, int workIx=0);
-    void getOrbVecChunk_sym(int* myOrbsIx, OrbitalVector &rcvOrbs, int* rcvOrbsIx, int size, int& iter0, int* sndtoMPI=0, int* sndOrbIx=0, int maxOrbs_in=-1, int workIx=0);
+    void Rcv_OrbVec(int source, int tag, int *orbsIx, int& workOrbVecIx);
+    void getOrbVecChunk(vector<int> &myOrbsIx, OrbitalVector &rcvOrbs, int* rcvOrbsIx, int size, int& iter0, int maxOrbs_in=-1, int workIx=0);
+    void getOrbVecChunk_sym(vector<int> &myOrbsIx, OrbitalVector &rcvOrbs, int* rcvOrbsIx, int size, int& iter0, int* sndtoMPI=0, int* sndOrbIx=0, int maxOrbs_in=-1, int workIx=0);
 
     bool inUse=false;
 

--- a/src/mrchem/qmoperators/FockOperator.cpp
+++ b/src/mrchem/qmoperators/FockOperator.cpp
@@ -121,14 +121,13 @@ MatrixXd FockOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs)
     OrbitalVector OrbVecChunk_i(0);//to store adresses of own i_orbs
     OrbitalVector OrbVecChunk_j(0);//to store adresses of own j_orbs
     OrbitalVector rcvOrbs(0);//to store adresses of received orbitals
-    int OrbsIx[workOrbVecSize];//to store own orbital indices
+    vector<int> orbsIx;           //to store own orbital indices  
     int rcvOrbsIx[workOrbVecSize];//to store received orbital indices
 
     //make vector with adresses of own orbitals
-    int i = 0;
     for (int Ix = mpiOrbRank; Ix < Ni; Ix += mpiOrbSize) {
 	OrbVecChunk_i.push_back(i_orbs.getOrbital(Ix));//i orbitals
-	OrbsIx[i++] = Ix;
+	orbsIx.push_back(Ix);
     }
     for (int Ix = mpiOrbRank; Ix < Nj; Ix += mpiOrbSize) OrbVecChunk_j.push_back(j_orbs.getOrbital(Ix));//j orbitals
     //need to pad OrbVecChunk_j so that all have same size
@@ -138,7 +137,7 @@ MatrixXd FockOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs)
 	//get a new chunk from other processes
 	//NB: should not use directly workorbvec as rcvOrbs, because they may 
 	//contain own orbitals, and these can be overwritten
-	OrbVecChunk_i.getOrbVecChunk(OrbsIx, rcvOrbs, rcvOrbsIx, Ni, iter);
+	OrbVecChunk_i.getOrbVecChunk(orbsIx, rcvOrbs, rcvOrbsIx, Ni, iter);
 
 	//Only one process does the computations. j orbitals always local
 	MatrixXd resultChunk = MatrixXd::Zero(rcvOrbs.size(),OrbVecChunk_j.size());

--- a/src/mrchem/qmoperators/IdentityOperator.cpp
+++ b/src/mrchem/qmoperators/IdentityOperator.cpp
@@ -86,14 +86,13 @@ MatrixXcd IdentityOperator::calcOverlapMatrix_P(OrbitalVector &bra, OrbitalVecto
     OrbitalVector orbVecChunk_j(0);	//to store adresses of own j_orbs
     OrbitalVector rcvOrbs(0);		//to store adresses of received orbitals
 
-    int orbsIx[workOrbVecSize];		//to store own orbital indices
+    vector<int> orbsIx;                 //to store own orbital indices
     int rcvOrbsIx[workOrbVecSize];	//to store received orbital indices
 
     //make vector with adresses of own orbitals
-    int i = 0;
     for (int ix = mpiOrbRank; ix < Ni; ix += mpiOrbSize) {
         orbVecChunk_i.push_back(bra.getOrbital(ix));//i orbitals
-        orbsIx[i++] = ix;
+        orbsIx.push_back(ix);
     }
     for (int jx = mpiOrbRank; jx < Nj; jx += mpiOrbSize) {
         orbVecChunk_j.push_back(ket.getOrbital(jx));//j orbitals
@@ -141,14 +140,13 @@ MatrixXcd IdentityOperator::calcOverlapMatrix_P_H(OrbitalVector &bra, OrbitalVec
     OrbitalVector orbVecChunk_j(0);	//to store adresses of own j_orbs
     OrbitalVector rcvOrbs(0);		//to store adresses of received orbitals
 
-    int orbsIx[workOrbVecSize];		//to store own orbital indices
+    vector<int> orbsIx;                 //to store own orbital indices
     int rcvOrbsIx[workOrbVecSize];	//to store received orbital indices
 
     //make vector with adresses of own orbitals
-    int i = 0;
     for (int ix = mpiOrbRank; ix < Ni; ix += mpiOrbSize) {
         orbVecChunk_i.push_back(bra.getOrbital(ix));//i orbitals
-        orbsIx[i++] = ix;
+        orbsIx.push_back(ix);
     }
     for (int jx = mpiOrbRank; jx < Nj; jx += mpiOrbSize) {
         orbVecChunk_j.push_back(ket.getOrbital(jx));//j orbitals

--- a/src/mrchem/scf_solver/EnergyOptimizer.cpp
+++ b/src/mrchem/scf_solver/EnergyOptimizer.cpp
@@ -173,14 +173,13 @@ MatrixXd EnergyOptimizer::calcFockMatrixUpdate() {
         OrbitalVector orbVecChunk_j(0); //to store adresses of own j_orbs
         OrbitalVector rcvOrbs(0);       //to store adresses of received orbitals
 
-        int orbsIx[workOrbVecSize];     //to store own orbital indices
-        int rcvOrbsIx[workOrbVecSize];  //to store received orbital indices
+	vector<int> orbsIx;             //to store own orbital indices    
+	int rcvOrbsIx[workOrbVecSize];  //to store received orbital indices
 
         //make vector with adresses of own orbitals
-        int i = 0;
         for (int ix = mpiOrbRank; ix < Ni; ix += mpiOrbSize) {
             orbVecChunk_i.push_back(phi_np1.getOrbital(ix));//i orbitals
-            orbsIx[i++] = ix;
+            orbsIx.push_back(ix);
         }
         for (int jx = mpiOrbRank; jx < Nj; jx += mpiOrbSize)
             orbVecChunk_j.push_back(dPhi_n.getOrbital(jx));//j orbitals

--- a/src/mrcpp/mwtrees/SerialFunctionTree.cpp
+++ b/src/mrcpp/mwtrees/SerialFunctionTree.cpp
@@ -44,7 +44,7 @@ SerialFunctionTree<D>::SerialFunctionTree(FunctionTree<D> *tree)
 	this->maxNodesPerChunk = 64;
 	sizePerChunk = this->maxNodesPerChunk*this->sizeNodeCoeff;
     }else{      
-	this->maxNodesPerChunk = sizePerChunk/this->sizeNodeCoeff/sizeof(double);
+	this->maxNodesPerChunk = (sizePerChunk/this->sizeNodeCoeff/sizeof(double)/8)*8;
     }
 
     this->lastNode = (ProjectedNode<D>*) this->sNodes;//position of last allocated node
@@ -410,6 +410,7 @@ void SerialFunctionTree<D>::deallocGenNodes(int serialIx) {
 
 template<int D>
 void SerialFunctionTree<D>::deallocGenNodeChunks() {
+    //if(mpiOrbRank==0 and (this->genNodeCoeffChunks.size()*2)*1024/8>10000)cout<<"deallocate genchunks MB "<<(this->genNodeCoeffChunks.size()*2)*1024/1024/8<<endl;
     for (int i = 0; i < this->genNodeCoeffChunks.size(); i++) delete[] this->genNodeCoeffChunks[i];
     for (int i = 0; i < this->genNodeChunks.size(); i++) delete[] (char*)(this->genNodeChunks[i]);
     this->genNodeCoeffChunks.clear();

--- a/src/mrcpp/mwtrees/SerialFunctionTree.cpp
+++ b/src/mrcpp/mwtrees/SerialFunctionTree.cpp
@@ -394,7 +394,11 @@ void SerialFunctionTree<D>::deallocGenNodes(int serialIx) {
         int topStack = this->nGenNodes;
         while (this->genNodeStackStatus[topStack-1] == 0) {
             topStack--;
-            if (topStack < 1) break;
+            if (topStack < 1) {
+		//remove all the GenNodeChunks once there are noe more genNodes
+		this->deallocGenNodeChunks();
+		break;
+	    }
         }
         this->nGenNodes = topStack;//move top of stack
         //has to redefine lastGenNode
@@ -402,6 +406,15 @@ void SerialFunctionTree<D>::deallocGenNodes(int serialIx) {
         this->lastGenNode = this->genNodeChunks[chunk] + this->nGenNodes%(this->maxNodesPerChunk);
     }
     omp_unset_lock(&Sfunc_tree_lock);
+}
+
+template<int D>
+void SerialFunctionTree<D>::deallocGenNodeChunks() {
+    for (int i = 0; i < this->genNodeCoeffChunks.size(); i++) delete[] this->genNodeCoeffChunks[i];
+    for (int i = 0; i < this->genNodeChunks.size(); i++) delete[] (char*)(this->genNodeChunks[i]);
+    this->genNodeCoeffChunks.clear();
+    this->genNodeChunks.clear();
+    this->genNodeStackStatus.clear();
 }
 
 /** Overwrite all pointers defined in the tree.

--- a/src/mrcpp/mwtrees/SerialFunctionTree.h
+++ b/src/mrcpp/mwtrees/SerialFunctionTree.h
@@ -31,6 +31,7 @@ public:
 
     virtual void deallocNodes(int serialIx);
     virtual void deallocGenNodes(int serialIx);
+    virtual void deallocGenNodeChunks();
 
     std::vector<ProjectedNode<D>*> nodeChunks;
     std::vector<double*> nodeCoeffChunks;

--- a/src/mrcpp/mwtrees/SerialOperatorTree.cpp
+++ b/src/mrcpp/mwtrees/SerialOperatorTree.cpp
@@ -237,3 +237,7 @@ void SerialOperatorTree::deallocNodes(int serialIx) {
 void SerialOperatorTree::deallocGenNodes(int serialIx) {
     NOT_REACHED_ABORT;
 }
+
+void SerialOperatorTree::deallocGenNodeChunks() {
+    NOT_REACHED_ABORT;
+}

--- a/src/mrcpp/mwtrees/SerialOperatorTree.h
+++ b/src/mrcpp/mwtrees/SerialOperatorTree.h
@@ -29,6 +29,7 @@ public:
 
     virtual void deallocNodes(int serialIx);
     virtual void deallocGenNodes(int serialIx);
+    virtual void deallocGenNodeChunks();
 
 protected:
     OperatorNode *sNodes;       //serial OperatorNodes

--- a/src/mrcpp/mwtrees/SerialTree.h
+++ b/src/mrcpp/mwtrees/SerialTree.h
@@ -32,6 +32,7 @@ public:
 
     virtual void deallocNodes(int serialIx) = 0;
     virtual void deallocGenNodes(int serialIx) = 0;
+    virtual void deallocGenNodeChunks() = 0;
 
     void S_mwTransform(double* coeff_in, double* coeff_out, bool readOnlyScaling, int stride, bool overwrite = true);
     void S_mwTransformBack(double* coeff_in, double* coeff_out, int stride);


### PR DESCRIPTION
orbsIx had fixed dimensions. This was wrong. It is now a dynamic vector with no size limitations.
This caused crashes for serial runs if the number of orbitals per mpi was larger that workOrbVecSize.
Bug in MPI orbitalsend, when many orbitals has been corrected.
Delete chunks for gennodes directly after that gennodes are removed. (not sure it helps, since when gennodes are removed we are probably done with the orbital, and if not the chunks could be reused).