### PR TITLE
Use normal BLAS instead of CBLAS.

### DIFF
--- a/cmake/custom/blas.cmake
+++ b/cmake/custom/blas.cmake
@@ -1,7 +1,14 @@
-option(BLAS_H "CBLAS header file" "")
-if(BLAS_H)
+option(ENABLE_BLAS "Enable use of BLAS? (Requires a Fortran compiler)" OFF)
+if(ENABLE_BLAS)
   include(FindBLAS)
   if(BLAS_FOUND)
     set(HAVE_BLAS 1)
+    # Get symbol names
+    enable_language(Fortran)
+    include(FortranCInterface)
+    FortranCInterface_HEADER(FCMangle.h
+      MACRO_NAMESPACE "FC_"
+      SYMBOL_NAMESPACE "FC_"
+      SYMBOLS dgemm ddot)
   endif(BLAS_FOUND)
-endif(BLAS_H)
+endif(ENABLE_BLAS)

--- a/cmake/custom/doxygen.cmake
+++ b/cmake/custom/doxygen.cmake
@@ -1,5 +1,5 @@
 find_package(Doxygen)
 
 if(DOXYGEN_FOUND)
-    add_subdirectory(doc EXCLUDE_FROM_ALL)
+#    add_subdirectory(doc EXCLUDE_FROM_ALL)
 endif()

--- a/src/mrcpp/MathUtils.cpp
+++ b/src/mrcpp/MathUtils.cpp
@@ -7,12 +7,7 @@
 #include "constants.h"
 #include "parallel.h"
 #include "eigen_disable_warnings.h"
-
-#ifdef HAVE_BLAS
-extern "C" {
-#include BLAS_H
-}
-#endif
+#include "blas.h"
 
 using namespace std;
 using namespace Eigen;
