### PR TITLE
Remove cblas calls, use EIGEN_USE_BLAS instead.

### DIFF
--- a/cmake/custom/blas.cmake
+++ b/cmake/custom/blas.cmake
@@ -1,7 +1,8 @@
-option(BLAS_H "CBLAS header file" "")
-if(BLAS_H)
+option(ENABLE_BLAS "Enable use of BLAS? (Requires a Fortran compiler)" OFF)
+if(ENABLE_BLAS)
   include(FindBLAS)
   if(BLAS_FOUND)
-    set(HAVE_BLAS 1)
+    # Enable BLAS in Eigen
+    add_definitions(-DEIGEN_USE_BLAS)
   endif(BLAS_FOUND)
-endif(BLAS_H)
+endif(ENABLE_BLAS)

--- a/config.h.in
+++ b/config.h.in
@@ -4,12 +4,10 @@
 
 #define MW_FILTER_DIR "@MW_FILTER_DIR@"
 
-#define BLAS_H "@BLAS_H@"
-
 #cmakedefine HAVE_MPI
 
 #cmakedefine HAVE_OPENMP
 
-#cmakedefine HAVE_BLAS
+#cmakedefine EIGEN_USE_BLAS
 
 #cmakedefine HAVE_XCFUN

--- a/src/mrchem/MREnv.cpp
+++ b/src/mrchem/MREnv.cpp
@@ -50,10 +50,10 @@ void MREnv::initializeMRCPP(int argc, char **argv) {
     println(0,endl);
     println(0,"Print level  : " <<  printlevel << endl);
 
-#ifdef HAVE_BLAS
-    println(0, "BLAS was found!" << endl);
+#ifdef EIGEN_USE_BLAS
+    println(0, "BLAS used in Eigen3" << endl);
 #else
-    println(0, "BLAS was NOT found, Eigen will be used instead!" << endl);
+    println(0, "BLAS is NOT used in Eigen3!" << endl);
 #endif
 
     if (mpiOrbSize > 1 or nThreads > 1) {

--- a/src/mrcpp/MathUtils.cpp
+++ b/src/mrcpp/MathUtils.cpp
@@ -8,12 +8,6 @@
 #include "parallel.h"
 #include "eigen_disable_warnings.h"
 
-#ifdef HAVE_BLAS
-extern "C" {
-#include BLAS_H
-}
-#endif
-
 using namespace std;
 using namespace Eigen;
 
@@ -261,11 +255,6 @@ VectorXd MathUtils::getBinomialCoefs(unsigned int order) {
 void MathUtils::applyFilter(double *out, double *in,
                             const MatrixXd &filter,
                             int kp1, int kp1_dm1, double fac) {
-#ifdef HAVE_BLAS
-    cblas_dgemm(CblasColMajor, CblasTrans, CblasNoTrans,
-                kp1_dm1, kp1, kp1, 1.0, in, kp1, filter.data(),
-                kp1, fac, out, kp1_dm1);
-#else
     Eigen::Map<MatrixXd> f(in, kp1, kp1_dm1);
     Eigen::Map<MatrixXd> g(out, kp1_dm1, kp1);
     if (fac < MachineZero) {
@@ -273,7 +262,6 @@ void MathUtils::applyFilter(double *out, double *in,
     } else {
         g += f.transpose() * filter;
     }
-#endif
 }
 
 /** Make a nD-representation from 1D-representations of separable functions.

--- a/src/mrcpp/mwbuilders/ConvolutionCalculator.cpp
+++ b/src/mrcpp/mwbuilders/ConvolutionCalculator.cpp
@@ -7,12 +7,6 @@
 #include "Timer.h"
 #include "eigen_disable_warnings.h"
 
-#ifdef HAVE_BLAS
-extern "C" {
-#include BLAS_H
-}
-#endif
-
 using namespace std;
 using namespace Eigen;
 
@@ -307,32 +301,6 @@ template<int D>
 void ConvolutionCalculator<D>::tensorApplyOperComp(OperatorState<D> &os) {
     double **aux = os.getAuxData();
     double **oData = os.getOperData();
-#ifdef HAVE_BLAS
-    double mult = 0.0;
-    for (int i = 0; i < D; i++) {
-        if (oData[i] != 0) {
-            if (i == D - 1) { // Last dir: Add up into g
-                mult = 1.0;
-            }
-            const double *f = aux[i];
-            double *g = const_cast<double *>(aux[i + 1]);
-            cblas_dgemm(CblasColMajor, CblasTrans, CblasNoTrans,
-                    os.kp1_dm1, os.kp1, os.kp1, 1.0, f,
-                    os.kp1, oData[i], os.kp1, mult, g, os.kp1_dm1);
-        } else {
-            // Identity operator in direction i
-            Map<MatrixXd> f(aux[i], os.kp1, os.kp1_dm1);
-            Map<MatrixXd> g(aux[i + 1], os.kp1_dm1, os.kp1);
-            if (oData[i] == 0) {
-                if (i == D - 1) { // Last dir: Add up into g
-                    g += f.transpose();
-                } else {
-                    g = f.transpose();
-                }
-            }
-        }
-    }
-#else
     for (int i = 0; i < D; i++) {
         Map<MatrixXd> f(aux[i], os.kp1, os.kp1_dm1);
         Map<MatrixXd> g(aux[i + 1], os.kp1_dm1, os.kp1);
@@ -352,7 +320,6 @@ void ConvolutionCalculator<D>::tensorApplyOperComp(OperatorState<D> &os) {
             }
         }
     }
-#endif
 }
 
 template<int D>

--- a/src/mrcpp/mwbuilders/DerivativeCalculator.cpp
+++ b/src/mrcpp/mwbuilders/DerivativeCalculator.cpp
@@ -7,12 +7,6 @@
 #include "Timer.h"
 #include "eigen_disable_warnings.h"
 
-#ifdef HAVE_BLAS
-extern "C" {
-#include BLAS_H
-}
-#endif
-
 using namespace std;
 using namespace Eigen;
 
@@ -194,32 +188,6 @@ template<int D>
 void DerivativeCalculator<D>::tensorApplyOperComp(OperatorState<D> &os) {
     double **aux = os.getAuxData();
     double **oData = os.getOperData();
-#ifdef HAVE_BLAS
-    double mult = 0.0;
-    for (int i = 0; i < D; i++) {
-        if (oData[i] != 0) {
-            if (i == D - 1) { // Last dir: Add up into g
-                mult = 1.0;
-            }
-            const double *f = aux[i];
-            double *g = const_cast<double *>(aux[i + 1]);
-            cblas_dgemm(CblasColMajor, CblasTrans, CblasNoTrans,
-                    os.kp1_dm1, os.kp1, os.kp1, 1.0, f,
-                    os.kp1, oData[i], os.kp1, mult, g, os.kp1_dm1);
-        } else {
-            // Identity operator in direction i
-            Map<MatrixXd> f(aux[i], os.kp1, os.kp1_dm1);
-            Map<MatrixXd> g(aux[i + 1], os.kp1_dm1, os.kp1);
-            if (oData[i] == 0) {
-                if (i == D - 1) { // Last dir: Add up into g
-                    g += f.transpose();
-                } else {
-                    g = f.transpose();
-                }
-            }
-        }
-    }
-#else
     for (int i = 0; i < D; i++) {
         Map<MatrixXd> f(aux[i], os.kp1, os.kp1_dm1);
         Map<MatrixXd> g(aux[i + 1], os.kp1_dm1, os.kp1);
@@ -239,7 +207,6 @@ void DerivativeCalculator<D>::tensorApplyOperComp(OperatorState<D> &os) {
             }
         }
     }
-#endif
 }
 
 template<int D>

--- a/src/mrcpp/mwtrees/FunctionNode.cpp
+++ b/src/mrcpp/mwtrees/FunctionNode.cpp
@@ -3,12 +3,6 @@
 #include "MathUtils.h"
 #include "QuadratureCache.h"
 
-#ifdef HAVE_BLAS
-extern "C" {
-#include BLAS_H
-}
-#endif
-
 using namespace std;
 using namespace Eigen;
 
@@ -286,15 +280,11 @@ double FunctionNode<D>::dotScaling(const FunctionNode<D> &ket) const {
     const double *b = ket.getCoefs();
 
     int size = bra.getKp1_d();
-#ifdef HAVE_BLAS
-    return cblas_ddot(size, a, 1, b, 1);
-#else
     double result = 0.0;
     for (int i = 0; i < size; i++) {
         result += a[i]*b[i];
     }
     return result;
-#endif
 }
 
 /** Inner product of the functions represented by the wavelet basis of the nodes.
@@ -318,15 +308,11 @@ double FunctionNode<D>::dotWavelet(const FunctionNode<D> &ket) const {
 
     int start = bra.getKp1_d();
     int size = (bra.getTDim() - 1) * start;
-#ifdef HAVE_BLAS
-    return cblas_ddot(size, &a[start], 1, &b[start], 1);
-#else
     double result = 0.0;
     for (int i = 0; i < size; i++) {
         result += a[start+i]*b[start+i];
     }
     return result;
-#endif
 }
 
 template<int D>

--- a/src/mrcpp/mwtrees/MWNode.cpp
+++ b/src/mrcpp/mwtrees/MWNode.cpp
@@ -10,12 +10,6 @@
 #include "GenNode.h"
 #include "Timer.h"
 
-#ifdef HAVE_BLAS
-extern "C" {
-#include BLAS_H
-}
-#endif
-
 using namespace std;
 using namespace Eigen;
 
@@ -433,13 +427,9 @@ double MWNode<D>::calcComponentNorm(int i) const {
     int start = i*size;
 
     double sq_norm = 0.0;
-#ifdef HAVE_BLAS
-    sq_norm = cblas_ddot(size, &c[start], 1, &c[start], 1);
-#else
     for (int i = start; i < start+size; i++) {
         sq_norm += c[i]*c[i];
     }
-#endif
     return sqrt(sq_norm);
 }
 


### PR DESCRIPTION
As requested in #81, this is a pull request that eliminates CBLAS in favor of BLAS support inside Eigen3.

Note that to actually compile the code against the present version of Eigen3, you need to address a bug in Eigen3 by adding a missing include statement
```
$ hg diff
diff -r 3a08a093adac Eigen/src/Core/products/TriangularMatrixMatrix_BLAS.h
--- a/Eigen/src/Core/products/TriangularMatrixMatrix_BLAS.h     Mon Apr 09 13:29:26 2018 +0200
+++ b/Eigen/src/Core/products/TriangularMatrixMatrix_BLAS.h     Tue Apr 10 15:51:12 2018 +0300
@@ -33,6 +33,8 @@
 #ifndef EIGEN_TRIANGULAR_MATRIX_MATRIX_BLAS_H
 #define EIGEN_TRIANGULAR_MATRIX_MATRIX_BLAS_H

+#include "../../misc/blas.h"
+
 namespace Eigen {

 namespace internal {

```