### PR TITLE
Add missing include and link to compile MRChem with BLAS.

### DIFF
--- a/src/mrcpp/mwtrees/MWNode.cpp
+++ b/src/mrcpp/mwtrees/MWNode.cpp
@@ -10,6 +10,12 @@
 #include "GenNode.h"
 #include "Timer.h"
 
+#ifdef HAVE_BLAS
+extern "C" {
+#include BLAS_H
+}
+#endif
+
 using namespace std;
 using namespace Eigen;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,4 +22,5 @@ target_link_libraries(unit_tests.x
     mwtrees
     mwoperators
     mwbuilders
+    ${BLAS_LIBRARIES}
 )


### PR DESCRIPTION
This pull request adds a missing CBLAS header include and BLAS library link so that MRChem can be built with BLAS.