@@ -262,9 +257,8 @@ void MathUtils::applyFilter(double *out, double *in,
                             const MatrixXd &filter,
                             int kp1, int kp1_dm1, double fac) {
 #ifdef HAVE_BLAS
-    cblas_dgemm(CblasColMajor, CblasTrans, CblasNoTrans,
-                kp1_dm1, kp1, kp1, 1.0, in, kp1, filter.data(),
-                kp1, fac, out, kp1_dm1);
+  dgemm('t', 'n', kp1_dm1, kp1, kp1, 1.0, in, kp1, filter.data(),
+        kp1, fac, out, kp1_dm1);
 #else
     Eigen::Map<MatrixXd> f(in, kp1, kp1_dm1);
     Eigen::Map<MatrixXd> g(out, kp1_dm1, kp1);

--- a/src/mrcpp/blas.h
+++ b/src/mrcpp/blas.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#ifdef HAVE_BLAS
+#include "FCMangle.h"
+
+// Fortran function template
+extern "C" {
+void FC_dgemm(char * transa, char * transb, int * m, int * n, int * k, double * alpha, const double *a, int * lda, const double *b, int * ldb, double * beta, double *c, int * ldc);
+}
+
+// C wrapper
+inline void dgemm(char transa, char transb, int m, int n, int k, double alpha, const double *a, int lda, const double *b, int ldb, double beta, double *c, int ldc) {
+  FC_dgemm(&transa, &transb, &m, &n, &k, &alpha, (double *) a, &lda, (double *) b, &ldb, &beta, c, &ldc);
+}
+
+// Fortran function template
+extern "C" {
+double FC_ddot(int * n, double * dx, int * incx, double * dy, int * incy);
+}
+
+// C wrapper
+inline double ddot(int n, const double *dx, int incx, const double *dy, int incy) {
+  // Fortran takes values by reference
+  return FC_ddot(&n, (double *) dx, &incx, (double *) dy, &incy);
+}
+#endif

--- a/src/mrcpp/mwbuilders/ConvolutionCalculator.cpp
+++ b/src/mrcpp/mwbuilders/ConvolutionCalculator.cpp
@@ -6,12 +6,7 @@
 #include "BandWidth.h"
 #include "Timer.h"
 #include "eigen_disable_warnings.h"
-
-#ifdef HAVE_BLAS
-extern "C" {
-#include BLAS_H
-}
-#endif
+#include "blas.h"
 
 using namespace std;
 using namespace Eigen;
@@ -316,9 +311,8 @@ void ConvolutionCalculator<D>::tensorApplyOperComp(OperatorState<D> &os) {
             }
             const double *f = aux[i];
             double *g = const_cast<double *>(aux[i + 1]);
-            cblas_dgemm(CblasColMajor, CblasTrans, CblasNoTrans,
-                    os.kp1_dm1, os.kp1, os.kp1, 1.0, f,
-                    os.kp1, oData[i], os.kp1, mult, g, os.kp1_dm1);
+            dgemm('t', 'n', os.kp1_dm1, os.kp1, os.kp1, 1.0, f,
+                  os.kp1, oData[i], os.kp1, mult, g, os.kp1_dm1);
         } else {
             // Identity operator in direction i
             Map<MatrixXd> f(aux[i], os.kp1, os.kp1_dm1);

--- a/src/mrcpp/mwbuilders/DerivativeCalculator.cpp
+++ b/src/mrcpp/mwbuilders/DerivativeCalculator.cpp
@@ -6,12 +6,7 @@
 #include "BandWidth.h"
 #include "Timer.h"
 #include "eigen_disable_warnings.h"
-
-#ifdef HAVE_BLAS
-extern "C" {
-#include BLAS_H
-}
-#endif
+#include "blas.h"
 
 using namespace std;
 using namespace Eigen;
@@ -203,9 +198,8 @@ void DerivativeCalculator<D>::tensorApplyOperComp(OperatorState<D> &os) {
             }
             const double *f = aux[i];
             double *g = const_cast<double *>(aux[i + 1]);
-            cblas_dgemm(CblasColMajor, CblasTrans, CblasNoTrans,
-                    os.kp1_dm1, os.kp1, os.kp1, 1.0, f,
-                    os.kp1, oData[i], os.kp1, mult, g, os.kp1_dm1);
+            dgemm('t', 'n', os.kp1_dm1, os.kp1, os.kp1, 1.0, f,
+                  os.kp1, oData[i], os.kp1, mult, g, os.kp1_dm1);
         } else {
             // Identity operator in direction i
             Map<MatrixXd> f(aux[i], os.kp1, os.kp1_dm1);

--- a/src/mrcpp/mwtrees/FunctionNode.cpp
+++ b/src/mrcpp/mwtrees/FunctionNode.cpp
@@ -2,12 +2,7 @@
 #include "FunctionTree.h"
 #include "MathUtils.h"
 #include "QuadratureCache.h"
-
-#ifdef HAVE_BLAS
-extern "C" {
-#include BLAS_H
-}
-#endif
+#include "blas.h"
 
 using namespace std;
 using namespace Eigen;
@@ -287,7 +282,7 @@ double FunctionNode<D>::dotScaling(const FunctionNode<D> &ket) const {
 
     int size = bra.getKp1_d();
 #ifdef HAVE_BLAS
-    return cblas_ddot(size, a, 1, b, 1);
+    return ddot(size, a, 1, b, 1);
 #else
     double result = 0.0;
     for (int i = 0; i < size; i++) {
@@ -319,7 +314,7 @@ double FunctionNode<D>::dotWavelet(const FunctionNode<D> &ket) const {
     int start = bra.getKp1_d();
     int size = (bra.getTDim() - 1) * start;
 #ifdef HAVE_BLAS
-    return cblas_ddot(size, &a[start], 1, &b[start], 1);
+    return ddot(size, &a[start], 1, &b[start], 1);
 #else
     double result = 0.0;
     for (int i = 0; i < size; i++) {

--- a/src/mrcpp/mwtrees/MWNode.cpp
+++ b/src/mrcpp/mwtrees/MWNode.cpp
@@ -9,12 +9,7 @@
 #include "QuadratureCache.h"
 #include "GenNode.h"
 #include "Timer.h"
-
-#ifdef HAVE_BLAS
-extern "C" {
-#include BLAS_H
-}
-#endif
+#include "blas.h"
 
 using namespace std;
 using namespace Eigen;
@@ -434,7 +429,7 @@ double MWNode<D>::calcComponentNorm(int i) const {
 
     double sq_norm = 0.0;
 #ifdef HAVE_BLAS
-    sq_norm = cblas_ddot(size, &c[start], 1, &c[start], 1);
+    sq_norm = ddot(size, &c[start], 1, &c[start], 1);
 #else
     for (int i = start; i < start+size; i++) {
         sq_norm += c[i]*c[i];


### PR DESCRIPTION
This pull request implements a wrapper for ddot and dgemv so that BLAS detection works out of the box.

If you need 64-bit interface support, that can be done just by customizing the headers in blas.h.