### PR TITLE
Memory save

### DIFF
--- a/src/mrchem/qmfunctions/OrbitalAdder.cpp
+++ b/src/mrchem/qmfunctions/OrbitalAdder.cpp
@@ -7,11 +7,11 @@ extern OrbitalVector workOrbVec;
 using namespace std;
 using namespace Eigen;
 
-OrbitalAdder::OrbitalAdder(double prec, int max_scale, int workVecMax)
+OrbitalAdder::OrbitalAdder(double prec, int max_scale, int work_vec_max)
     : add(prec, max_scale),
       grid(max_scale) ,
-      workVecMax(workVecMax) {
-      }
+      workVecMax(work_vec_max) {
+}
 
 void OrbitalAdder::operator()(Orbital &phi_ab,
                               complex<double> a, Orbital &phi_a,
@@ -206,42 +206,41 @@ void OrbitalAdder::rotate_P(OrbitalVector &out, const MatrixXd &U, OrbitalVector
     if (U.rows() < out.size()) MSG_ERROR("Invalid arguments");
 
     int Ni = phi.size();
-    OrbitalVector OrbVecChunk_i(0);//to store adresses of own i_orbs
-    vector<int> orbsIx;     //to store own orbital indices
-    OrbitalVector rcvOrbs(0);//to store adresses of received orbitals
-    int rcvOrbsIx[workOrbVecSize];//to store received orbital indices
+    OrbitalVector orbVecChunk_i(0);//to store adresses of own i_orbs
+    vector<int> orbsIx;            //to store own orbital indices
+    OrbitalVector rcvOrbs(0);      //to store adresses of received orbitals
+    int rcvOrbsIx[workOrbVecSize]; //to store received orbital indices
     
     //make vector with adresses of own orbitals
-    for (int Ix = mpiOrbRank;  Ix < Ni; Ix += mpiOrbSize) {
-	OrbVecChunk_i.push_back(phi.getOrbital(Ix));//i orbitals
+    for (int Ix = mpiOrbRank; Ix < Ni; Ix += mpiOrbSize) {
+	orbVecChunk_i.push_back(phi.getOrbital(Ix));//i orbitals
 	out.getOrbital(Ix).clear(true);
 	orbsIx.push_back(Ix);
     }
     
-    for (int iter = 0;  iter >= 0; iter++) {
+    for (int iter = 0; iter >= 0; iter++) {
 	//get a new chunk from other processes
-	OrbVecChunk_i.getOrbVecChunk(orbsIx, rcvOrbs, rcvOrbsIx, Ni, iter, this->workVecMax, 0);
+	orbVecChunk_i.getOrbVecChunk(orbsIx, rcvOrbs, rcvOrbsIx, Ni, iter, this->workVecMax, 0);
 	//Update only own orbitals	
-	for (int Jx = mpiOrbRank;  Jx < Ni; Jx += mpiOrbSize) {
+	for (int Jx = mpiOrbRank; Jx < Ni; Jx += mpiOrbSize) {
 	    VectorXd U_Chunk(rcvOrbs.size());
-	    for (int ix = 0; ix<rcvOrbs.size(); ix++)U_Chunk(ix)=U(Jx,rcvOrbsIx[ix]);
-	    this->inPlace(out.getOrbital(Jx),U_Chunk, rcvOrbs, false);//can start with empty orbital
+	    for (int ix = 0; ix < rcvOrbs.size(); ix++) U_Chunk(ix) = U(Jx,rcvOrbsIx[ix]);
+	    this->inPlace(out.getOrbital(Jx), U_Chunk, rcvOrbs, false);//can start with empty orbital
 	}
 	rcvOrbs.clearVec(false);//reset to zero size orbital vector
     }
     
     //clear orbital adresses, not the orbitals
-    OrbVecChunk_i.clearVec(false);
+    orbVecChunk_i.clearVec(false);
     workOrbVec.clear();
-
 }
 
 void OrbitalAdder::rotate(OrbitalVector &out, const MatrixXd &U, OrbitalVector &inp) {
     if (U.cols() != inp.size()) MSG_ERROR("Invalid arguments");
     if (U.rows() < out.size()) MSG_ERROR("Invalid arguments");
-    if( mpiOrbSize > 1) {
+    if (mpiOrbSize > 1) {
 	rotate_P(out, U, inp);
-    }else{
+    } else {
 	for (int i = 0; i < out.size(); i++) {
 	    const VectorXd &c = U.row(i);
 	    Orbital &out_i = out.getOrbital(i);
@@ -253,9 +252,9 @@ void OrbitalAdder::rotate(OrbitalVector &out, const MatrixXd &U, OrbitalVector &
 /** In place rotation of orbital vector */
 void OrbitalAdder::rotate(OrbitalVector &out, const MatrixXd &U) {
     OrbitalVector tmp(out);
-    if( mpiOrbSize > 1) {
+    if (mpiOrbSize > 1) {
 	rotate_P(tmp, U, out);
-    }else{
+    } else {
 	rotate(tmp, U, out);
     }
     out.clear(true);      // Delete pointers
@@ -287,11 +286,9 @@ void OrbitalAdder::inPlace(Orbital &out,
    
 }
 
-void OrbitalAdder::inPlace(Orbital &out, const VectorXd &c, OrbitalVector &inp,
-			   bool union_grid) {
-
+void OrbitalAdder::inPlace(Orbital &out, const VectorXd &c, OrbitalVector &inp, bool union_grid) {
     VectorXd c_extended(c.size()+1);
-    for (int i = 0; i < c.size(); i++)c_extended(i)=c(i);
+    for (int i = 0; i < c.size(); i++) c_extended(i) = c(i);
     c_extended(c.size())=1.0;
     Orbital tmp(out);	  // Copy parameters
     inp.push_back(out);
@@ -300,7 +297,6 @@ void OrbitalAdder::inPlace(Orbital &out, const VectorXd &c, OrbitalVector &inp,
     out.shallowCopy(tmp); // Copy pointers
     tmp.clear(false);     // Clear pointers
     inp.pop_back(false);  // Restore vector
-   
 }
 
 void OrbitalAdder::inPlace(OrbitalVector &out, double c, OrbitalVector &inp) {

--- a/src/mrchem/qmfunctions/OrbitalAdder.cpp
+++ b/src/mrchem/qmfunctions/OrbitalAdder.cpp
@@ -2,12 +2,15 @@
 #include "OrbitalVector.h"
 #include "Orbital.h"
 
+extern OrbitalVector workOrbVec;
+
 using namespace std;
 using namespace Eigen;
 
-OrbitalAdder::OrbitalAdder(double prec, int max_scale)
+OrbitalAdder::OrbitalAdder(double prec, int max_scale, int workVecMax)
     : add(prec, max_scale),
-      grid(max_scale) {
+      grid(max_scale) ,
+      workVecMax(workVecMax) {
       }
 
 void OrbitalAdder::operator()(Orbital &phi_ab,
@@ -217,7 +220,7 @@ void OrbitalAdder::rotate_P(OrbitalVector &out, const MatrixXd &U, OrbitalVector
     
     for (int iter = 0;  iter >= 0; iter++) {
 	//get a new chunk from other processes
-	OrbVecChunk_i.getOrbVecChunk(orbsIx, rcvOrbs, rcvOrbsIx, Ni, iter);
+	OrbVecChunk_i.getOrbVecChunk(orbsIx, rcvOrbs, rcvOrbsIx, Ni, iter, this->workVecMax, 0);
 	//Update only own orbitals	
 	for (int Jx = mpiOrbRank;  Jx < Ni; Jx += mpiOrbSize) {
 	    VectorXd U_Chunk(rcvOrbs.size());
@@ -229,7 +232,8 @@ void OrbitalAdder::rotate_P(OrbitalVector &out, const MatrixXd &U, OrbitalVector
     
     //clear orbital adresses, not the orbitals
     OrbVecChunk_i.clearVec(false);
- 
+    workOrbVec.clear();
+
 }
 
 void OrbitalAdder::rotate(OrbitalVector &out, const MatrixXd &U, OrbitalVector &inp) {

--- a/src/mrchem/qmfunctions/OrbitalAdder.cpp
+++ b/src/mrchem/qmfunctions/OrbitalAdder.cpp
@@ -8,9 +8,9 @@ using namespace std;
 using namespace Eigen;
 
 OrbitalAdder::OrbitalAdder(double prec, int max_scale, int work_vec_max)
-    : add(prec, max_scale),
-      grid(max_scale) ,
-      workVecMax(work_vec_max) {
+    : workVecMax(work_vec_max),
+      add(prec, max_scale),
+      grid(max_scale){
 }
 
 void OrbitalAdder::operator()(Orbital &phi_ab,

--- a/src/mrchem/qmfunctions/OrbitalAdder.h
+++ b/src/mrchem/qmfunctions/OrbitalAdder.h
@@ -5,13 +5,14 @@
 
 #include "MWAdder.h"
 #include "GridGenerator.h"
+#include "constants.h"
 
 class Orbital;
 class OrbitalVector;
 
 class OrbitalAdder {
 public:
-    OrbitalAdder(double prec, int max_scale);
+    OrbitalAdder(double prec, int max_scale, int workVecMax = workOrbVecSize);
     virtual ~OrbitalAdder() { }
 
     void setPrecision(double prec) { this->add.setPrecision(prec); }
@@ -38,6 +39,7 @@ public:
 
     void rotate(OrbitalVector &out, const Eigen::MatrixXd &U, OrbitalVector &inp);
     void rotate_P(OrbitalVector &out, const Eigen::MatrixXd &U, OrbitalVector &inp);
+    int workVecMax;//max number of orbitals to store temporarily while sending
     void rotate(OrbitalVector &out, const Eigen::MatrixXd &U);
 
     void inPlace(Orbital &out, std::complex<double> c, Orbital &inp);

--- a/src/mrchem/qmfunctions/OrbitalAdder.h
+++ b/src/mrchem/qmfunctions/OrbitalAdder.h
@@ -12,7 +12,7 @@ class OrbitalVector;
 
 class OrbitalAdder {
 public:
-    OrbitalAdder(double prec, int max_scale, int workVecMax = workOrbVecSize);
+    OrbitalAdder(double prec, int max_scale, int work_vec_max = workOrbVecSize);
     virtual ~OrbitalAdder() { }
 
     void setPrecision(double prec) { this->add.setPrecision(prec); }
@@ -39,7 +39,6 @@ public:
 
     void rotate(OrbitalVector &out, const Eigen::MatrixXd &U, OrbitalVector &inp);
     void rotate_P(OrbitalVector &out, const Eigen::MatrixXd &U, OrbitalVector &inp);
-    int workVecMax;//max number of orbitals to store temporarily while sending
     void rotate(OrbitalVector &out, const Eigen::MatrixXd &U);
 
     void inPlace(Orbital &out, std::complex<double> c, Orbital &inp);
@@ -54,6 +53,7 @@ public:
     void orthogonalize(OrbitalVector &out, OrbitalVector &inp);
 
 protected:
+    int workVecMax; //max number of orbitals to store temporarily while sending
     MWAdder<3> add;
     GridGenerator<3> grid;
 };

--- a/src/mrchem/qmfunctions/OrbitalVector.cpp
+++ b/src/mrchem/qmfunctions/OrbitalVector.cpp
@@ -602,7 +602,7 @@ void OrbitalVector::Rcv_OrbVec(int source, int tag, int *orbsIx, int& workOrbVec
 #ifdef HAVE_MPI
     MPI_Status status;
     MPI_Comm comm=mpiCommOrb;
-    OrbitalVector* workOrbVec_p;//pointer to the workOrbVec to use
+    OrbitalVector* workOrbVec_p = 0;//pointer to the workOrbVec to use
   
     if(workOrbVec2.inUse){
 	workOrbVec_p = &workOrbVec2;//use workOrbVec2

--- a/src/mrchem/qmoperators/ExchangeOperator.h
+++ b/src/mrchem/qmoperators/ExchangeOperator.h
@@ -33,7 +33,7 @@ public:
 protected:
     double x_factor;            ///< Exchange factor for hybrid XC functionals
     PoissonOperator *poisson;   ///< Pointer to external object
-    OrbitalVector *orbitals;    // Pointer to external object
+    OrbitalVector *orbitals;    ///< Pointer to external object
 
     bool screen;                ///< Apply screening in exchange evaluation
     Eigen::VectorXd tot_norms;  ///< Total norms for use in screening

--- a/src/mrchem/qmoperators/ExchangePotential.cpp
+++ b/src/mrchem/qmoperators/ExchangePotential.cpp
@@ -16,7 +16,7 @@ ExchangePotential::ExchangePotential(PoissonOperator &P,
                                      double x_fac)
     : ExchangeOperator(P, phi, x_fac),
       exchange(phi) {
-      }
+}
 
 void ExchangePotential::setup(double prec) {
     setApplyPrec(prec);
@@ -69,20 +69,20 @@ Orbital* ExchangePotential::calcExchange(Orbital &phi_p) {
 
 #ifdef HAVE_MPI
 
-    OrbitalVector OrbVecChunk_i(0);//to store adresses of own i_orbs
-    vector<int> orbsIx;      //to store own orbital indices
-    OrbitalVector rcvOrbs(0);//to store adresses of received orbitals
-    int rcvOrbsIx[workOrbVecSize];//to store received orbital indices
+    OrbitalVector orbVecChunk_i(0); //to store adresses of own i_orbs
+    OrbitalVector rcvOrbs(0);       //to store adresses of received orbitals
+    vector<int> orbsIx;             //to store own orbital indices
+    int rcvOrbsIx[workOrbVecSize];  //to store received orbital indices
 
     //make vector with adresses of own orbitals
     for (int Ix = mpiOrbRank;  Ix < nOrbs; Ix += mpiOrbSize) {
-	OrbVecChunk_i.push_back(this->orbitals->getOrbital(Ix));//i orbitals
+	orbVecChunk_i.push_back(this->orbitals->getOrbital(Ix));//i orbitals
 	orbsIx.push_back(Ix);
     }
 
     for (int iter = 0;  iter >= 0; iter++) {
 	//get a new chunk from other processes
-	OrbVecChunk_i.getOrbVecChunk(orbsIx, rcvOrbs, rcvOrbsIx, nOrbs, iter, workOrbVecSize, 2);
+	orbVecChunk_i.getOrbVecChunk(orbsIx, rcvOrbs, rcvOrbsIx, nOrbs, iter, workOrbVecSize, 2);
 	for (int i = 0; i<rcvOrbs.size(); i++){
 	    Orbital &phi_i = rcvOrbs.getOrbital(i);
 	
@@ -111,7 +111,7 @@ Orbital* ExchangePotential::calcExchange(Orbital &phi_p) {
 	    orb_vec.push_back(phi_iip);
 	}
     }
-    OrbVecChunk_i.clearVec(false);
+    orbVecChunk_i.clearVec(false);
     rcvOrbs.clearVec(false);
     workOrbVec2.clear();
 	
@@ -171,7 +171,7 @@ void ExchangePotential::calcInternalExchange() {
     int nOrbs = this->orbitals->size();
     int n = 0;
 
-    if(mpiOrbSize==1){
+    if (mpiOrbSize==1) {
 	for (int i = 0; i < nOrbs; i++) {
 	    calcInternal(i);
 	    for (int j = 0; j < i; j++) {
@@ -184,7 +184,7 @@ void ExchangePotential::calcInternalExchange() {
 	    this->tot_norms(i) = sqrt(ex_i.getSquareNorm());
 	    n = max(n, ex_i.getNNodes());
 	}
-    }else{
+    } else {
 
 #ifdef HAVE_MPI
 
@@ -193,17 +193,17 @@ void ExchangePotential::calcInternalExchange() {
 	MPI_Request request=MPI_REQUEST_NULL;
 	MPI_Status status;
 	//has to distribute the calculations evenly among processors
-	OrbitalVector OrbVecChunk_i(0);//to store adresses of own i_orbs
-	vector<int> orbsIx;      //to store own orbital indices
-	OrbitalVector rcvOrbs(0);//to store adresses of received orbitals
-	int rcvOrbsIx[workOrbVecSize];//to store received orbital indices
+	OrbitalVector orbVecChunk_i(0); //to store adresses of own i_orbs
+	OrbitalVector rcvOrbs(0);       //to store adresses of received orbitals
+	vector<int> orbsIx;             //to store own orbital indices
+	int rcvOrbsIx[workOrbVecSize];  //to store received orbital indices
       
-	int sndtoMPI[workOrbVecSize];//to store rank of MPI where orbitals were sent
-	int sndOrbIx[workOrbVecSize];//to store indices of where orbitals were sent
+	int sndtoMPI[workOrbVecSize];   //to store rank of MPI where orbitals were sent
+	int sndOrbIx[workOrbVecSize];   //to store indices of where orbitals were sent
       
 	//make vector with adresses of own orbitals
 	for (int Ix = mpiOrbRank;  Ix < nOrbs; Ix += mpiOrbSize) {
-	    OrbVecChunk_i.push_back(this->orbitals->getOrbital(Ix));//i orbitals
+	    orbVecChunk_i.push_back(this->orbitals->getOrbital(Ix));//i orbitals
 	    orbsIx.push_back(Ix);
 	}
       
@@ -215,36 +215,36 @@ void ExchangePotential::calcInternalExchange() {
 	    //get a new chunk from other processes
 	    sndOrbIx[0] = 0;//init
 	    sndtoMPI[0] = -1;//init
-	    OrbVecChunk_i.getOrbVecChunk_sym(orbsIx, rcvOrbs, rcvOrbsIx, nOrbs, iter, sndtoMPI, sndOrbIx,1,2);
+	    orbVecChunk_i.getOrbVecChunk_sym(orbsIx, rcvOrbs, rcvOrbsIx, nOrbs, iter, sndtoMPI, sndOrbIx,1,2);
 	    int rcv_left = 1;//normally we get one phi_jji per ii, maybe none
 	    if (sndtoMPI[0] < 0 or sndtoMPI[0] == mpiOrbRank) rcv_left = 0;//we haven't sent anything, will not receive anything back	    
 	    //convention: all indices with "i" are owned locally
-	    for (int ii = 0; ii < OrbVecChunk_i.size()+1 ; ii++){ //we may have to do one extra iteration to fetch all data
-		int j = 0;//because we limited the size in getOrbVecChunk_sym to 1
+	    for (int ii = 0; ii < orbVecChunk_i.size()+1 ; ii++){ //we may have to do one extra iteration to fetch all data
+		int j = 0; //because we limited the size in getOrbVecChunk_sym to 1
 		int i = ii;
-		if(ii >= OrbVecChunk_i.size()) i = 0;//so that phi_i is defined, but will not be used
+		if (ii >= orbVecChunk_i.size()) i = 0; //so that phi_i is defined, but will not be used
 	  
-		Orbital &phi_i = OrbVecChunk_i.getOrbital(i);
+		Orbital &phi_i = orbVecChunk_i.getOrbital(i);
 		Orbital *phi_iij = new Orbital(phi_i);
 		int i_rcv = sndOrbIx[j];
 		Orbital &phi_i_rcv = this->orbitals->getOrbital(i_rcv);
 		Orbital *phi_jji_rcv = new Orbital(phi_i_rcv);	      
-		if(rcvOrbs.size()>0 and ii<OrbVecChunk_i.size()){
-		    if(orbsIx[i] == rcvOrbsIx[j]) {
+		if (rcvOrbs.size() > 0 and ii < orbVecChunk_i.size()) {
+		    if (orbsIx[i] == rcvOrbsIx[j]) {
 			//orbital should be own and i and j point to same orbital
 			calcInternal(orbsIx[i]);
-		    }else{	    
+		    } else {
 			Orbital &phi_j = rcvOrbs.getOrbital(j);	    
-			if(rcvOrbsIx[j]%mpiOrbSize != mpiOrbRank){
+			if (rcvOrbsIx[j]%mpiOrbSize != mpiOrbRank) {
 			    calcInternal(orbsIx[i], rcvOrbsIx[j], phi_i, phi_j, phi_iij);
 			    //we send back the locally computed result to where j came from 
 			    phi_iij->setOccupancy(orbsIx[i]);//We temporarily use Occupancy to send Orbital rank 
-			    phi_iij->setSpin(OrbVecChunk_i.size()-i-1);//We temporarily use Spin to send info about number of transfers left
+			    phi_iij->setSpin(orbVecChunk_i.size()-i-1);//We temporarily use Spin to send info about number of transfers left
 			    phi_iij->setError( this->part_norms(rcvOrbsIx[j],orbsIx[i]));//We temporarily use Error to send part_norm
 			    phi_iij->Isend_Orbital(rcvOrbsIx[j]%mpiOrbSize, mpiiter%10, request);
-			}else{
+			} else {
 			    //only compute j < i in own block 
-			    if(rcvOrbsIx[j] < orbsIx[i]) calcInternal(orbsIx[i], rcvOrbsIx[j], phi_i, phi_j, phi_iij);
+			    if (rcvOrbsIx[j] < orbsIx[i]) calcInternal(orbsIx[i], rcvOrbsIx[j], phi_i, phi_j, phi_iij);
 			}
 		    }
 		}
@@ -252,7 +252,7 @@ void ExchangePotential::calcInternalExchange() {
 		    //we expect to receive data 
 		    phi_jji_rcv->Rcv_Orbital(sndtoMPI[j], mpiiter%10);//we get back phi_jji from where we sent i
 		}
-		if (rcvOrbsIx[j]%mpiOrbSize != mpiOrbRank and rcvOrbs.size() > 0 and ii < OrbVecChunk_i.size()){
+		if (rcvOrbsIx[j]%mpiOrbSize != mpiOrbRank and rcvOrbs.size() > 0 and ii < orbVecChunk_i.size()){
 		    MPI_Wait(&request, &status);//do not continue before isend is finished	      
 		}
 		if (rcv_left > 0) {
@@ -260,7 +260,7 @@ void ExchangePotential::calcInternalExchange() {
 		    int i_rcv = sndOrbIx[j];
 		    int j_rcv = phi_jji_rcv->getOccupancy();//occupancy was used to send rank!
 		    rcv_left = phi_jji_rcv->getSpin();//occupancy was used to send number of transfers left!
-		    if(i_rcv!=j_rcv){
+		    if (i_rcv!=j_rcv) {
 			phi_jji_rcv->setOccupancy(this->orbitals->getOrbital(j_rcv).getOccupancy());//restablish occupancy		
 			phi_jji_rcv->setSpin(this->orbitals->getOrbital(j_rcv).getSpin());//restablish spin		
 			this->part_norms(i_rcv,j_rcv) = phi_jji_rcv->getError();//does not seem to matter?
@@ -280,7 +280,7 @@ void ExchangePotential::calcInternalExchange() {
 	    }
 	    rcvOrbs.clearVec(false);//reset to zero size orbital vector     	
 	}
-	OrbVecChunk_i.clearVec(false);
+	orbVecChunk_i.clearVec(false);
 	workOrbVec2.clear();
 
 	for (int i = 0; i < nOrbs; i++) {
@@ -288,7 +288,7 @@ void ExchangePotential::calcInternalExchange() {
 		Orbital &ex_i = this->exchange.getOrbital(i);
 		this->tot_norms(i) = sqrt(ex_i.getSquareNorm());
 		n = max(n, ex_i.getNNodes());
-	    }else{
+	    } else {
 		this->tot_norms(i) = 0.0;
 	    }
 	}
@@ -411,6 +411,7 @@ void ExchangePotential::calcInternal(int i, int j) {
     add.inPlace(ex_j, j_factor, *phi_iij);
     if (phi_iij != 0) delete phi_iij;
 }
+
 //NB: this routine only compute ex_i, never ex_j
 void ExchangePotential::calcInternal(int i, int j, Orbital &phi_i, Orbital &phi_j) {
     OrbitalAdder add(-1.0, this->max_scale);
@@ -418,8 +419,6 @@ void ExchangePotential::calcInternal(int i, int j, Orbital &phi_i, Orbital &phi_
     MWConvolution<3> apply(-1.0, this->max_scale);
 
     PoissonOperator &P = *this->poisson;
-    //    Orbital &phi_i = this->orbitals->getOrbital(i);
-    //    Orbital &phi_j = this->orbitals->getOrbital(j);
 
     double i_factor = phi_i.getExchangeFactor(phi_j);
     double j_factor = phi_j.getExchangeFactor(phi_i);
@@ -472,7 +471,6 @@ void ExchangePotential::calcInternal(int i, int j, Orbital &phi_i, Orbital &phi_
     Orbital &ex_i = this->exchange.getOrbital(i);
     add.inPlace(ex_i, i_factor, *phi_jij);
     if (phi_jij != 0) delete phi_jij;
-
 }
 
 void ExchangePotential::calcInternal(int i, int j, Orbital &phi_i, Orbital &phi_j, Orbital* phi_iij) {
@@ -482,8 +480,6 @@ void ExchangePotential::calcInternal(int i, int j, Orbital &phi_i, Orbital &phi_
     MWConvolution<3> apply(-1.0, this->max_scale);
 
     PoissonOperator &P = *this->poisson;
-    //    Orbital &phi_i = this->orbitals->getOrbital(i);
-    //    Orbital &phi_j = this->orbitals->getOrbital(j);
 
     double i_factor = phi_i.getExchangeFactor(phi_j);
     double j_factor = phi_j.getExchangeFactor(phi_i);
@@ -526,7 +522,6 @@ void ExchangePotential::calcInternal(int i, int j, Orbital &phi_i, Orbital &phi_
     add.inPlace(ex_i, i_factor, *phi_jij);
     if (phi_jij != 0) delete phi_jij;
 
-
     //part_norms(i,j) MUST be computed to use for symmetric screening
     // compute phi_iij = phi_i * V_ij
     double fac_iij = -(this->x_factor/phi_i.getSquareNorm());
@@ -536,7 +531,7 @@ void ExchangePotential::calcInternal(int i, int j, Orbital &phi_i, Orbital &phi_
     if (V_ij != 0) delete V_ij;
 
     //This part (phi_iij) is sent to owner of j orbital if it is on another MPI
-    if(j%mpiOrbSize==mpiOrbRank){
+    if (j%mpiOrbSize == mpiOrbRank) {
 	// compute x_j += phi_iij
         Orbital &ex_j = this->exchange.getOrbital(j);
         add.inPlace(ex_j, j_factor, *phi_iij);
@@ -549,7 +544,6 @@ Orbital* ExchangePotential::testPreComputed(Orbital &phi_p) {
     for (int i = 0; i < nOrbs; i++) {
         Orbital &phi_i  = this->orbitals->getOrbital(i);
         Orbital *ex_i = this->exchange[i];
-	//if (&phi_i == &phi_p and ex_i->getNNodes() != 0) { //cannot be used with MPI, because phi_p is moved
         if (&phi_i.real() == &phi_p.real() and &phi_i.imag() == &phi_p.imag() and ex_i->getNNodes() != 0) {
             Orbital *result = new Orbital(phi_p);
             // Deep copy of orbital

--- a/src/mrchem/qmoperators/FockOperator.cpp
+++ b/src/mrchem/qmoperators/FockOperator.cpp
@@ -170,6 +170,7 @@ MatrixXd FockOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs)
     //clear orbital vector adresses. NB: only references and metadata must be deleted, not the trees in orbitals
     OrbVecChunk_i.clearVec(false);
     OrbVecChunk_j.clearVec(false);
+    workOrbVec.clear();
 
     //combine results from all processes
     MPI_Allreduce(MPI_IN_PLACE, &result(0,0), Ni*Nj,

--- a/src/mrchem/qmoperators/FockOperator.cpp
+++ b/src/mrchem/qmoperators/FockOperator.cpp
@@ -116,50 +116,52 @@ MatrixXd FockOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs)
     int Ni = i_orbs.size();
     int Nj = j_orbs.size();
     MatrixXd result = MatrixXd::Zero(Ni,Nj);
+    Timer tot_t;
+    TelePrompter::printHeader(0, "Calculating Fock matrix");
 
 #ifdef HAVE_MPI
-    OrbitalVector OrbVecChunk_i(0);//to store adresses of own i_orbs
-    OrbitalVector OrbVecChunk_j(0);//to store adresses of own j_orbs
-    OrbitalVector rcvOrbs(0);//to store adresses of received orbitals
-    vector<int> orbsIx;           //to store own orbital indices  
-    int rcvOrbsIx[workOrbVecSize];//to store received orbital indices
+    OrbitalVector orbVecChunk_i(0); //to store adresses of own i_orbs
+    OrbitalVector orbVecChunk_j(0); //to store adresses of own j_orbs
+    OrbitalVector rcvOrbs(0);       //to store adresses of received orbitals
+    vector<int> orbsIx;             //to store own orbital indices
+    int rcvOrbsIx[workOrbVecSize];  //to store received orbital indices
 
     //make vector with adresses of own orbitals
     for (int Ix = mpiOrbRank; Ix < Ni; Ix += mpiOrbSize) {
-	OrbVecChunk_i.push_back(i_orbs.getOrbital(Ix));//i orbitals
+	orbVecChunk_i.push_back(i_orbs.getOrbital(Ix));//i orbitals
 	orbsIx.push_back(Ix);
     }
-    for (int Ix = mpiOrbRank; Ix < Nj; Ix += mpiOrbSize) OrbVecChunk_j.push_back(j_orbs.getOrbital(Ix));//j orbitals
-    //need to pad OrbVecChunk_j so that all have same size
-    if (OrbVecChunk_j.size() < (Nj+mpiOrbSize-1)/mpiOrbSize ) OrbVecChunk_j.push_back(j_orbs.getOrbital(mpiOrbRank));
+    for (int Ix = mpiOrbRank; Ix < Nj; Ix += mpiOrbSize) orbVecChunk_j.push_back(j_orbs.getOrbital(Ix));//j orbitals
+    //need to pad orbVecChunk_j so that all have same size
+    if (orbVecChunk_j.size() < (Nj+mpiOrbSize-1)/mpiOrbSize) orbVecChunk_j.push_back(j_orbs.getOrbital(mpiOrbRank));
 
-    for (int iter = 0;  iter >= 0 ; iter++) {
+    for (int iter = 0; iter >= 0; iter++) {
 	//get a new chunk from other processes
 	//NB: should not use directly workorbvec as rcvOrbs, because they may 
 	//contain own orbitals, and these can be overwritten
-	OrbVecChunk_i.getOrbVecChunk(orbsIx, rcvOrbs, rcvOrbsIx, Ni, iter);
+	orbVecChunk_i.getOrbVecChunk(orbsIx, rcvOrbs, rcvOrbsIx, Ni, iter);
 
 	//Only one process does the computations. j orbitals always local
-	MatrixXd resultChunk = MatrixXd::Zero(rcvOrbs.size(),OrbVecChunk_j.size());
+	MatrixXd resultChunk = MatrixXd::Zero(rcvOrbs.size(),orbVecChunk_j.size());
       
-	if (this->T != 0) resultChunk = (*this->T)(rcvOrbs,OrbVecChunk_j);
-	if (this->V != 0) resultChunk += (*this->V)(rcvOrbs,OrbVecChunk_j);
-	if (this->J != 0) resultChunk += (*this->J)(rcvOrbs,OrbVecChunk_j);
-	if (this->K != 0){
-	    resultChunk += (*this->K)(rcvOrbs,OrbVecChunk_j);
-	    if(rcvOrbs.size()==0 and iter>=0 ){
+	if (this->T != 0) resultChunk = (*this->T)(rcvOrbs,orbVecChunk_j);
+	if (this->V != 0) resultChunk += (*this->V)(rcvOrbs,orbVecChunk_j);
+	if (this->J != 0) resultChunk += (*this->J)(rcvOrbs,orbVecChunk_j);
+	if (this->K != 0) {
+	    resultChunk += (*this->K)(rcvOrbs,orbVecChunk_j);
+	    if (rcvOrbs.size() == 0 and iter>=0) {
 		//we must still go through operator to send own orbitals to others. Just make a fake operation!
 		rcvOrbs.push_back(i_orbs.getOrbital(mpiOrbRank));//i orbitals
-		MatrixXd resultChunk_notused = MatrixXd::Zero(rcvOrbs.size(),OrbVecChunk_j.size());
-		resultChunk_notused = (*this->K)(rcvOrbs,OrbVecChunk_j);	  
+		MatrixXd resultChunk_notused = MatrixXd::Zero(rcvOrbs.size(),orbVecChunk_j.size());
+		resultChunk_notused = (*this->K)(rcvOrbs,orbVecChunk_j);
 	    }
 	}
-	if (this->XC != 0) resultChunk += (*this->XC)(rcvOrbs,OrbVecChunk_j);
+	if (this->XC != 0) resultChunk += (*this->XC)(rcvOrbs,orbVecChunk_j);
 
 	//copy results into final matrix
 	int j = 0;
-	for (int Jx = mpiOrbRank;  Jx < Nj ; Jx += mpiOrbSize) {
-	    for (int ix = 0;  ix<rcvOrbs.size() ; ix++) {
+	for (int Jx = mpiOrbRank; Jx < Nj; Jx += mpiOrbSize) {
+	    for (int ix = 0; ix < rcvOrbs.size(); ix++) {
 		result(rcvOrbsIx[ix],Jx) += resultChunk(ix,j);
 	    }
 	    j++;
@@ -168,8 +170,8 @@ MatrixXd FockOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs)
     }
 
     //clear orbital vector adresses. NB: only references and metadata must be deleted, not the trees in orbitals
-    OrbVecChunk_i.clearVec(false);
-    OrbVecChunk_j.clearVec(false);
+    orbVecChunk_i.clearVec(false);
+    orbVecChunk_j.clearVec(false);
     workOrbVec.clear();
 
     //combine results from all processes
@@ -177,8 +179,6 @@ MatrixXd FockOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs)
                   MPI_DOUBLE, MPI_SUM, mpiCommOrb);
 
 #else
-    Timer tot_t;
-    TelePrompter::printHeader(0, "Calculating Fock matrix");
     if (this->T != 0) {
         Timer timer;
         result += (*this->T)(i_orbs, j_orbs);
@@ -215,9 +215,9 @@ MatrixXd FockOperator::operator() (OrbitalVector &i_orbs, OrbitalVector &j_orbs)
         timer.stop();
         TelePrompter::printDouble(0, "Perturbation matrix", timer.getWallTime());
     }
+#endif
     tot_t.stop();
     TelePrompter::printFooter(0, tot_t, 2);
-#endif
 
     return result;
 }

--- a/src/mrchem/qmoperators/IdentityOperator.cpp
+++ b/src/mrchem/qmoperators/IdentityOperator.cpp
@@ -5,6 +5,7 @@
 using namespace Eigen;
 
 extern MultiResolutionAnalysis<3> *MRA; // Global MRA
+extern OrbitalVector workOrbVec;
 
 IdentityOperator::IdentityOperator() : QMOperator(MRA->getMaxScale()) {
 }
@@ -117,6 +118,7 @@ MatrixXcd IdentityOperator::calcOverlapMatrix_P(OrbitalVector &bra, OrbitalVecto
     //clear orbital adresses (not the orbitals)
     orbVecChunk_i.clearVec(false);
     orbVecChunk_j.clearVec(false);
+    workOrbVec.clear();
 
     MPI_Allreduce(MPI_IN_PLACE, &S(0,0), Ni*Nj,
                   MPI_DOUBLE_COMPLEX, MPI_SUM, mpiCommOrb);
@@ -177,6 +179,7 @@ MatrixXcd IdentityOperator::calcOverlapMatrix_P_H(OrbitalVector &bra, OrbitalVec
     //clear orbital adresses (not the orbitals)
     orbVecChunk_i.clearVec(false);
     orbVecChunk_j.clearVec(false);
+    workOrbVec.clear();
 
     MPI_Allreduce(MPI_IN_PLACE, &S(0,0), Ni*Nj,
                   MPI_DOUBLE_COMPLEX, MPI_SUM, mpiCommOrb);

--- a/src/mrchem/scf_solver/EnergyOptimizer.cpp
+++ b/src/mrchem/scf_solver/EnergyOptimizer.cpp
@@ -206,6 +206,7 @@ MatrixXd EnergyOptimizer::calcFockMatrixUpdate() {
         //clear orbital adresses, not the orbitals
         orbVecChunk_i.clearVec(false);
         orbVecChunk_j.clearVec(false);
+	workOrbVec.clear();
 
         MPI_Allreduce(MPI_IN_PLACE, &dV_n(0,0), Ni*Nj,
                       MPI_DOUBLE, MPI_SUM, mpiCommOrb);

--- a/src/mrchem/scf_solver/EnergyOptimizer.cpp
+++ b/src/mrchem/scf_solver/EnergyOptimizer.cpp
@@ -206,7 +206,7 @@ MatrixXd EnergyOptimizer::calcFockMatrixUpdate() {
         //clear orbital adresses, not the orbitals
         orbVecChunk_i.clearVec(false);
         orbVecChunk_j.clearVec(false);
-	workOrbVec.clear();
+        workOrbVec.clear();
 
         MPI_Allreduce(MPI_IN_PLACE, &dV_n(0,0), Ni*Nj,
                       MPI_DOUBLE, MPI_SUM, mpiCommOrb);

--- a/src/mrchem/scf_solver/GroundStateSolver.cpp
+++ b/src/mrchem/scf_solver/GroundStateSolver.cpp
@@ -19,6 +19,8 @@
 using namespace std;
 using namespace Eigen;
 
+extern OrbitalVector workOrbVec;
+
 GroundStateSolver::GroundStateSolver(HelmholtzOperatorSet &h)
     : SCF(h),
       fOper_n(0),
@@ -123,6 +125,7 @@ OrbitalVector* GroundStateSolver::setupHelmholtzArguments(FockOperator &fock,
         rcvOrbs.clearVec(false);//reset to zero size orbital vector
     }
     orbVecChunk_i.clearVec(false);
+    workOrbVec.clear();
     timer_2.stop();
     TelePrompter::printDouble(0, "Matrix part", timer_2.getWallTime());
 
@@ -381,6 +384,7 @@ RR::RR(double prec, OrbitalVector &phi) {
         rcvOrbs.clearVec(false);
     }
     OrbVecChunk_i.clearVec(false);
+    workOrbVec.clear();
     //combine results from all processes
     MPI_Allreduce(MPI_IN_PLACE, &r_i_orig(0,0), N*3*N,
                   MPI_DOUBLE, MPI_SUM, mpiCommOrb);

--- a/src/mrchem/scf_solver/GroundStateSolver.cpp
+++ b/src/mrchem/scf_solver/GroundStateSolver.cpp
@@ -52,7 +52,7 @@ OrbitalVector* GroundStateSolver::setupHelmholtzArguments(FockOperator &fock,
                                                           const Eigen::MatrixXd &M,
                                                           OrbitalVector &phi,
                                                           bool adjoint,
-							  bool clearFock) {
+                                                          bool clearFock) {
     Timer timer_tot;
     TelePrompter::printHeader(0, "Setting up Helmholtz arguments");
     int oldprec = TelePrompter::setPrecision(5);
@@ -80,7 +80,7 @@ OrbitalVector* GroundStateSolver::setupHelmholtzArguments(FockOperator &fock,
     Timer timer_2;
     OrbitalVector orbVecChunk_i(0); //to store adresses of own i_orbs
     OrbitalVector rcvOrbs(0);       //to store adresses of received orbitals
-    vector<int> orbsIx;     //to store own orbital indices
+    vector<int> orbsIx;             //to store own orbital indices
     int rcvOrbsIx[workOrbVecSize];  //to store received orbital indices
 
     //make vector with adresses of own orbitals
@@ -105,7 +105,7 @@ OrbitalVector* GroundStateSolver::setupHelmholtzArguments(FockOperator &fock,
                 int jx = rcvOrbsIx[j];
                 double coef = M(ix,jx);
                 // Linear scaling screening inserted here
-               // if (fabs(coef) > MachineZero) {
+                // if (fabs(coef) > MachineZero) {
                     Orbital &phi_j = rcvOrbs.getOrbital(j);
                     double norm_j = sqrt(phi_j.getSquareNorm());
                     if (norm_j > 0.01*getOrbitalPrecision()) {
@@ -336,22 +336,22 @@ RR::RR(double prec, OrbitalVector &phi) {
 
 #ifdef HAVE_MPI
 
-    OrbitalVector OrbVecChunk_i(0);//to store adresses of own i_orbs
-    vector<int> orbsIx;//to store own orbital indices
-    OrbitalVector rcvOrbs(0);//to store adresses of received orbitals
-    int rcvOrbsIx[workOrbVecSize];//to store received orbital indices
+    OrbitalVector orbVecChunk_i(0); //to store adresses of own i_orbs
+    OrbitalVector rcvOrbs(0);       //to store adresses of received orbitals
+    vector<int> orbsIx;             //to store own orbital indices
+    int rcvOrbsIx[workOrbVecSize];  //to store received orbital indices
 
     //make vector with adresses of own orbitals
-    for (int Ix = mpiOrbRank;  Ix < N; Ix += mpiOrbSize) {
-        OrbVecChunk_i.push_back(phi.getOrbital(Ix));//i orbitals
+    for (int Ix = mpiOrbRank; Ix < N; Ix += mpiOrbSize) {
+        orbVecChunk_i.push_back(phi.getOrbital(Ix));//i orbitals
         orbsIx.push_back(Ix);
     }
 
-    for (int iter = 0;  iter >= 0; iter++) {
+    for (int iter = 0; iter >= 0; iter++) {
         //get a new chunk from other processes
-        OrbVecChunk_i.getOrbVecChunk_sym(orbsIx, rcvOrbs, rcvOrbsIx, N, iter);
-        for (int i = 0; i<OrbVecChunk_i.size(); i++){
-            Orbital &phi_i = OrbVecChunk_i.getOrbital(i);
+        orbVecChunk_i.getOrbVecChunk_sym(orbsIx, rcvOrbs, rcvOrbsIx, N, iter);
+        for (int i = 0; i<orbVecChunk_i.size(); i++){
+            Orbital &phi_i = orbVecChunk_i.getOrbital(i);
             int spin_i = phi_i.getSpin();
             for (int j = 0; j < rcvOrbs.size(); j++) {
                 Orbital &phi_j = rcvOrbs.getOrbital(j);
@@ -383,7 +383,7 @@ RR::RR(double prec, OrbitalVector &phi) {
         }
         rcvOrbs.clearVec(false);
     }
-    OrbVecChunk_i.clearVec(false);
+    orbVecChunk_i.clearVec(false);
     workOrbVec.clear();
     //combine results from all processes
     MPI_Allreduce(MPI_IN_PLACE, &r_i_orig(0,0), N*3*N,

--- a/src/mrchem/scf_solver/GroundStateSolver.cpp
+++ b/src/mrchem/scf_solver/GroundStateSolver.cpp
@@ -49,13 +49,13 @@ GroundStateSolver::~GroundStateSolver() {
 OrbitalVector* GroundStateSolver::setupHelmholtzArguments(FockOperator &fock,
                                                           const Eigen::MatrixXd &M,
                                                           OrbitalVector &phi,
-                                                          bool adjoint) {
+                                                          bool adjoint,
+							  bool clearFock) {
     Timer timer_tot;
     TelePrompter::printHeader(0, "Setting up Helmholtz arguments");
     int oldprec = TelePrompter::setPrecision(5);
-
+    
     double coef = -1.0/(2.0*pi);
-
     Timer timer_1;
     OrbitalVector *args = new OrbitalVector(0);
     for (int i = 0; i < phi.size(); i++) {
@@ -72,6 +72,8 @@ OrbitalVector* GroundStateSolver::setupHelmholtzArguments(FockOperator &fock,
     }
     timer_1.stop();
     TelePrompter::printDouble(0, "Potential part", timer_1.getWallTime());
+
+    if (clearFock) fock.clear();
 
     Timer timer_2;
     OrbitalVector orbVecChunk_i(0); //to store adresses of own i_orbs
@@ -101,14 +103,14 @@ OrbitalVector* GroundStateSolver::setupHelmholtzArguments(FockOperator &fock,
                 int jx = rcvOrbsIx[j];
                 double coef = M(ix,jx);
                 // Linear scaling screening inserted here
-                if (fabs(coef) > MachineZero) {
+               // if (fabs(coef) > MachineZero) {
                     Orbital &phi_j = rcvOrbs.getOrbital(j);
                     double norm_j = sqrt(phi_j.getSquareNorm());
                     if (norm_j > 0.01*getOrbitalPrecision()) {
                         coefs.push_back(coef);
                         orbs.push_back(&phi_j);
                     }
-                }
+                //}
             }
 
             Orbital *tmp_i = new Orbital(phi_i);

--- a/src/mrchem/scf_solver/GroundStateSolver.h
+++ b/src/mrchem/scf_solver/GroundStateSolver.h
@@ -28,7 +28,8 @@ protected:
     OrbitalVector *setupHelmholtzArguments(FockOperator &fock,
                                            const Eigen::MatrixXd &M,
                                            OrbitalVector &phi,
-                                           bool adjoint = false);
+                                           bool adjoint = false,
+                                           bool clearFock = false);
     void printProperty() const;
     double calcProperty();
     double calcPropertyError() const;

--- a/src/mrchem/scf_solver/HelmholtzOperatorSet.cpp
+++ b/src/mrchem/scf_solver/HelmholtzOperatorSet.cpp
@@ -25,9 +25,7 @@ void HelmholtzOperatorSet::setup(double prec, const VectorXd &energies) {
     if (mpiOrbSize > 1) this->clear();
     for (int i = 0; i < energies.size(); i++) {
         double energy = energies(i);
-        if (energy > 0.0 ) {
-            energy = -0.5;
-        }
+        if (energy > 0.0 ) energy = -0.5;
         int idx = initHelmholtzOperator(energy, i);
 	
         this->operIdx.push_back(idx);
@@ -35,9 +33,10 @@ void HelmholtzOperatorSet::setup(double prec, const VectorXd &energies) {
 	    double mu = getOperator(i).getMu();
 	    this->lambda.push_back(-0.5*mu*mu);
 	} else { 
-	    this->lambda.push_back(energy); }
+	    this->lambda.push_back(energy);
+        }
     }
-    if (mpiOrbSize == 1)clearUnused();
+    if (mpiOrbSize == 1) clearUnused();
     timer.stop();
     TelePrompter::printFooter(0, timer, 2);
 }

--- a/src/mrchem/scf_solver/HelmholtzOperatorSet.cpp
+++ b/src/mrchem/scf_solver/HelmholtzOperatorSet.cpp
@@ -22,38 +22,46 @@ void HelmholtzOperatorSet::setup(double prec, const VectorXd &energies) {
     Timer timer;
     this->operIdx.clear();
     this->lambda.clear();
+    if (mpiOrbSize > 1) this->clear();
     for (int i = 0; i < energies.size(); i++) {
         double energy = energies(i);
- 
-        if (energy > 0.0) {
+        if (energy > 0.0 ) {
             energy = -0.5;
         }
-        int idx = initHelmholtzOperator(energy);
+        int idx = initHelmholtzOperator(energy, i);
+	
         this->operIdx.push_back(idx);
-        double mu = getOperator(i).getMu();
-        this->lambda.push_back(-0.5*mu*mu);
+	if (mpiOrbSize == 1) {
+	    double mu = getOperator(i).getMu();
+	    this->lambda.push_back(-0.5*mu*mu);
+	} else { 
+	    this->lambda.push_back(energy); }
     }
-    clearUnused();
+    if (mpiOrbSize == 1)clearUnused();
     timer.stop();
     TelePrompter::printFooter(0, timer, 2);
 }
 
-int HelmholtzOperatorSet::initHelmholtzOperator(double energy) {
+int HelmholtzOperatorSet::initHelmholtzOperator(double energy, int i) {
     if (energy > 0.0) MSG_ERROR("Complex Helmholtz not available");
     double mu = sqrt(-2.0*energy);
-    for (int j = 0; j < this->operators.size(); j++) {
-        double mu_j = this->operators[j]->getMu();
-        double muDiff = mu - mu_j;
-        double relDiff = muDiff/mu;
-        if (fabs(relDiff) < this->threshold) {
-            double l = -0.5*mu_j*mu_j;
-            TelePrompter::printDouble(0, "Re-using operator with lambda", l);
-            return j;
-        }
+    if (mpiOrbSize == 1) {
+	for (int j = 0; j < this->operators.size(); j++) {
+	    double mu_j = this->operators[j]->getMu();
+	    double muDiff = mu - mu_j;
+	    double relDiff = muDiff/mu;
+	    if (fabs(relDiff) < this->threshold and false) {
+		double l = -0.5*mu_j*mu_j;
+		TelePrompter::printDouble(0, "Re-using operator with lambda", l);
+		return j;
+	    }
+	}
     }
-    TelePrompter::printDouble(0, "Creating operator with lambda", energy);
-
-    HelmholtzOperator *oper = new HelmholtzOperator(*MRA, mu, this->build_prec);
+    HelmholtzOperator *oper = 0;
+    if( i%mpiOrbSize == mpiOrbRank) {
+	TelePrompter::printDouble(0, "Creating operator with lambda", energy);	
+	oper = new HelmholtzOperator(*MRA, mu, this->build_prec);
+    }
     this->operators.push_back(oper);
 
     return this->operators.size() - 1;
@@ -118,22 +126,27 @@ VectorXd HelmholtzOperatorSet::getLambda() const {
 }
 
 /** Prints the number of trees and nodes kept in the operator set */
-/*
+
 int HelmholtzOperatorSet::printTreeSizes() const {
     int totNodes = 0;
     int totTrees = 0;
     int nOperators = this->operators.size();
+    int k = MRA->getOrder();
+    int kp1 = k + 1;
     for (int i = 0; i < nOperators; i++) {
-        int nTrees = this->operators[i]->size();
-        for (int j = 0; j < nTrees; j++) {
-            totNodes += this->operators[i]->getComponent(j).getNNodes();
-        }
-        totTrees += nTrees;
+	if(this->operators[i] != 0){
+	    int nTrees = this->operators[i]->size();
+	    for (int j = 0; j < nTrees; j++) {
+		totNodes += this->operators[i]->getComponent(j).getNNodes();
+	    }
+	    totTrees += nTrees;
+	}
     }
-    println(0, " HelmholtzOperators" << setw(15) << totTrees << setw(25) << totNodes);
+    println(0, " HelmholtzOperators " << totTrees <<" trees, " << totNodes<<" nodes, "<<nOperators<<" operators, total"<< totNodes*49*4*8/1024/1024<<" MB");
+
     return totNodes;
 }
-*/
+
 
 void HelmholtzOperatorSet::operator()(int i, Orbital &out, Orbital &inp) {
     if (out.hasReal()) MSG_ERROR("Orbital not empty");

--- a/src/mrchem/scf_solver/HelmholtzOperatorSet.h
+++ b/src/mrchem/scf_solver/HelmholtzOperatorSet.h
@@ -24,6 +24,7 @@ public:
     double getLambda(int i) const { return this->lambda[i]; }
     Eigen::VectorXd getLambda() const;
     HelmholtzOperator &getOperator(int i);
+    printTreeSizes() const;
 
     void operator()(int i, Orbital &out, Orbital &inp);
     void operator()(OrbitalVector &out, OrbitalVector &inp);
@@ -37,7 +38,7 @@ private:
     std::vector<double> lambda;
     std::vector<HelmholtzOperator *> operators;
 
-    int initHelmholtzOperator(double energy);
+    int initHelmholtzOperator(double energy, int i);
     void clearUnused();
 };
 

--- a/src/mrchem/scf_solver/LinearResponseSolver.cpp
+++ b/src/mrchem/scf_solver/LinearResponseSolver.cpp
@@ -237,7 +237,8 @@ void LinearResponseSolver::calcHelmholtzUpdates(OrbitalVector *phi_n,
 OrbitalVector* LinearResponseSolver::setupHelmholtzArguments(FockOperator &fock,
                                                              const Eigen::MatrixXd &M,
                                                              OrbitalVector &phi,
-                                                             bool adjoint) {
+                                                             bool adjoint,
+							     bool clearFock) {
     NOT_IMPLEMENTED_ABORT;
 }
 

--- a/src/mrchem/scf_solver/LinearResponseSolver.h
+++ b/src/mrchem/scf_solver/LinearResponseSolver.h
@@ -52,7 +52,8 @@ protected:
     OrbitalVector *setupHelmholtzArguments(FockOperator &fock,
                                            const Eigen::MatrixXd &M,
                                            OrbitalVector &phi,
-                                           bool adjoint = false);
+                                           bool adjoint = false,
+                                           bool clearFock = false);
 
     void printProperty() const;
 

--- a/src/mrchem/scf_solver/OrbitalOptimizer.cpp
+++ b/src/mrchem/scf_solver/OrbitalOptimizer.cpp
@@ -84,13 +84,17 @@ bool OrbitalOptimizer::optimize() {
         // Setup Helmholtz operators and argument
         H.setup(orb_prec, F.diagonal());
         MatrixXd L = H.getLambda().asDiagonal();
-        OrbitalVector *args_n = setupHelmholtzArguments(fock, L-F, phi_n);
+	bool adjoint = false;
+	bool clearFock = false;
+	if(mpiOrbSize>1)clearFock = true;
+        OrbitalVector *args_n = setupHelmholtzArguments(fock, L-F, phi_n, adjoint, clearFock);
 
         // Apply Helmholtz operators
         H(phi_np1, *args_n);
         delete args_n;
+	if(mpiOrbSize>1)H.clear();
 
-        fock.clear();
+        if(not clearFock) fock.clear();
         orthonormalize(fock, F, phi_np1);
 
         // Compute orbital updates

--- a/src/mrchem/scf_solver/OrbitalOptimizer.cpp
+++ b/src/mrchem/scf_solver/OrbitalOptimizer.cpp
@@ -86,15 +86,15 @@ bool OrbitalOptimizer::optimize() {
         MatrixXd L = H.getLambda().asDiagonal();
 	bool adjoint = false;
 	bool clearFock = false;
-	if(mpiOrbSize>1)clearFock = true;
+	if (mpiOrbSize > 1) clearFock = true;
         OrbitalVector *args_n = setupHelmholtzArguments(fock, L-F, phi_n, adjoint, clearFock);
 
         // Apply Helmholtz operators
         H(phi_np1, *args_n);
         delete args_n;
-	if(mpiOrbSize>1)H.clear();
+        if (mpiOrbSize > 1) H.clear();
 
-        if(not clearFock) fock.clear();
+        if (not clearFock) fock.clear();
         orthonormalize(fock, F, phi_np1);
 
         // Compute orbital updates

--- a/src/mrchem/scf_solver/SCF.h
+++ b/src/mrchem/scf_solver/SCF.h
@@ -66,7 +66,7 @@ protected:
                                                    const Eigen::MatrixXd &M,
                                                    OrbitalVector &phi,
                                                    bool adjoint = false,
-						   bool clearFock = false) = 0;
+                                                   bool clearFock = false) = 0;
 };
 
 

--- a/src/mrchem/scf_solver/SCF.h
+++ b/src/mrchem/scf_solver/SCF.h
@@ -65,7 +65,8 @@ protected:
     virtual OrbitalVector* setupHelmholtzArguments(FockOperator &fock,
                                                    const Eigen::MatrixXd &M,
                                                    OrbitalVector &phi,
-                                                   bool adjoint = false) = 0;
+                                                   bool adjoint = false,
+						   bool clearFock = false) = 0;
 };
 
 

--- a/src/mrcpp/MathUtils.cpp
+++ b/src/mrcpp/MathUtils.cpp
@@ -46,8 +46,9 @@ double MathUtils::matrixNorm2(const MatrixXd &M) {
     Eigen::VectorXd x(size);
     Eigen::VectorXd y(size);
 
+    std::srand(1);
     for (int i = 0; i < maxTry; i++) {
-        y = Eigen::VectorXd::Random(size);
+	y = Eigen::VectorXd::Random(size);
         newNorm = sqrt(y.squaredNorm());
 
         ratio = 0.0;

--- a/src/mrcpp/MathUtils.cpp
+++ b/src/mrcpp/MathUtils.cpp
@@ -48,7 +48,7 @@ double MathUtils::matrixNorm2(const MatrixXd &M) {
 
     std::srand(1);
     for (int i = 0; i < maxTry; i++) {
-	y = Eigen::VectorXd::Random(size);
+        y = Eigen::VectorXd::Random(size);
         newNorm = sqrt(y.squaredNorm());
 
         ratio = 0.0;

--- a/src/mrcpp/constants.h
+++ b/src/mrcpp/constants.h
@@ -6,7 +6,7 @@
 #pragma once
 
 const double MachinePrec = 1.0e-15L;
-const double MachineZero = 1.0e-15L;
+const double MachineZero = 1.0e-13L;
 const int MaxOrder = 41; ///< Maximum scaling order
 const int MaxDepth = 30; ///< Maximum depth of trees
 const int MaxScale = 31; ///< Maximum scale of trees

--- a/src/mrcpp/constants.h
+++ b/src/mrcpp/constants.h
@@ -6,7 +6,7 @@
 #pragma once
 
 const double MachinePrec = 1.0e-15L;
-const double MachineZero = 1.0e-13L;
+const double MachineZero = 1.0e-14L;
 const int MaxOrder = 41; ///< Maximum scaling order
 const int MaxDepth = 30; ///< Maximum depth of trees
 const int MaxScale = 31; ///< Maximum scale of trees


### PR DESCRIPTION
Different changes to use less memory:

1) Compute only own Helmholt operators. Do not attempt to reuse for parallel runs.
2) Rotate exchange orbitals using smaller buffer (workOrbVec)
3) Clear more frequently

Other:
Set  MachineZero = 1.0e-14L, since for "L-F" in setupHelmholtzArguments it was sometimes, above the threshold only because of machine precision limits.

Set a fixed seed in matrixNorm2, so as to get identical results, independently of the method used (mpi and serial runs could give different results because of this in some cases).

Note: With intel 2015 compiler, for large molecules, the code will use huge amounts (>20GB) of extra memory because of a compiler bug! (the memory used, as defined by top for instance, will increase for each call to allocGenChildren. It can look like a stack memory leak, even if there are no leaks according to Valgrind)
