### PR TITLE
repaired merge

### DIFF
--- a/src/mrcpp/mwtrees/GenNode.h
+++ b/src/mrcpp/mwtrees/GenNode.h
@@ -49,9 +49,6 @@ protected:
     }
 
     virtual void dealloc() {
-#ifdef HAVE_OPENMP
-	omp_destroy_lock(&this->node_lock);
-#endif
         this->tree->decrementGenNodeCount();
         this->tree->getSerialTree()->deallocGenNodes(this->getSerialIx());
     }

--- a/src/mrcpp/mwtrees/OperatorNode.h
+++ b/src/mrcpp/mwtrees/OperatorNode.h
@@ -38,9 +38,6 @@ protected:
     double calcComponentNorm(int i) const;
 
     void dealloc() {
-#ifdef HAVE_OPENMP
-	omp_destroy_lock(&this->node_lock);
-#endif
         this->tree->decrementNodeCount(this->getScale());
         this->tree->getSerialTree()->deallocNodes(this->getSerialIx());
     }

--- a/src/mrcpp/mwtrees/ProjectedNode.h
+++ b/src/mrcpp/mwtrees/ProjectedNode.h
@@ -27,9 +27,6 @@ protected:
     virtual ~ProjectedNode() { assert(this->tree == 0); }
 
     void dealloc() {
-#ifdef HAVE_OPENMP
-        omp_destroy_lock(&this->node_lock);
-#endif
         this->tree->decrementNodeCount(this->getScale());
         this->tree->getSerialTree()->deallocNodes(this->getSerialIx());
     }


### PR DESCRIPTION
The pull request "removed node_lock" did not merge correctly with "parallel improvements".
In the  "removed node_lock", the "node_lock destroy" introduced in "parallel improvements" was removed again, but something went wrong in the merge process.
This pull request removed the "node_lock destroy" again.
