### PR TITLE
parallel improvements

### DIFF
--- a/cmake/compiler_flags/Intel.C.cmake
+++ b/cmake/compiler_flags/Intel.C.cmake
@@ -1,7 +1,7 @@
 if(NOT DEFINED ENV{CFLAGS})
     if(CMAKE_C_COMPILER_ID MATCHES Intel)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
-        set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
+        set(CMAKE_C_FLAGS_RELEASE "-O2 -DNDEBUG")
         set(CMAKE_C_FLAGS_DEBUG "-O0 -g -DDEBUG")
     endif()
 endif()

--- a/cmake/compiler_flags/Intel.CXX.cmake
+++ b/cmake/compiler_flags/Intel.CXX.cmake
@@ -1,7 +1,7 @@
 if(NOT DEFINED ENV{CXXFLAGS})
     if(CMAKE_CXX_COMPILER_ID MATCHES Intel)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas -std=c++11")
-        set(CMAKE_CXX_FLAGS_RELEASE "-debug -O3 -DNDEBUG")
+        set(CMAKE_CXX_FLAGS_RELEASE "-debug -O2 -DNDEBUG")
         set(CMAKE_CXX_FLAGS_DEBUG "-O0 -debug -DDEBUG")
     endif()
 endif()

--- a/src/mrchem/qmfunctions/Density.cpp
+++ b/src/mrchem/qmfunctions/Density.cpp
@@ -17,7 +17,7 @@ Density::Density(bool spin, bool shared)
       dens_a(0),
       dens_b(0) {
     if(shared and mpiShSize>1){
-	this->shMem = new SharedMemory(500);//initiate up to 500MB shared memory
+	this->shMem = new SharedMemory(2000);//initiate up to 2000MB shared memory
     }else{
 	this->setIsShared(false);//at least 2 processes for sharing
     }
@@ -163,7 +163,7 @@ void Density::send_Density(int dest, int tag){
     if(this->dens_b){
 	Densinfo.NchunksBeta = this->beta().getSerialFunctionTree()->nodeChunks.size();//should reduce to actual number of chunks
     }else{Densinfo.NchunksBeta = 0;}
- 
+
 
     int count=sizeof(Metadata);
     MPI_Send(&Densinfo, count, MPI_BYTE, dest, tag, comm);
@@ -206,7 +206,7 @@ void Density::Rcv_Density(int source, int tag){
     if(Densinfo.NchunksBeta>0){
 	if (not this->hasBeta()) this->allocBeta();
 	Rcv_SerialTree(this->dens_b, Densinfo.NchunksBeta, source, tag+30000, comm);}
-  
+
 #endif
 }
 

--- a/src/mrchem/qmfunctions/OrbitalVector.cpp
+++ b/src/mrchem/qmfunctions/OrbitalVector.cpp
@@ -164,7 +164,7 @@ void OrbitalVector::push_back(int n_orbs, int occ, int spin) {
 void OrbitalVector::push_back(Orbital &orb) {
     Orbital *newOrb = new Orbital(orb);
     newOrb->shallowCopy(orb);
-    this->orbitals.push_back(newOrb);	
+    this->orbitals.push_back(newOrb);
 }
 
 /** Remove the last orbital from this set
@@ -173,7 +173,7 @@ void OrbitalVector::push_back(Orbital &orb) {
 void OrbitalVector::pop_back(bool free) {
     this->orbitals[this->size()-1]->clear(free);
     delete this->orbitals[this->size()-1];
-    this->orbitals.pop_back();	
+    this->orbitals.pop_back();
 }
 
 const Orbital& OrbitalVector::getOrbital(int i) const {
@@ -526,7 +526,7 @@ void OrbitalVector::send_OrbVec(int dest, int tag, vector<int> &orbsIx, int star
     Metadata Orbinfo;
 
     Orbinfo.Norbitals = min(this->size() - start, maxcount);
-  
+
     Orbital* orb_i;
     for (int i = start; i < this->size() && (i-start<maxcount); i++) {
 	int i_out=i-start;
@@ -545,14 +545,14 @@ void OrbitalVector::send_OrbVec(int dest, int tag, vector<int> &orbsIx, int star
 
     int count=sizeof(Metadata);
     MPI_Send(&Orbinfo, count, MPI_BYTE, dest, tag, comm);
-  
+
     for (int i = start; i <  this->size() && (i-start<maxcount); i++) {
 	int i_out=i-start;
 	orb_i = &this->getOrbital(i);
 	if(orb_i->hasReal())Send_SerialTree(&orb_i->real(), Orbinfo.NchunksReal[i_out], dest, 2*i_out+1+tag, comm);
 	if(orb_i->hasImag())Send_SerialTree(&orb_i->imag(), Orbinfo.NchunksImag[i_out], dest, 2*i_out+2+tag, comm);
     }
-  
+
 #endif
 }
 
@@ -564,9 +564,9 @@ void OrbitalVector::Isend_OrbVec(int dest, int tag, vector<int> &orbsIx, int sta
     MPI_Comm comm=mpiCommOrb;
 
     Metadata Orbinfo;
- 
+
     Orbinfo.Norbitals = min(this->size() - start, maxcount);
-  
+
     Orbital* orb_i;
     for (int i = start; i < this->size() && (i-start<maxcount); i++) {
 	int i_out=i-start;
@@ -586,7 +586,7 @@ void OrbitalVector::Isend_OrbVec(int dest, int tag, vector<int> &orbsIx, int sta
     int count=sizeof(Metadata);
 
     MPI_Isend(&Orbinfo, count, MPI_BYTE, dest, tag, comm, &request);
-  
+
     for (int i = start; i <  this->size() && (i-start<maxcount); i++) {
 	int i_out=i-start;
 	orb_i = &this->getOrbital(i);
@@ -603,7 +603,7 @@ void OrbitalVector::Rcv_OrbVec(int source, int tag, int *orbsIx, int& workOrbVec
     MPI_Status status;
     MPI_Comm comm=mpiCommOrb;
     OrbitalVector* workOrbVec_p = 0;//pointer to the workOrbVec to use
-  
+
     if(workOrbVec2.inUse){
 	workOrbVec_p = &workOrbVec2;//use workOrbVec2
     }else{
@@ -633,14 +633,14 @@ void OrbitalVector::Rcv_OrbVec(int source, int tag, int *orbsIx, int& workOrbVec
 	orb_i->setSpin(Orbinfo.spin[i]);
 	orb_i->setOccupancy(Orbinfo.occupancy[i]);
 	orb_i->setError(Orbinfo.error[i]);
-    
+
 	if(Orbinfo.NchunksReal[i]>0){
 	    if(not orb_i->hasReal()){
 		//We must have a tree defined for receiving nodes. Define one:
 		orb_i->allocReal();
 	    }
 	    Rcv_SerialTree(&orb_i->real(), Orbinfo.NchunksReal[i], source, 2*i+1+tag, comm);}
-    
+
 	if(Orbinfo.NchunksImag[i]>0){
 	    if(not orb_i->hasImag()){
 		//We must have a tree defined for receiving nodes. Define one:
@@ -655,7 +655,7 @@ void OrbitalVector::Rcv_OrbVec(int source, int tag, int *orbsIx, int& workOrbVec
 	this->getOrbital(workOrbVecIx).shallowCopy(workOrbVec_p->getOrbital(workOrbVecIx));
 	workOrbVecIx++;
     }
-  
+
 #endif
 
 }
@@ -684,7 +684,7 @@ void OrbitalVector::getOrbVecChunk(vector<int> &myOrbsIx, OrbitalVector &rcvOrbs
      * Index of local orbital (owned by the local MPI process). max = maxsizeperOrbvec
      * Chunk iteration. max = (maxsizeperOrbvec*mpiOrbSize +  maxOrbs-1)/maxOrbs
      * For accounting, we assume that all MPI are filled with maxsizeperOrbvec;
-     * this is in order to know where to restart 
+     * this is in order to know where to restart
      * Last iteration is for cleanups: clear send and receive vectors and set workOrbVec flag as available.
      */
 
@@ -698,11 +698,11 @@ void OrbitalVector::getOrbVecChunk(vector<int> &myOrbsIx, OrbitalVector &rcvOrbs
     if(workIx!=0){
 	workOrbVec2.inUse = true;
     }else{
-	workOrbVec2.inUse = false;      
+	workOrbVec2.inUse = false;
     }
 
     if(MPI_iter0>=mpiOrbSize){
-	iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals  
+	iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals
     }
 
     for (int MPI_iter = MPI_iter0;  true; MPI_iter++) {
@@ -710,7 +710,7 @@ void OrbitalVector::getOrbVecChunk(vector<int> &myOrbsIx, OrbitalVector &rcvOrbs
 	if (MPI_iter > MPI_iter0) maxcount = maxOrbs+start0-(MPI_iter-MPI_iter0)*maxsizeperOrbvec;//place left after first iteration
 	if(maxcount<=0) break;
 	if(MPI_iter>=mpiOrbSize){
-	    iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals  
+	    iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals
 	    break;
 	}
 	int rcv_MPI = (mpiOrbSize+MPI_iter-mpiOrbRank)%mpiOrbSize;//rank of process to communicate with
@@ -723,7 +723,7 @@ void OrbitalVector::getOrbVecChunk(vector<int> &myOrbsIx, OrbitalVector &rcvOrbs
 	    rcvOrbs.Rcv_OrbVec(rcv_MPI,MPI_iter, rcvOrbsIx, RcvOrbVecIx);
 	    this->send_OrbVec(rcv_MPI, MPI_iter, myOrbsIx, start, maxcount);
 	}else{
-	    for (int i = start;  i < this->size() && (i-start<maxcount) ; i++){	
+	    for (int i = start;  i < this->size() && (i-start<maxcount) ; i++){
 		rcvOrbsIx[RcvOrbVecIx] = myOrbsIx[i];
 		if(rcvOrbs.size()<=RcvOrbVecIx){
 		    rcvOrbs.push_back(this->getOrbital(i));
@@ -738,7 +738,7 @@ void OrbitalVector::getOrbVecChunk(vector<int> &myOrbsIx, OrbitalVector &rcvOrbs
 }
 
 /** Send and receive a chunk of an OrbitalVector
- * Assumes that a symmetric operator is calculated, so that only 
+ * Assumes that a symmetric operator is calculated, so that only
  * half of the orbitals need to be sent. i.e exactly one of (i,j)or(j,i) is sent.
  * The orbitals are sent and received from different processors.
  * this : Vector with orbitals locally (owned by this MPI process)
@@ -762,15 +762,17 @@ void OrbitalVector::getOrbVecChunk_sym(vector<int> &myOrbsIx, OrbitalVector &rcv
     int RcvOrbVecIx = 0;
 #ifdef HAVE_MPI
 
-    MPI_Request request=MPI_REQUEST_NULL;
-    MPI_Status status;
+    MPI_Request request[mpiOrbSize];
+    for (int i = 0; i < mpiOrbSize; i++) request[i] = MPI_REQUEST_NULL;
+    int nRequests = 0;
+    MPI_Status status[mpiOrbSize];
     /* many index scales:
      * Orbital vector index. max = size
      * MPI_iter index. The iteration count through all MPI processes. max = mpiOrbSize
      * Index of local orbital (owned by the local MPI process). max = maxsizeperOrbvec
      * Chunk iteration. max = (maxsizeperOrbvec*mpiOrbSize + maxOrbs-1)/maxOrbs
      * For accounting, we assume that all MPI are filled with maxsizeperOrbvec;
-     * this is in order to know where to restart 
+     * this is in order to know where to restart
      */
 
     int MPI_iter0 = (iter0*maxOrbs)/maxsizeperOrbvec;//which MPI_iter to start with
@@ -782,11 +784,11 @@ void OrbitalVector::getOrbVecChunk_sym(vector<int> &myOrbsIx, OrbitalVector &rcv
     if(workIx!=0){
 	workOrbVec2.inUse = true;
     }else{
-	workOrbVec2.inUse = false;      
+	workOrbVec2.inUse = false;
     }
- 
+
     if(MPI_iter0 >= (mpiOrbSize/2 + 1) ){
-	iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals  
+	iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals
     }
 
     int isnd=0;
@@ -795,7 +797,7 @@ void OrbitalVector::getOrbVecChunk_sym(vector<int> &myOrbsIx, OrbitalVector &rcv
 	if (MPI_iter > MPI_iter0) maxcount = maxOrbs+start0-(MPI_iter-MPI_iter0)*maxsizeperOrbvec;//place left
 	if(maxcount <= 0)  break;//chunk is full
 	if(MPI_iter >= (mpiOrbSize/2 + 1) ){
-	    iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals  
+	    iter0=-2;//to indicate that we are finished with receiving AND sending all orbitals
 	    break;
 	}
 	int rcv_MPI = abs((mpiOrbSize-MPI_iter+mpiOrbRank)%mpiOrbSize);//rank of process to receive from
@@ -814,14 +816,14 @@ void OrbitalVector::getOrbVecChunk_sym(vector<int> &myOrbsIx, OrbitalVector &rcv
 		    sndOrbIx[isnd]=myOrbsIx[i];
 		    isnd++;
 		}
-		this->Isend_OrbVec(snd_MPI, MPI_iter, myOrbsIx, start, maxcount, request);
+		this->Isend_OrbVec(snd_MPI, MPI_iter, myOrbsIx, start, maxcount, request[nRequests++]);
 	    }
 	    if(rcv_MPI>=0){
 		rcvOrbs.Rcv_OrbVec(rcv_MPI, MPI_iter, rcvOrbsIx, RcvOrbVecIx);
 	    }
 	}else{
 	    //own orbitals
-	    for (int i = start;  i < this->size() && (i-start<maxcount) ; i++){	
+	    for (int i = start;  i < this->size() && (i-start<maxcount) ; i++){
 		rcvOrbsIx[RcvOrbVecIx] = myOrbsIx[i];
 		if(rcvOrbs.size()<=RcvOrbVecIx){
 		    rcvOrbs.push_back(this->getOrbital(i));
@@ -833,6 +835,6 @@ void OrbitalVector::getOrbVecChunk_sym(vector<int> &myOrbsIx, OrbitalVector &rcv
 	}
 	start = 0;//always start at 0 after first iteration
     }
-    MPI_Wait(&request, &status);//wait only for last request
+    MPI_Waitall(nRequests,request, status);
 #endif
 }

--- a/src/mrchem/qmoperators/CoulombOperator.h
+++ b/src/mrchem/qmoperators/CoulombOperator.h
@@ -9,7 +9,8 @@ public:
         : poisson(&P),
           orbitals(&phi),
 #ifdef HAVE_MPI
-          density(false, true){//Use shared memory. 
+	density(false, true){//Use shared memory.
+	//          density(false, false){//do not Use shared memory.
 #else
           density(false) {
 #endif

--- a/src/mrcpp/mwtrees/GenNode.h
+++ b/src/mrcpp/mwtrees/GenNode.h
@@ -49,6 +49,9 @@ protected:
     }
 
     virtual void dealloc() {
+#ifdef HAVE_OPENMP
+	omp_destroy_lock(&this->node_lock);
+#endif
         this->tree->decrementGenNodeCount();
         this->tree->getSerialTree()->deallocGenNodes(this->getSerialIx());
     }

--- a/src/mrcpp/mwtrees/MWNode.cpp
+++ b/src/mrcpp/mwtrees/MWNode.cpp
@@ -540,7 +540,7 @@ void MWNode<D>::deleteChildren() {
 
 template<int D>
 void MWNode<D>::deleteGenerated() {
-    if (this->isBranchNode()) {      
+    if (this->isBranchNode()) {
         if (this->isEndNode()) {
             this->deleteChildren();
         } else {
@@ -802,14 +802,17 @@ MWNode<D> *MWNode<D>::retrieveNode(const double *r, int depth) {
         return this;
     }
     assert(hasCoord(r));
-    // If we have reached an endNode, lock if necessary, and start generating
-    // NB! retrieveNode() for GenNodes behave a bit differently.
-    SET_NODE_LOCK();
+    //we add this "if" for performance only. Avoids having to set/unset locks and queue unnecessarily
     if (this->isLeafNode()) {
-        genChildren();
-        giveChildrenCoefs();
-   }
-    UNSET_NODE_LOCK();
+	// If we have reached an endNode, lock if necessary, and start generating
+	// NB! retrieveNode() for GenNodes behave a bit differently.
+	SET_NODE_LOCK();
+	if (this->isLeafNode()) {
+	    genChildren();
+	    giveChildrenCoefs();
+	}
+	UNSET_NODE_LOCK();
+    }
     int cIdx = getChildIndex(r);
     assert(this->children[cIdx] != 0);
     return this->children[cIdx]->retrieveNode(r, depth);

--- a/src/mrcpp/mwtrees/OperatorNode.h
+++ b/src/mrcpp/mwtrees/OperatorNode.h
@@ -38,6 +38,9 @@ protected:
     double calcComponentNorm(int i) const;
 
     void dealloc() {
+#ifdef HAVE_OPENMP
+	omp_destroy_lock(&this->node_lock);
+#endif
         this->tree->decrementNodeCount(this->getScale());
         this->tree->getSerialTree()->deallocNodes(this->getSerialIx());
     }

--- a/src/mrcpp/mwtrees/ProjectedNode.h
+++ b/src/mrcpp/mwtrees/ProjectedNode.h
@@ -27,6 +27,9 @@ protected:
     virtual ~ProjectedNode() { assert(this->tree == 0); }
 
     void dealloc() {
+#ifdef HAVE_OPENMP
+        omp_destroy_lock(&this->node_lock);
+#endif
         this->tree->decrementNodeCount(this->getScale());
         this->tree->getSerialTree()->deallocNodes(this->getSerialIx());
     }


### PR DESCRIPTION
1) OMP memory leak 
2) MPI_Waitall: should fix [issue 56](https://github.com/MRChemSoft/mrchem/issues/56) 
3) Changed compiler optimization flag from O3 to O2. O3 was giving Bus errors sometimes (seldom and randomly) in big calculations. O2 does not seem to go slower.
4) Added a "if(isLeafNode)" in retrieveNode. This is to avoid setting and unsetting locks and queuing when there is nothing to wait for.
5) Increased the size of shared memory to 2000MB. 500MB was not enough for 161 orbitals systems.
( 6. my editor now remove trailing white space automatically )

With these changes, a HF calculation can be performed on ch4_020 (81 orbitals) on 9 compute-nodes or ch4_040 (161 orbitals) on 27 compute-nodes (relprec 1E-6). Localized orbitals must be used for minimizing memory and CPU usage. 1 MPI and 20 OMP per compute-node is recommended.
Though scf orbitals did not completely converge to 1E-3 (2 of the 81 orbitals not yet converged after 10 iterations)
  