### PR TITLE
Reimplementing external field

### DIFF
--- a/src/SCFDriver.cpp
+++ b/src/SCFDriver.cpp
@@ -381,7 +381,7 @@ void SCFDriver::setup() {
     fock = new FockOperator(T, V);
     // For Hartree, HF and DFT we need the coulomb part
     if (wf_method == "Hartree" or wf_method == "HF" or wf_method == "DFT") {
-        J = new CoulombOperator(*P, *phi);
+        J = new CoulombOperator(P, phi);
         fock->setCoulombOperator(J);
     }
     // For HF we need the full HF exchange
@@ -397,7 +397,7 @@ void SCFDriver::setup() {
     //For DFT we need the XC operator
     if (wf_method == "DFT") {
         mrcpp::DerivativeOperator<3> * der_dft = 0;
-        xcfun = new XCFunctional(dft_spin, dft_explicit_der, dft_cutoff, *phi, useDerivative(diff_dft));
+        xcfun = new mrdft::XCFunctional(*MRA, dft_spin); //, dft_use_gamma, dft_cutoff, *phi, useDerivative(diff_dft));
         for (int i = 0; i < dft_func_names.size(); i++) {
             xcfun->setFunctional(dft_func_names[i], dft_func_coefs[i]);
         }

--- a/src/SCFDriver.cpp
+++ b/src/SCFDriver.cpp
@@ -396,12 +396,7 @@ void SCFDriver::setup() {
     }
     //For DFT we need the XC operator
     if (wf_method == "DFT") {
-        mrcpp::DerivativeOperator<3> * der_dft = 0;
-        xcfun = new mrdft::XCFunctional(*MRA, dft_spin); //, dft_use_gamma, dft_cutoff, *phi, useDerivative(diff_dft));
-        for (int i = 0; i < dft_func_names.size(); i++) {
-            xcfun->setFunctional(dft_func_names[i], dft_func_coefs[i]);
-        }
-        std::cout << "and here 0" << std::endl;
+        xcfun = setupFunctional(1);
         XC = new XCOperator(xcfun, phi);
         fock->setXCOperator(XC);
     }
@@ -915,4 +910,23 @@ void SCFDriver::setupInitialGrid(mrdft::XCFunctional &func, const Molecule &mol)
     Printer::printFooter(0, timer, 2);
 }
 
+    /** @brief helper routine to set up the correct parameters in the functional before using it
+     *
+     * param[in] order the requested order of the derivative (order=1 for SCF)
+     *
+     */
+
+mrdft::XCFunctional* SCFDriver::setupFunctional(int order) {
+    mrdft::XCFunctional* fun = new mrdft::XCFunctional(*MRA, dft_spin);
+    for (int i = 0; i < dft_func_names.size(); i++) {
+        fun->setFunctional(dft_func_names[i], dft_func_coefs[i]);
+    }
+    fun->setUseGamma(dft_use_gamma);
+    fun->setDensityCutoff(dft_cutoff);
+    fun->evalSetup(order);
+    setupInitialGrid(*fun, *molecule);
+    return fun;
+}
+    
 } //namespace mrchem
+

--- a/src/SCFDriver.cpp
+++ b/src/SCFDriver.cpp
@@ -52,6 +52,7 @@ SCFDriver::SCFDriver(Getkw &input) {
 
     gauge = input.getDblVec("MRA.gauge_origin");
     center_of_mass = input.get<bool>("MRA.center_of_mass");
+    center_of_charge = input.get<bool>("MRA.center_of_charge");
 
     diff_kin = input.get<string>("Derivatives.kinetic");
     diff_orb = input.get<string>("Derivatives.h_orb");
@@ -243,6 +244,7 @@ bool SCFDriver::sanityCheck() const {
 void SCFDriver::setup() {
     // Setting up molecule
     molecule = new Molecule(mol_coords, mol_charge, mol_multiplicity);
+    molecule->printGeometry();
     nuclei = &molecule->getNuclei();
 
     // Setting up empty orbitals
@@ -250,7 +252,12 @@ void SCFDriver::setup() {
 
     // Defining gauge origin
     const double *COM = molecule->getCenterOfMass();
+    const double *COC = molecule->getCenterOfCharge();
     if (center_of_mass) {
+        r_O[0] = COM[0];
+        r_O[1] = COM[1];
+        r_O[2] = COM[2];
+    } else if (center_of_charge) {
         r_O[0] = COM[0];
         r_O[1] = COM[1];
         r_O[2] = COM[2];

--- a/src/SCFDriver.cpp
+++ b/src/SCFDriver.cpp
@@ -6,6 +6,8 @@
 #include "MRCPP/Printer"
 #include "MRCPP/Timer"
 #include "Getkw.h"
+#include "Section.h"
+#include "Keyword.h"
 
 #include "initial_guess/core.h"
 #include "initial_guess/gto.h"
@@ -120,6 +122,15 @@ SCFDriver::SCFDriver(Getkw &input) {
     rsp_directions = input.getIntVec("Response.directions");
     rsp_orbital_prec = input.getDblVec("Response.orbital_prec");
 
+    ext_electric = input.getKeyword<vector<double> >("ExternalField.electric_field").isDefined();
+    ext_magnetic = input.getKeyword<vector<double> >("ExternalField.electric_field").isDefined();
+    if (ext_electric) {
+        ext_electric_field = input.getDblVec("ExternalField.electric_field");
+    }
+    if (ext_magnetic) {
+        ext_magnetic_field = input.getDblVec("ExternalField.magnetic_field");
+    }
+    
     file_start_orbitals = input.get<string>("Files.start_orbitals");
     file_final_orbitals = input.get<string>("Files.final_orbitals");
     file_basis_set = input.get<string>("Files.basis_set");

--- a/src/SCFDriver.cpp
+++ b/src/SCFDriver.cpp
@@ -258,9 +258,9 @@ void SCFDriver::setup() {
         r_O[1] = COM[1];
         r_O[2] = COM[2];
     } else if (center_of_charge) {
-        r_O[0] = COM[0];
-        r_O[1] = COM[1];
-        r_O[2] = COM[2];
+        r_O[0] = COC[0];
+        r_O[1] = COC[1];
+        r_O[2] = COC[2];
     } else {
         r_O[0] = gauge[0];
         r_O[1] = gauge[1];

--- a/src/SCFDriver.cpp
+++ b/src/SCFDriver.cpp
@@ -122,8 +122,8 @@ SCFDriver::SCFDriver(Getkw &input) {
     rsp_directions = input.getIntVec("Response.directions");
     rsp_orbital_prec = input.getDblVec("Response.orbital_prec");
 
-    ext_electric = input.getKeyword<vector<double> >("ExternalField.electric_field").isDefined();
-    ext_magnetic = input.getKeyword<vector<double> >("ExternalField.electric_field").isDefined();
+    ext_electric = input.get<bool>("ExternalField.electric_run");
+    ext_magnetic = input.get<bool>("ExternalField.magnetic_run");
     if (ext_electric) {
         ext_electric_field = input.getDblVec("ExternalField.electric_field");
     }

--- a/src/SCFDriver.h
+++ b/src/SCFDriver.h
@@ -89,6 +89,7 @@ protected:
 
     // World input
     bool center_of_mass;
+    bool center_of_charge;
     std::vector<double> gauge;
 
     // Derivative operators

--- a/src/SCFDriver.h
+++ b/src/SCFDriver.h
@@ -212,7 +212,7 @@ protected:
     CoulombOperator *J;
     ExchangeOperator *K;
     XCOperator *XC;
-    RankZeroTensorOperator *Vext;
+    ElectricFieldOperator *Vext;
     FockOperator *fock;
     ComplexMatrix F;
 
@@ -266,6 +266,8 @@ protected:
     void printEigenvalues(OrbitalVector &orbs, ComplexMatrix &f_mat);
 
     void extendRotationMatrix(const OrbitalVector &orbs, ComplexMatrix &O);
+
+    mrcpp::DerivativeOperator<3>* useDerivative(string derivative_name);
 };
 
 } //namespace mrchem

--- a/src/SCFDriver.h
+++ b/src/SCFDriver.h
@@ -248,6 +248,7 @@ protected:
     void calcGroundStateProperties();
     void calcLinearResponseProperties(const ResponseCalculation &rsp_calc);
 
+    mrdft::XCFunctional* setupFunctional(int order);
     void setupInitialGrid(mrdft::XCFunctional &func, const Molecule &mol);
     void setupInitialGroundState();
     void setupPerturbedOperators(const ResponseCalculation &rsp_calc);

--- a/src/SCFDriver.h
+++ b/src/SCFDriver.h
@@ -212,6 +212,7 @@ protected:
     CoulombOperator *J;
     ExchangeOperator *K;
     XCOperator *XC;
+    RankZeroTensorOperator *Vext;
     FockOperator *fock;
     ComplexMatrix F;
 

--- a/src/SCFDriver.h
+++ b/src/SCFDriver.h
@@ -168,6 +168,12 @@ protected:
     std::vector<int> rsp_directions;
     std::vector<double> rsp_orbital_prec;
 
+    // External field input
+    bool ext_electric;
+    bool ext_magnetic;
+    std::vector<double> ext_electric_field;
+    std::vector<double> ext_magnetic_field;
+    
     // File input
     std::string file_start_orbitals;
     std::string file_final_orbitals;

--- a/src/SCFDriver.h
+++ b/src/SCFDriver.h
@@ -29,7 +29,9 @@ class KineticOperator;
 class NuclearOperator;
 class ExchangeOperator;
 class XCOperator;
-
+class XCFunctional;
+class ElectricFieldOperator;
+class MagneticFieldOperator;
 
 class ResponseCalculation  final {
 public:
@@ -171,8 +173,8 @@ protected:
     // External field input
     bool ext_electric;
     bool ext_magnetic;
-    std::vector<double> ext_electric_field;
-    std::vector<double> ext_magnetic_field;
+    Eigen::Vector3d ext_electric_field;
+    Eigen::Vector3d ext_magnetic_field;
     
     // File input
     std::string file_start_orbitals;

--- a/src/chemistry/CMakeLists.txt
+++ b/src/chemistry/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(mrchem PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/chem_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/PeriodicTable.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/Molecule.cpp
     )

--- a/src/chemistry/Molecule.cpp
+++ b/src/chemistry/Molecule.cpp
@@ -441,23 +441,23 @@ void Molecule::calcCenterOfMass() {
 }
 
 /** @brief Compute nuclear center of charge */
-void Molecule::calcCenterOfMass() {
+void Molecule::calcCenterOfCharge() {
     this->COC[0] = 0.0;
     this->COC[1] = 0.0;
     this->COC[2] = 0.0;
 
-    double M = 0.0;
+    double Z = 0.0;
     for (int i = 0; i < getNNuclei(); i++) {
         const Nucleus &nuc = getNucleus(i);
         const double *r_i = nuc.getCoord();
-        const double z_i = nuc.getElement().getCharge();
+        const double z_i = nuc.getElement().getZ();
         for (int d = 0; d < 3; d++) {
             this->COM[d] += r_i[d] * z_i;
         }
-        M += m_i;
+        Z += z_i;
     }
     for (int d = 0; d < 3; d++) {
-        this->COC[d] *= 1.0/M;
+        this->COC[d] *= 1.0/Z;
     }
 }
 

--- a/src/chemistry/Molecule.cpp
+++ b/src/chemistry/Molecule.cpp
@@ -34,6 +34,7 @@ Molecule::Molecule(const Nuclei &nucs, int c, int m)
           hfcc(0),
           sscc(0) {
     calcCenterOfMass();
+    calcCenterOfCharge();
     allocNuclearProperties();
 }
 
@@ -57,6 +58,7 @@ Molecule::Molecule(const std::string &coord_file, int c, int m)
           sscc(0) {
     readCoordinateFile(coord_file);
     calcCenterOfMass();
+    calcCenterOfCharge();
     allocNuclearProperties();
 }
 
@@ -80,6 +82,7 @@ Molecule::Molecule(const std::vector<std::string> &coord_str, int c, int m)
           sscc(0) {
     readCoordinateString(coord_str);
     calcCenterOfMass();
+    calcCenterOfCharge();
     allocNuclearProperties();
 }
 

--- a/src/chemistry/Molecule.cpp
+++ b/src/chemistry/Molecule.cpp
@@ -440,6 +440,27 @@ void Molecule::calcCenterOfMass() {
     }
 }
 
+/** @brief Compute nuclear center of charge */
+void Molecule::calcCenterOfMass() {
+    this->COC[0] = 0.0;
+    this->COC[1] = 0.0;
+    this->COC[2] = 0.0;
+
+    double M = 0.0;
+    for (int i = 0; i < getNNuclei(); i++) {
+        const Nucleus &nuc = getNucleus(i);
+        const double *r_i = nuc.getCoord();
+        const double z_i = nuc.getElement().getCharge();
+        for (int d = 0; d < 3; d++) {
+            this->COM[d] += r_i[d] * z_i;
+        }
+        M += m_i;
+    }
+    for (int d = 0; d < 3; d++) {
+        this->COC[d] *= 1.0/M;
+    }
+}
+
 /** @brief Read nuclear coordinates from xyz file
  *
  * First entry in file is number of atoms:

--- a/src/chemistry/Molecule.h
+++ b/src/chemistry/Molecule.h
@@ -48,6 +48,7 @@ public:
     int getNElectrons() const;
 
     const double *getCenterOfMass() const { return this->COM; }
+    const double *getCenterOfCharge() const { return this->COC; }
 
     Nuclei &getNuclei() { return this->nuclei; }
     const Nuclei &getNuclei() const { return this->nuclei; }
@@ -84,6 +85,7 @@ protected:
 
     // Properties
     double COM[3];
+    double COC[3];
     SCFEnergy *energy;
     DipoleMoment *dipole;
     QuadrupoleMoment *quadrupole;
@@ -95,6 +97,7 @@ protected:
     std::vector<OpticalRotation *> optical_rotation;
 
     void calcCenterOfMass();
+    void calcCenterOfCharge();
 
     void allocNuclearProperties();
     void freeNuclearProperties();

--- a/src/chemistry/chem_utils.cpp
+++ b/src/chemistry/chem_utils.cpp
@@ -1,0 +1,35 @@
+#include <csignal>
+#include <iostream>
+#include <cstdlib>
+#include "Nucleus.h"
+#include "math_utils.h"
+#include "chem_utils.h"
+
+namespace mrchem {
+extern mrcpp::MultiResolutionAnalysis<3> *MRA; // Global MRA
+
+/** @brief computes the repulsion self energy of a set of nuclei
+ * 
+ * @param[in] nucs the set of nuclei
+ *
+ */    
+double compute_nuclear_repulsion(const Nuclei &nucs) {
+    int nNucs = nucs.size();
+    double E_nuc = 0.0;
+    for (int i = 0; i < nNucs; i++) {
+        const Nucleus &nuc_i = nucs[i];
+        const double Z_i = nuc_i.getCharge();
+        const double *R_i = nuc_i.getCoord();
+        for (int j = i+1; j < nNucs; j++) {
+            const Nucleus &nuc_j = nucs[j];
+            const double Z_j = nuc_j.getCharge();
+            const double *R_j = nuc_j.getCoord();
+            double R_ij = math_utils::calc_distance(R_i, R_j);
+            E_nuc += (Z_i*Z_j)/R_ij;
+        }
+    }
+    return E_nuc;
+}
+
+    
+} //namespace mrchem

--- a/src/chemistry/chem_utils.h
+++ b/src/chemistry/chem_utils.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "mrchem.h"
+
+class Molecule;
+class Nuclei;
+
+namespace mrchem {
+
+double compute_nuclear_repulsion(const Nuclei &nucs);
+
+} //namespace mrchem

--- a/src/mrchem.in
+++ b/src/mrchem.in
@@ -169,6 +169,11 @@ def setup_keywords():
     properties.add_kw('hyperfine_coupling',     'BOOL', False)
     top.add_sect(properties)
 
+    external_field=getkw.Section('ExternalField', callback=verify_ext_field)
+    external_field.add_kw('electric_field',     'DBL_ARRAY') 
+    external_field.add_kw('magnetic_field',     'DBL_ARRAY') 
+    top.add_sect(external_field)
+
     polarizability=getkw.Section('Polarizability', callback=verify_pol)
     polarizability.add_kw('velocity',           'BOOL', False)
     polarizability.add_kw('frequency',          'DBL_ARRAY')
@@ -330,6 +335,28 @@ def verify_response(rsp):
     if rsp['property_thrs'][0] < 0:
         rsp['property_thrs'][0] = 1.0
 
+def verify_ext_field(ext_field):
+    if ext_field.get('electric_field').is_set():
+        len_e = len(ext_field['electric_field'].get())
+        if (len_e != 3):
+            print "invalid length of electric field vector:", len_e
+            exit()
+        for i in range(3):
+            val = abs(ext_field['electric_field'][i])
+            if val > 10.0 or val < 1.0e-10:
+                print "magnitude of el. field component ", i, "is out of range [1.0e-10 - 10.0]:", val
+                exit()
+    if ext_field.get('magnetic_field').is_set():
+        len_m = len(ext_field['magnetic_field'].get())
+        if (len_m != 3):
+            print "invalid length of magnetic field vector:", len_m
+            exit()
+        for i in range(3):
+            val = abs(ext_field['magnetic_field'][i])
+            if val > 10.0 or val < 1.0e-10:
+                print "magnitude of mag. field component ", i, "is out of range [1.0e-10 - 10.0]", val
+                exit()
+    
 def verify_pol(pol):
     if pol.get('wavelength').is_set():
         for wlength in pol['wavelength'].get():

--- a/src/mrchem.in
+++ b/src/mrchem.in
@@ -170,7 +170,9 @@ def setup_keywords():
     top.add_sect(properties)
 
     external_field=getkw.Section('ExternalField', callback=verify_ext_field)
+    external_field.add_kw('electric_run',       'BOOL', False)
     external_field.add_kw('electric_field',     'DBL_ARRAY') 
+    external_field.add_kw('magnetic_run',       'BOOL', False)
     external_field.add_kw('magnetic_field',     'DBL_ARRAY') 
     top.add_sect(external_field)
 

--- a/src/mrchem.in
+++ b/src/mrchem.in
@@ -124,6 +124,7 @@ def setup_keywords():
     mra.add_kw('boxes',                 'INT_ARRAY', [1, 1, 1])
     mra.add_kw('corner',                'INT_ARRAY', [0, 0, 0])
     mra.add_kw('center_of_mass',        'BOOL', False)
+    mra.add_kw('center_of_charge',      'BOOL', False)
     mra.add_kw('gauge_origin',          'DBL_ARRAY', [0.0, 0.0, 0.0])
     top.add_sect(mra)
 

--- a/src/mrchem.in
+++ b/src/mrchem.in
@@ -339,26 +339,25 @@ def verify_response(rsp):
 
 def verify_ext_field(ext_field):
     if ext_field.get('electric_field').is_set():
-        len_e = len(ext_field['electric_field'].get())
-        if (len_e != 3):
-            print "invalid length of electric field vector:", len_e
+        elf = ext_field['electric_field'].get()
+        if (len(elf) != 3):
+            print "invalid length of electric field vector:", len(elf)
             exit()
-        for i in range(3):
-            val = abs(ext_field['electric_field'][i])
-            if val > 10.0 or val < 1.0e-10:
-                print "magnitude of el. field component ", i, "is out of range [1.0e-10 - 10.0]:", val
-                exit()
+        val = math.sqrt(elf[0]**2 + elf[1]**2 + elf[2]**2)
+        if val > 10.0 or val < 1.0e-10:
+            print "magnitude of el. field is out of range [1.0e-10 - 10.0]:", val
+            exit()
+            
     if ext_field.get('magnetic_field').is_set():
-        len_m = len(ext_field['magnetic_field'].get())
-        if (len_m != 3):
-            print "invalid length of magnetic field vector:", len_m
+        maf = ext_field['magnetic_field'].get()
+        if (len(maff) != 3):
+            print "invalid length of magnetic field vector:", len(maf)
             exit()
-        for i in range(3):
-            val = abs(ext_field['magnetic_field'][i])
-            if val > 10.0 or val < 1.0e-10:
-                print "magnitude of mag. field component ", i, "is out of range [1.0e-10 - 10.0]", val
-                exit()
-    
+        val = math.sqrt(maf[0]**2 + maf[1]**2 + maf[2]**2)
+        if val > 10.0 or val < 1.0e-10:
+            print "magnitude of mag. field is out of range [1.0e-10 - 10.0]:", val
+            exit()
+
 def verify_pol(pol):
     if pol.get('wavelength').is_set():
         for wlength in pol['wavelength'].get():

--- a/src/mrchem.in
+++ b/src/mrchem.in
@@ -344,8 +344,8 @@ def verify_ext_field(ext_field):
             print "invalid length of electric field vector:", len(elf)
             exit()
         val = math.sqrt(elf[0]**2 + elf[1]**2 + elf[2]**2)
-        if val > 10.0 or val < 1.0e-10:
-            print "magnitude of el. field is out of range [1.0e-10 - 10.0]:", val
+        if val > 10.0:
+            print "magnitude of el. field is greater than 10.0:", val
             exit()
             
     if ext_field.get('magnetic_field').is_set():
@@ -354,8 +354,8 @@ def verify_ext_field(ext_field):
             print "invalid length of magnetic field vector:", len(maf)
             exit()
         val = math.sqrt(maf[0]**2 + maf[1]**2 + maf[2]**2)
-        if val > 10.0 or val < 1.0e-10:
-            print "magnitude of mag. field is out of range [1.0e-10 - 10.0]:", val
+        if val > 10.0:
+            print "magnitude of mag. field is greater than 10.0:", val
             exit()
 
 def verify_pol(pol):

--- a/src/properties/SCFEnergy.h
+++ b/src/properties/SCFEnergy.h
@@ -16,9 +16,10 @@ class SCFEnergy final {
 public:
     SCFEnergy(double nuc = 0.0, double el = 0.0, double orb = 0.0,
               double kin = 0.0, double en = 0.0, double ee = 0.0,
-              double xc = 0.0, double x = 0.0, double ext = 0.0) :
+              double xc = 0.0, double x = 0.0, double nex = 0.0,
+              double ext = 0.0) :
         E_nuc(nuc), E_el(el), E_orb(orb), E_kin(kin), E_en(en),
-        E_ee(ee), E_x(x), E_xc(xc), E_ext(ext){ }
+        E_ee(ee), E_x(x), E_xc(xc), E_nex(nex), E_ext(ext){ }
 
     double getTotalEnergy() const { return this->E_nuc + this->E_el; }
     double getNuclearEnergy() const { return this->E_nuc; }
@@ -48,7 +49,8 @@ public:
         o << " Coulomb energy:              " << std::setw(29) << en.E_ee   << std::endl;
         o << " Exchange energy:             " << std::setw(29) << en.E_x    << std::endl;
         o << " X-C energy:                  " << std::setw(29) << en.E_xc   << std::endl;
-        o << " External field energy:       " << std::setw(29) << en.E_ext  << std::endl;
+        o << " El. External field energy:   " << std::setw(29) << en.E_ext  << std::endl;
+        o << " Nuc. External field energy:  " << std::setw(29) << en.E_nex  << std::endl;
         o << "                                                            " << std::endl;
         o << "------------------------------------------------------------" << std::endl;
         o << "                                                            " << std::endl;
@@ -78,6 +80,7 @@ protected:
     double E_ee;
     double E_x;
     double E_xc;
+    double E_nex;
     double E_ext;
 };
 

--- a/src/properties/SCFEnergy.h
+++ b/src/properties/SCFEnergy.h
@@ -14,12 +14,11 @@ namespace mrchem {
 
 class SCFEnergy final {
 public:
-    SCFEnergy(double nuc = 0.0, double el = 0.0,
-              double orb = 0.0, double kin = 0.0,
-              double en = 0.0,  double ee = 0.0,
-              double xc = 0.0,  double x = 0.0) :
-        E_nuc(nuc), E_el(el), E_orb(orb), E_kin(kin),
-        E_en(en), E_ee(ee), E_x(x), E_xc(xc){ }
+    SCFEnergy(double nuc = 0.0, double el = 0.0, double orb = 0.0,
+              double kin = 0.0, double en = 0.0, double ee = 0.0,
+              double xc = 0.0, double x = 0.0, double ext = 0.0) :
+        E_nuc(nuc), E_el(el), E_orb(orb), E_kin(kin), E_en(en),
+        E_ee(ee), E_x(x), E_xc(xc), E_ext(ext){ }
 
     double getTotalEnergy() const { return this->E_nuc + this->E_el; }
     double getNuclearEnergy() const { return this->E_nuc; }
@@ -49,6 +48,7 @@ public:
         o << " Coulomb energy:              " << std::setw(29) << en.E_ee   << std::endl;
         o << " Exchange energy:             " << std::setw(29) << en.E_x    << std::endl;
         o << " X-C energy:                  " << std::setw(29) << en.E_xc   << std::endl;
+        o << " External field energy:       " << std::setw(29) << en.E_ext  << std::endl;
         o << "                                                            " << std::endl;
         o << "------------------------------------------------------------" << std::endl;
         o << "                                                            " << std::endl;
@@ -78,6 +78,7 @@ protected:
     double E_ee;
     double E_x;
     double E_xc;
+    double E_ext;
 };
 
 } //namespace mrchem

--- a/src/qmoperators/RankZeroTensorOperator.h
+++ b/src/qmoperators/RankZeroTensorOperator.h
@@ -36,6 +36,9 @@ namespace mrchem {
 // Convenience typedef
 typedef std::vector<QMOperator *> QMOperatorVector;
 
+class Nucleus;
+class Nuclei;
+ 
 class RankZeroTensorOperator {
 public:
     RankZeroTensorOperator() { }
@@ -60,7 +63,7 @@ public:
 
     ComplexDouble trace(OrbitalVector &Phi);
     ComplexDouble trace(OrbitalVector &Phi, OrbitalVector &X, OrbitalVector &Y);
-
+    
     RankZeroTensorOperator& operator=(QMOperator &O);
     RankZeroTensorOperator& operator+=(QMOperator &O);
     RankZeroTensorOperator& operator-=(QMOperator &O);

--- a/src/qmoperators/one_electron/ElectricFieldOperator.h
+++ b/src/qmoperators/one_electron/ElectricFieldOperator.h
@@ -24,7 +24,7 @@ public:
         RankZeroTensorOperator &d_z = this->dipole[2];
 
         RankZeroTensorOperator &HEF = (*this);
-        HEF = 0.5*(f[0]*d_x + f[1]*d_y + f[2]*d_z);
+        HEF = f[0]*d_x + f[1]*d_y + f[2]*d_z;
     }
 
 protected:

--- a/src/qmoperators/one_electron/ElectricFieldOperator.h
+++ b/src/qmoperators/one_electron/ElectricFieldOperator.h
@@ -27,10 +27,27 @@ public:
         HEF = f[0]*d_x + f[1]*d_y + f[2]*d_z;
     }
 
-protected:
+    ComplexDouble trace(const Nuclei &nucs) {
+        ComplexDouble result = 0.0;
+        for (int k = 0; k < nucs.size(); k++) {
+            result += trace(nucs[k]);
+        }
+        return result;
+    }
+
+    ComplexDouble trace(const Nucleus &nuc) {
+        ComplexDouble val = dipole.trace(nuc).dot(field);
+        std::cout << "Dipole val " << val << std::endl;
+        return val;
+    }
+
+    using RankZeroTensorOperator::trace;
+
+ protected:
     Eigen::Vector3d field;
     H_E_dip dipole;
     
+
 };
 
 } //namespace mrchem

--- a/src/qmoperators/one_electron/ElectricFieldOperator.h
+++ b/src/qmoperators/one_electron/ElectricFieldOperator.h
@@ -36,7 +36,7 @@ public:
     }
 
     ComplexDouble trace(const Nucleus &nuc) {
-        return dipole.trace(nuc).dot(field);
+        return - dipole.trace(nuc).dot(field);
     }
 
     using RankZeroTensorOperator::trace;

--- a/src/qmoperators/one_electron/ElectricFieldOperator.h
+++ b/src/qmoperators/one_electron/ElectricFieldOperator.h
@@ -24,7 +24,7 @@ public:
         RankZeroTensorOperator &d_z = this->dipole[2];
 
         RankZeroTensorOperator &HEF = (*this);
-        HEF = f[0]*d_x + f[1]*d_y + f[2]*d_z;
+        HEF = + f[0]*d_x + f[1]*d_y + f[2]*d_z;
     }
 
     ComplexDouble trace(const Nuclei &nucs) {
@@ -36,9 +36,7 @@ public:
     }
 
     ComplexDouble trace(const Nucleus &nuc) {
-        ComplexDouble val = dipole.trace(nuc).dot(field);
-        std::cout << "Dipole val " << val << std::endl;
-        return val;
+        return dipole.trace(nuc).dot(field);
     }
 
     using RankZeroTensorOperator::trace;

--- a/src/qmoperators/one_electron/ElectricFieldOperator.h
+++ b/src/qmoperators/one_electron/ElectricFieldOperator.h
@@ -11,10 +11,17 @@
  * moment. The operator is simply implemented as a scalar product of
  * the dipole moment operator with the electric field vector.
  *
+ * It implements also explicit trace functions for the nuclear contributions
+ *
  */
 
 namespace mrchem {
 
+/** @brief constructor
+ *
+ * @param[in] f the external electric field
+ *
+ */
 class ElectricFieldOperator final : public RankZeroTensorOperator {
 public:
  ElectricFieldOperator(const Eigen::Vector3d &f)
@@ -27,6 +34,12 @@ public:
         HEF = - f[0]*d_x - f[1]*d_y - f[2]*d_z;
     }
 
+/** @brief returns the total nuclear contribution to the interaction
+ * energy
+ *
+ * @param[in] the set of nuclei
+ *
+ */
     ComplexDouble trace(const Nuclei &nucs) {
         ComplexDouble result = 0.0;
         for (int k = 0; k < nucs.size(); k++) {
@@ -35,6 +48,12 @@ public:
         return result;
     }
 
+/** @brief returns contribution to the interaction energy from a
+ * single nucleus
+ *
+ * @param[in] the nucleus
+ *
+ */
     ComplexDouble trace(const Nucleus &nuc) {
         return - dipole.trace(nuc).dot(field);
     }
@@ -42,8 +61,8 @@ public:
     using RankZeroTensorOperator::trace;
 
  protected:
-    Eigen::Vector3d field;
-    H_E_dip dipole;
+    Eigen::Vector3d field; ///< the external field vector 
+    H_E_dip dipole; ///< the dipole moment operator
     
 
 };

--- a/src/qmoperators/one_electron/ElectricFieldOperator.h
+++ b/src/qmoperators/one_electron/ElectricFieldOperator.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "RankZeroTensorOperator.h"
+#include "H_E_dip.h"
+
+/** @class ElectricFieldOperator
+ *
+ * @brief External electric field operator
+ *
+ * An external electric field interacts with the molecular dipole
+ * moment. The operator is simply implemented as a scalar product of
+ * the dipole moment operator with the electric field vector.
+ *
+ */
+
+namespace mrchem {
+
+class ElectricFieldOperator final : public RankZeroTensorOperator {
+public:
+ ElectricFieldOperator(Eigen::Vector3D f)
+     : field(f) {
+        RankZeroTensorOperator &d_x = this->dipole[0];
+        RankZeroTensorOperator &d_y = this->dipole[1];
+        RankZeroTensorOperator &d_z = this->dipole[2];
+
+        RankZeroTensorOperator &HEF = (*this);
+        HEF = 0.5*(f[0]*d_x + f[1]*d_y + f[2]*d_z);
+    }
+
+protected:
+    Eigen::Vector3D field;
+    H_E_dip dipole;
+    
+};
+
+} //namespace mrchem

--- a/src/qmoperators/one_electron/ElectricFieldOperator.h
+++ b/src/qmoperators/one_electron/ElectricFieldOperator.h
@@ -24,7 +24,7 @@ public:
         RankZeroTensorOperator &d_z = this->dipole[2];
 
         RankZeroTensorOperator &HEF = (*this);
-        HEF = + f[0]*d_x + f[1]*d_y + f[2]*d_z;
+        HEF = - f[0]*d_x - f[1]*d_y - f[2]*d_z;
     }
 
     ComplexDouble trace(const Nuclei &nucs) {

--- a/src/qmoperators/one_electron/ElectricFieldOperator.h
+++ b/src/qmoperators/one_electron/ElectricFieldOperator.h
@@ -17,7 +17,7 @@ namespace mrchem {
 
 class ElectricFieldOperator final : public RankZeroTensorOperator {
 public:
- ElectricFieldOperator(Eigen::Vector3D f)
+ ElectricFieldOperator(const Eigen::Vector3d &f)
      : field(f) {
         RankZeroTensorOperator &d_x = this->dipole[0];
         RankZeroTensorOperator &d_y = this->dipole[1];
@@ -28,7 +28,7 @@ public:
     }
 
 protected:
-    Eigen::Vector3D field;
+    Eigen::Vector3d field;
     H_E_dip dipole;
     
 };

--- a/src/qmoperators/one_electron/H_E_dip.h
+++ b/src/qmoperators/one_electron/H_E_dip.h
@@ -7,7 +7,15 @@ namespace mrchem {
 
 class H_E_dip final : public PositionOperator {
 public:
-    H_E_dip(const double *o = 0) : PositionOperator(o) { }
+    H_E_dip(const double *o = 0) : PositionOperator(o) { 
+        RankOneTensorOperator<3> &h = (*this);
+        h[0] = (*this)[0];
+        h[1] = (*this)[1];
+        h[2] = (*this)[2];
+        h[0] = -1.0 * h[0];
+        h[1] = -1.0 * h[1];
+        h[2] = -1.0 * h[2];
+    }
     ~H_E_dip() { }
 
     ComplexVector trace(const Nuclei &nucs) {
@@ -21,9 +29,9 @@ public:
         ComplexVector result = ComplexVector::Zero(3);
         double Z = nuc.getCharge();
         const double *R = nuc.getCoord();
-        result(0) = -Z*this->r_x.real().evalf(R);
-        result(1) = -Z*this->r_y.real().evalf(R);
-        result(2) = -Z*this->r_z.real().evalf(R);
+        result(0) = Z*this->r_x.real().evalf(R);
+        result(1) = Z*this->r_y.real().evalf(R);
+        result(2) = Z*this->r_z.real().evalf(R);
         return result;
     }
 

--- a/src/qmoperators/one_electron/H_E_dip.h
+++ b/src/qmoperators/one_electron/H_E_dip.h
@@ -24,12 +24,9 @@ class H_E_dip final : public PositionOperator {
 public:
     H_E_dip(const double *o = 0) : PositionOperator(o) { 
         RankOneTensorOperator<3> &h = (*this);
-        h[0] = (*this)[0];
-        h[1] = (*this)[1];
-        h[2] = (*this)[2];
-        h[0] = -1.0 * h[0];
-        h[1] = -1.0 * h[1];
-        h[2] = -1.0 * h[2];
+        h[0] = -1.0 * (*this)[0];
+        h[1] = -1.0 * (*this)[1];
+        h[2] = -1.0 * (*this)[2];
     }
     ~H_E_dip() { }
 

--- a/src/qmoperators/one_electron/H_E_dip.h
+++ b/src/qmoperators/one_electron/H_E_dip.h
@@ -3,8 +3,23 @@
 #include "PositionOperator.h"
 #include "Nucleus.h"
 
+/** Class H_E_dip 
+ *
+ * @brief Electric dipole operator
+ *
+ * The operator is based on the PositionOperator. The sign is coherent
+ * with nuclear and electronic charges. It impleents explicit trace
+ * functions for the nuclear contributions.
+ *
+ */
+
 namespace mrchem {
 
+/** @brief constructor
+ *
+ * @param[in] o the origin wrt which the dipole moment is computed.
+ *
+ */
 class H_E_dip final : public PositionOperator {
 public:
     H_E_dip(const double *o = 0) : PositionOperator(o) { 
@@ -18,6 +33,11 @@ public:
     }
     ~H_E_dip() { }
 
+/** @brief returns the nuclear contribution to the dipole moment
+ *
+ * @param[in] the set of nuclei
+ *
+ */
     ComplexVector trace(const Nuclei &nucs) {
         ComplexVector result = ComplexVector::Zero(3);
         for (int k = 0; k < nucs.size(); k++) {
@@ -25,6 +45,12 @@ public:
         }
         return result;
     }
+
+/** @brief returns the contribution to the dipole moment 
+ *
+ * @param[in] the nucleus
+ *
+ */
     ComplexVector trace(const Nucleus &nuc) {
         ComplexVector result = ComplexVector::Zero(3);
         double Z = nuc.getCharge();

--- a/src/qmoperators/one_electron/MagneticFieldOperator.h
+++ b/src/qmoperators/one_electron/MagneticFieldOperator.h
@@ -15,7 +15,7 @@
 
 namespace mrchem {
 
-class MagneticFieldOperator final : public RankZeroTensorOperator {
+class MagneticFieldOperator final : public ExternalFieldOperator {
 public:
  MagneticFieldOperator(const Eigen::Vector3d &f, mrcpp::DerivativeOperator<3> &D, const double *o = 0)
      : field(f), dipole(D, o) {
@@ -25,6 +25,14 @@ public:
 
         RankZeroTensorOperator &HMF = (*this);
         HMF = f[0]*d_x + f[1]*d_y + f[2]*d_z;
+    }
+    
+    ComplexDouble trace(const Nuclei &nucs) {
+        return 0.0;
+    }
+
+    ComplexDouble trace(const Nucleus &nuc) {
+        return 0.0;
     }
 
 protected:

--- a/src/qmoperators/one_electron/MagneticFieldOperator.h
+++ b/src/qmoperators/one_electron/MagneticFieldOperator.h
@@ -24,7 +24,7 @@ public:
         RankZeroTensorOperator &d_z = this->dipole[2];
 
         RankZeroTensorOperator &HMF = (*this);
-        HMF = 0.5*(f[0]*d_x + f[1]*d_y + f[2]*d_z);
+        HMF = f[0]*d_x + f[1]*d_y + f[2]*d_z;
     }
 
 protected:

--- a/src/qmoperators/one_electron/MagneticFieldOperator.h
+++ b/src/qmoperators/one_electron/MagneticFieldOperator.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "RankZeroTensorOperator.h"
+#include "H_B_dip.h"
+
+/** @class MagneticFieldOperator
+ *
+ * @brief External magnetic field operator
+ *
+ * An external magnetic field interacts with the molecular dipole
+ * moment. The operator is simply implemented as a scalar product of
+ * the dipole moment operator with the magnetic field vector.
+ *
+ */
+
+namespace mrchem {
+
+class MagneticFieldOperator final : public RankZeroTensorOperator {
+public:
+ MagneticFieldOperator(Eigen::Vector3D f)
+     : field(f) {
+        RankZeroTensorOperator &d_x = this->dipole[0];
+        RankZeroTensorOperator &d_y = this->dipole[1];
+        RankZeroTensorOperator &d_z = this->dipole[2];
+
+        RankZeroTensorOperator &HMF = (*this);
+        HMF = 0.5*(f[0]*d_x + f[1]*d_y + f[2]*d_z);
+    }
+
+protected:
+    Eigen::Vector3D field;
+    H_B_dip dipole;
+    
+};
+
+} //namespace mrchem

--- a/src/qmoperators/one_electron/MagneticFieldOperator.h
+++ b/src/qmoperators/one_electron/MagneticFieldOperator.h
@@ -17,8 +17,8 @@ namespace mrchem {
 
 class MagneticFieldOperator final : public RankZeroTensorOperator {
 public:
- MagneticFieldOperator(Eigen::Vector3D f)
-     : field(f) {
+ MagneticFieldOperator(const Eigen::Vector3d &f, mrcpp::DerivativeOperator<3> &D, const double *o = 0)
+     : field(f), dipole(D, o) {
         RankZeroTensorOperator &d_x = this->dipole[0];
         RankZeroTensorOperator &d_y = this->dipole[1];
         RankZeroTensorOperator &d_z = this->dipole[2];
@@ -28,7 +28,7 @@ public:
     }
 
 protected:
-    Eigen::Vector3D field;
+    Eigen::Vector3d field;
     H_B_dip dipole;
     
 };

--- a/src/qmoperators/one_electron/NuclearOperator.cpp
+++ b/src/qmoperators/one_electron/NuclearOperator.cpp
@@ -1,5 +1,6 @@
 #include "MRCPP/Printer"
 #include "MRCPP/Timer"
+#include "utils/math_utils.h"
 
 #include "NuclearOperator.h"
 
@@ -59,12 +60,11 @@ void NuclearPotential::clear() {
     clearApplyPrec(); // apply_prec = -1
 }
 
-    /** @brief computes the repulsion self energy of a set of nuclei
-     * 
-     * @param[in] nucs the set of nuclei
-     *
-     */
-    
+/** @brief computes the repulsion self energy of a set of nuclei
+ * 
+ * @param[in] nucs the set of nuclei
+ *
+ */    
 double NuclearOperator::trace(const Nuclei &nucs) {
     int nNucs = nucs.size();
     double E_nuc = 0.0;

--- a/src/qmoperators/one_electron/NuclearOperator.cpp
+++ b/src/qmoperators/one_electron/NuclearOperator.cpp
@@ -60,27 +60,24 @@ void NuclearPotential::clear() {
     clearApplyPrec(); // apply_prec = -1
 }
 
-/** @brief computes the repulsion self energy of a set of nuclei
+/** @brief computes the interaction energy of the nuclear potential with a second set of nuclei.
  * 
  * @param[in] nucs the set of nuclei
  *
+ * Note: this function is not suited to compute the nuclear self-energy
+ *
  */    
 double NuclearOperator::trace(const Nuclei &nucs) {
+    MSG_WARN("This routine has never been tested!")
     int nNucs = nucs.size();
     double E_nuc = 0.0;
     for (int i = 0; i < nNucs; i++) {
-        for (int j = i+1; j < nNucs; j++) {
-            const Nucleus &nuc_i = nucs[i];
-            const Nucleus &nuc_j = nucs[j];
-            double Z_i = nuc_i.getCharge();
-            double Z_j = nuc_j.getCharge();
-            const double *R_i = nuc_i.getCoord();
-                const double *R_j = nuc_j.getCoord();
-                double R_ij = math_utils::calc_distance(R_i, R_j);
-                E_nuc += (Z_i*Z_j)/R_ij;
-        }
+        const Nucleus &nuc_i = nucs[i];
+        double Z_i = nuc_i.getCharge();
+        const double *R_i = nuc_i.getCoord();
+        E_nuc += Z_i*this->r_m1.evalf(R_i);
     }
     return E_nuc;
 }
-
+    
 } //namespace mrchem

--- a/src/qmoperators/one_electron/NuclearOperator.cpp
+++ b/src/qmoperators/one_electron/NuclearOperator.cpp
@@ -59,4 +59,28 @@ void NuclearPotential::clear() {
     clearApplyPrec(); // apply_prec = -1
 }
 
+    /** @brief computes the repulsion self energy of a set of nuclei
+     * 
+     * @param[in] nucs the set of nuclei
+     *
+     */
+    
+double NuclearOperator::trace(const Nuclei &nucs) {
+    int nNucs = nucs.size();
+    double E_nuc = 0.0;
+    for (int i = 0; i < nNucs; i++) {
+        for (int j = i+1; j < nNucs; j++) {
+            const Nucleus &nuc_i = nucs[i];
+            const Nucleus &nuc_j = nucs[j];
+            double Z_i = nuc_i.getCharge();
+            double Z_j = nuc_j.getCharge();
+            const double *R_i = nuc_i.getCoord();
+                const double *R_j = nuc_j.getCoord();
+                double R_ij = math_utils::calc_distance(R_i, R_j);
+                E_nuc += (Z_i*Z_j)/R_ij;
+        }
+    }
+    return E_nuc;
+}
+
 } //namespace mrchem

--- a/src/qmoperators/one_electron/NuclearOperator.h
+++ b/src/qmoperators/one_electron/NuclearOperator.h
@@ -33,7 +33,11 @@ public:
     Nuclei &getNuclei() { return this->r_m1.getNuclei(); }
     const Nuclei &getNuclei() const { return this->r_m1.getNuclei(); }
 
-protected:
+    double trace(const Nuclei &nucs); 
+
+    using RankZeroTensorOperator::trace;
+    
+ protected:
     NuclearPotential r_m1;
 };
 

--- a/src/qmoperators/one_electron/NuclearOperator.h
+++ b/src/qmoperators/one_electron/NuclearOperator.h
@@ -16,7 +16,8 @@ public:
 
     Nuclei &getNuclei() { return this->func.getNuclei(); }
     const Nuclei &getNuclei() const { return this->func.getNuclei(); }
-
+    double evalf(const double *r)  { return this->func.evalf(r); }
+    
 protected:
     NuclearFunction func;
 };

--- a/src/qmoperators/two_electron/FockOperator.cpp
+++ b/src/qmoperators/two_electron/FockOperator.cpp
@@ -44,7 +44,7 @@ FockOperator::FockOperator(KineticOperator  *t,
     if (this->xc   != 0) this->V += *this->xc;
 
     RankZeroTensorOperator &F = (*this);
-    F = this->T + this->V;
+    F = this->T + this->V + this->V_ext;
 }
 
 /** @brief prepare operator for application
@@ -147,4 +147,8 @@ SCFEnergy FockOperator::trace(OrbitalVector &Phi, const ComplexMatrix &F) {
     return SCFEnergy(E_nuc, E_el, E_orb, E_kin, E_en, E_ee, E_xc, E_x);
 }
 
+void FockOperator::addExternalPotential(RankZeroTensorOperator &O) {
+    this->V_ext += O;
+}
+    
 } //namespace mrchem

--- a/src/qmoperators/two_electron/FockOperator.cpp
+++ b/src/qmoperators/two_electron/FockOperator.cpp
@@ -7,7 +7,6 @@
 #include "CoulombOperator.h"
 #include "ExchangeOperator.h"
 #include "ElectricFieldOperator.h"
-#include "XCFunctional.h"
 #include "XCOperator.h"
 #include "SCFEnergy.h"
 #include "utils/math_utils.h"

--- a/src/qmoperators/two_electron/FockOperator.cpp
+++ b/src/qmoperators/two_electron/FockOperator.cpp
@@ -11,6 +11,7 @@
 #include "XCOperator.h"
 #include "SCFEnergy.h"
 #include "utils/math_utils.h"
+#include "chemistry/chem_utils.h"
 
 using mrcpp::Printer;
 using mrcpp::Timer;
@@ -124,7 +125,7 @@ SCFEnergy FockOperator::trace(OrbitalVector &Phi, const ComplexMatrix &F) {
     // Nuclear part
     if (this->nuc != 0) {
         Nuclei &nucs = this->nuc->getNuclei();
-        E_nuc = this->nuc->trace(nucs);
+        E_nuc = compute_nuclear_repulsion(nucs);
         if (this->ext  != 0) {
             E_nex = this->ext->trace(nucs).real();
             E_nuc += E_nex;

--- a/src/qmoperators/two_electron/FockOperator.cpp
+++ b/src/qmoperators/two_electron/FockOperator.cpp
@@ -123,7 +123,12 @@ SCFEnergy FockOperator::trace(OrbitalVector &Phi, const ComplexMatrix &F) {
 
     // Nuclear part
     if (this->nuc != 0) {
-        E_nuc = this->nuc->trace(this->nuc->getNuclei());
+        Nuclei &nucs = this->nuc->getNuclei();
+        E_nuc = this->nuc->trace(nucs);
+        if (this->ext  != 0) {
+            E_nex = this->ext->trace(nucs).real();
+            E_nuc += E_nex;
+        }
     }
 
     // Orbital energies

--- a/src/qmoperators/two_electron/FockOperator.cpp
+++ b/src/qmoperators/two_electron/FockOperator.cpp
@@ -123,25 +123,7 @@ SCFEnergy FockOperator::trace(OrbitalVector &Phi, const ComplexMatrix &F) {
 
     // Nuclear part
     if (this->nuc != 0) {
-        std::cout << "Computing nuc conts " << ext << std::endl;
-        Nuclei &nucs = this->nuc->getNuclei();
-        int nNucs = nucs.size();
-        for (int i = 0; i < nNucs; i++) {
-            for (int j = i+1; j < nNucs; j++) {
-                const Nucleus &nuc_i = nucs[i];
-                const Nucleus &nuc_j = nucs[j];
-                double Z_i = nuc_i.getCharge();
-                double Z_j = nuc_j.getCharge();
-                const double *R_i = nuc_i.getCoord();
-                const double *R_j = nuc_j.getCoord();
-                double R_ij = math_utils::calc_distance(R_i, R_j);
-                E_nuc += (Z_i*Z_j)/R_ij;
-            }
-        }
-        if (this->ext  != 0) {
-            E_nex = this->ext->trace(nucs).real();
-            E_nuc += E_nex;
-        }
+        E_nuc = this->nuc->trace(this->nuc->getNuclei());
     }
 
     // Orbital energies

--- a/src/qmoperators/two_electron/FockOperator.cpp
+++ b/src/qmoperators/two_electron/FockOperator.cpp
@@ -139,7 +139,6 @@ SCFEnergy FockOperator::trace(OrbitalVector &Phi, const ComplexMatrix &F) {
             }
         }
         if (this->ext  != 0) {
-            std::cout << "Computing nuc conts to dip ener" << std::endl;
             E_nex = this->ext->trace(nucs).real();
             E_nuc += E_nex;
         }
@@ -162,7 +161,7 @@ SCFEnergy FockOperator::trace(OrbitalVector &Phi, const ComplexMatrix &F) {
     double E_eex    = E_ee  + E_x;
     double E_orbxc2 = E_orb - E_xc2;
     E_kin = E_orbxc2 - 2.0*E_eex - E_en - E_ext;
-    E_el  = E_orbxc2 -     E_eex + E_xc + E_ext;
+    E_el  = E_orbxc2 -     E_eex + E_xc;
 
     return SCFEnergy(E_nuc, E_el, E_orb, E_kin, E_en, E_ee, E_xc, E_x,
                      E_nex, E_ext);

--- a/src/qmoperators/two_electron/FockOperator.h
+++ b/src/qmoperators/two_electron/FockOperator.h
@@ -27,34 +27,36 @@ public:
                  NuclearOperator  *v = 0,
                  CoulombOperator  *j = 0,
                  ExchangeOperator *k = 0,
-                 XCOperator      *xc = 0);
+                 XCOperator       *xc = 0);
     ~FockOperator() { }
 
     RankZeroTensorOperator& kinetic()   { return this->T; }
     RankZeroTensorOperator& potential() { return this->V; }
 
-    KineticOperator  *getKineticOperator()  { return this->kin;  }
-    NuclearOperator  *getNuclearOperator()  { return this->nuc;  }
-    CoulombOperator  *getCoulombOperator()  { return this->coul; }
-    ExchangeOperator *getExchangeOperator() { return this->ex;   }
-    XCOperator       *getXCOperator()       { return this->xc;   }
+    KineticOperator           *getKineticOperator()  { return this->kin;  }
+    NuclearOperator           *getNuclearOperator()  { return this->nuc;  }
+    CoulombOperator           *getCoulombOperator()  { return this->coul; }
+    ExchangeOperator          *getExchangeOperator() { return this->ex;   }
+    XCOperator                *getXCOperator()       { return this->xc;   }
 
     void rotate(const ComplexMatrix &U);
 
     void setup(double prec);
     void clear();
-
+    void addExternalPotential(RankZeroTensorOperator &O);
+    
     SCFEnergy trace(OrbitalVector &Phi, const ComplexMatrix &F);
 
 protected:
-    RankZeroTensorOperator T;   ///< Total kinetic energy operator
-    RankZeroTensorOperator V;   ///< Total potential energy operator
-
-    KineticOperator  *kin;
-    NuclearOperator  *nuc;
-    CoulombOperator  *coul;
+    RankZeroTensorOperator T;     ///< Total kinetic energy operator
+    RankZeroTensorOperator V;     ///< Total potential energy operator
+    RankZeroTensorOperator V_ext; ///< Total external potential
+    
+    KineticOperator *kin;
+    NuclearOperator *nuc;
+    CoulombOperator *coul;
     ExchangeOperator *ex;
-    XCOperator       *xc;
+    XCOperator *xc;
 };
 
 } //namespace mrchem

--- a/src/qmoperators/two_electron/FockOperator.h
+++ b/src/qmoperators/two_electron/FockOperator.h
@@ -20,6 +20,7 @@ class NuclearOperator;
 class CoulombOperator;
 class ExchangeOperator;
 class XCOperator;
+class ElectricFieldOperator;
 
 class FockOperator final : public RankZeroTensorOperator {
 public:
@@ -28,7 +29,7 @@ public:
                  CoulombOperator        *j = 0,
                  ExchangeOperator       *k = 0,
                  XCOperator             *xc = 0,
-                 RankZeroTensorOperator *ext = 0);
+                 ElectricFieldOperator  *ext = 0);
     ~FockOperator() { }
 
     RankZeroTensorOperator& kinetic()   { return this->T; }
@@ -39,14 +40,14 @@ public:
     CoulombOperator        *getCoulombOperator()  { return this->coul; }
     ExchangeOperator       *getExchangeOperator() { return this->ex;   }
     XCOperator             *getXCOperator()       { return this->xc;   }
-    RankZeroTensorOperator *getExtOperator()      { return this->ext;  }
+    ElectricFieldOperator  *getExtOperator()      { return this->ext;  }
     
     void setKineticOperator (KineticOperator        *t)  { this->kin = t;  }
     void setNuclearOperator (NuclearOperator        *v)  { this->nuc = v;  }
     void setCoulombOperator (CoulombOperator        *j)  { this->coul = j; }
     void setExchangeOperator(ExchangeOperator       *k)  { this->ex = k;   }
     void setXCOperator      (XCOperator             *xc) { this->xc = xc;  }
-    void setExtOperator     (RankZeroTensorOperator *ext){ this->ext = ext;}
+    void setExtOperator     (ElectricFieldOperator  *ext){ this->ext = ext;}
     
     void rotate(const ComplexMatrix &U);
 
@@ -65,7 +66,7 @@ protected:
     CoulombOperator        *coul;
     ExchangeOperator       *ex;
     XCOperator             *xc;
-    RankZeroTensorOperator *ext; ///< Total external potential
+    ElectricFieldOperator  *ext; ///< Total external potential
 
 };
 

--- a/src/qmoperators/two_electron/FockOperator.h
+++ b/src/qmoperators/two_electron/FockOperator.h
@@ -23,40 +23,50 @@ class XCOperator;
 
 class FockOperator final : public RankZeroTensorOperator {
 public:
-    FockOperator(KineticOperator  *t = 0,
-                 NuclearOperator  *v = 0,
-                 CoulombOperator  *j = 0,
-                 ExchangeOperator *k = 0,
-                 XCOperator       *xc = 0);
+    FockOperator(KineticOperator        *t = 0,
+                 NuclearOperator        *v = 0,
+                 CoulombOperator        *j = 0,
+                 ExchangeOperator       *k = 0,
+                 XCOperator             *xc = 0,
+                 RankZeroTensorOperator *ext = 0);
     ~FockOperator() { }
 
     RankZeroTensorOperator& kinetic()   { return this->T; }
     RankZeroTensorOperator& potential() { return this->V; }
 
-    KineticOperator           *getKineticOperator()  { return this->kin;  }
-    NuclearOperator           *getNuclearOperator()  { return this->nuc;  }
-    CoulombOperator           *getCoulombOperator()  { return this->coul; }
-    ExchangeOperator          *getExchangeOperator() { return this->ex;   }
-    XCOperator                *getXCOperator()       { return this->xc;   }
-
+    KineticOperator        *getKineticOperator()  { return this->kin;  }
+    NuclearOperator        *getNuclearOperator()  { return this->nuc;  }
+    CoulombOperator        *getCoulombOperator()  { return this->coul; }
+    ExchangeOperator       *getExchangeOperator() { return this->ex;   }
+    XCOperator             *getXCOperator()       { return this->xc;   }
+    RankZeroTensorOperator *getExtOperator()      { return this->ext;  }
+    
+    void setKineticOperator (KineticOperator        *t)  { this->kin = t;  }
+    void setNuclearOperator (NuclearOperator        *v)  { this->nuc = v;  }
+    void setCoulombOperator (CoulombOperator        *j)  { this->coul = j; }
+    void setExchangeOperator(ExchangeOperator       *k)  { this->ex = k;   }
+    void setXCOperator      (XCOperator             *xc) { this->xc = xc;  }
+    void setExtOperator     (RankZeroTensorOperator *ext){ this->ext = ext;}
+    
     void rotate(const ComplexMatrix &U);
 
+    void build();
     void setup(double prec);
     void clear();
-    void addExternalPotential(RankZeroTensorOperator &O);
     
     SCFEnergy trace(OrbitalVector &Phi, const ComplexMatrix &F);
 
 protected:
     RankZeroTensorOperator T;     ///< Total kinetic energy operator
     RankZeroTensorOperator V;     ///< Total potential energy operator
-    RankZeroTensorOperator V_ext; ///< Total external potential
-    
-    KineticOperator *kin;
-    NuclearOperator *nuc;
-    CoulombOperator *coul;
-    ExchangeOperator *ex;
-    XCOperator *xc;
+
+    KineticOperator        *kin;
+    NuclearOperator        *nuc;
+    CoulombOperator        *coul;
+    ExchangeOperator       *ex;
+    XCOperator             *xc;
+    RankZeroTensorOperator *ext; ///< Total external potential
+
 };
 
 } //namespace mrchem

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ target_include_directories(mrchem-tests PRIVATE
     ${CMAKE_BINARY_DIR}/stage/${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}/MRCPP
     ${CMAKE_SOURCE_DIR}/src
     ${CMAKE_SOURCE_DIR}/src/chemistry
+    ${CMAKE_SOURCE_DIR}/src/properties
     ${CMAKE_SOURCE_DIR}/src/analyticfunctions
     ${CMAKE_SOURCE_DIR}/src/qmfunctions
     ${CMAKE_SOURCE_DIR}/src/qmoperators

--- a/tests/qmoperators/CMakeLists.txt
+++ b/tests/qmoperators/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(mrchem-tests PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/momentum_operator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kinetic_operator.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/nuclear_operator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/electric_field_operator.cpp
     )
 
 add_catch_test(identity_operator "identity_operator")
@@ -11,3 +12,4 @@ add_catch_test(position_operator "position_operator")
 add_catch_test(momentum_operator "momentum_operator")
 add_catch_test(kinetic_operator "kinetic_operator")
 add_catch_test(nuclear_operator "nuclear_operator")
+add_catch_test(electric_field_operator "electric_field_operator")

--- a/tests/qmoperators/electric_field_operator.cpp
+++ b/tests/qmoperators/electric_field_operator.cpp
@@ -1,0 +1,151 @@
+#include "catch.hpp"
+
+#include "mrchem.h"
+
+#include "HydrogenFunction.h"
+#include "ElectricFieldOperator.h"
+#include "Molecule.h"
+#include "Orbital.h"
+
+using namespace mrchem;
+using namespace orbital;
+
+namespace electric_field_operator {
+
+typedef std::tuple<int, int, int> QuantumNumbers;
+    
+TEST_CASE("ElectricFieldOperator", "[electric_field_operator]") {
+    const double prec = 1.0e-4;
+    const double thrs = prec * prec * 10.0;
+    OrbitalVector Phi;
+    
+    std::vector<QuantumNumbers> qn;
+    qn.push_back( QuantumNumbers (1, 0, 0));
+    qn.push_back( QuantumNumbers (2, 0, 0));
+    qn.push_back( QuantumNumbers (2, 1, 0));
+    qn.push_back( QuantumNumbers (2, 1, 1));
+    qn.push_back( QuantumNumbers (2, 1, 2));
+    int nFuncs = qn.size();
+
+    Eigen::MatrixXd ref(nFuncs,nFuncs);
+
+    //reference values for the electric field energy operator
+    ref << 0.9,        0.0,  0.74493554, 0.74493554, 0.74493554,
+           0.0,        0.9,  3.0,        3.0,        3.0,
+           0.74493554, 3.0,  0.9,        0.0,        0.0,
+           0.74493554, 3.0,  0.0,        0.9,        0.0,
+           0.74493554, 3.0,  0.0,        0.0,        0.9;
+
+    // setting up the field
+    Eigen::Vector3d field;
+    field << 1.0, 1.0, 1.0;
+    ElectricFieldOperator EF(field);
+    EF.setup(prec);
+
+    //origin 
+    double *o = new double[3];
+    o[0] = 0.4;
+    o[1] = 0.3;
+    o[2] = 0.2;
+
+    //setting up the orbitals
+    for (int i = 0; i < nFuncs; i++) {
+        HydrogenFunction f(std::get<0>(qn[i]), std::get<1>(qn[i]), std::get<2>(qn[i]), 1.0, o);
+        Orbital phi(SPIN::Paired);
+        phi.alloc(NUMBER::Real);
+        mrcpp::project(prec, phi.real(), f);
+        Phi.push_back(phi);
+    }
+    
+    SECTION("apply") {
+        Orbital phi_x = EF(Phi[0]);
+        ComplexDouble X_00 = orbital::dot(Phi[0], phi_x);
+        ComplexDouble X_10 = orbital::dot(Phi[1], phi_x);
+        ComplexDouble X_20 = orbital::dot(Phi[2], phi_x);
+        ComplexDouble X_30 = orbital::dot(Phi[3], phi_x);
+        ComplexDouble X_40 = orbital::dot(Phi[4], phi_x);
+        REQUIRE( X_00.real() == Approx(ref(0,0)).margin(thrs));
+        REQUIRE( X_10.real() == Approx(ref(0,1)).margin(thrs));
+        REQUIRE( X_20.real() == Approx(ref(0,2)).margin(thrs));
+        REQUIRE( X_30.real() == Approx(ref(0,3)).margin(thrs));
+        REQUIRE( X_40.real() == Approx(ref(0,4)).margin(thrs));
+        phi_x.free();
+    }
+
+    SECTION("vector apply") {
+        OrbitalVector xPhi = EF(Phi);
+        for (int i = 0; i < Phi.size(); i++) {
+            for (int j = 0; j < xPhi.size(); j++) {
+                ComplexDouble X_ij = orbital::dot(Phi[i], xPhi[j]);
+                REQUIRE( std::abs(X_ij.real()) == Approx(ref(i,j)).margin(thrs));
+            }
+        }
+        free(xPhi);
+    }
+    SECTION("expectation value") {
+        ComplexDouble X_00 = EF(Phi[0], Phi[0]);
+        REQUIRE( X_00.real() == Approx(ref(0,0)) );
+    }
+    SECTION("operator matrix elements") {
+        ComplexMatrix X = EF(Phi, Phi);
+        for (int i = 0; i < Phi.size(); i++) {
+            for (int j = 0; j < Phi.size(); j++) {
+                REQUIRE( std::abs(X(i,j).real()) == Approx(ref(i,j)).margin(thrs));
+            }
+        }
+    }
+    EF.clear();
+    free(Phi);
+}
+
+TEST_CASE("ElectricFieldEnergy", "[electric_field_energy]") {
+    const double prec = 1.0e-4;
+    const double thrs = prec * prec * 10.0;
+    OrbitalVector Phi;
+
+    // Setting up the field
+    Eigen::Vector3d field;
+    field << 1.0, 1.0, 1.0;
+    ElectricFieldOperator EF(field);
+    EF.setup(prec);
+
+    // Setting up the molecule
+    std::vector<std::string> nuc_coor;
+    nuc_coor.push_back("H    1.0,    0.0,   0.0");
+    nuc_coor.push_back("Li  -1.0,    0.0,   0.0");
+    Molecule LiH(nuc_coor);
+
+    double *o = new double[3];
+    
+    // Setting up the 1s orbital on H
+    o[0] = 1.0;
+    o[1] = 0.0;
+    o[2] = 0.0;
+    HydrogenFunction sh(1, 0, 0, 1.0, o);
+    Orbital phi_h(SPIN::Paired);
+    phi_h.alloc(NUMBER::Real);
+    mrcpp::project(prec, phi_h.real(), sh);
+
+    // Setting up the 1s orbital on Li
+    o[0] = -1.0;
+    o[1] =  0.0;
+    o[2] =  0.0;
+    HydrogenFunction sli(1, 0, 0, 3.0, o);
+    Orbital phi_li(SPIN::Paired);
+    phi_li.alloc(NUMBER::Real);
+    mrcpp::project(prec, phi_li.real(), sli);
+
+    SECTION("energy in the external field") {
+        OrbitalVector Phi_LiH;
+        Phi_LiH.push_back(phi_h);
+        Phi_LiH.push_back(phi_li);
+        double E_ext = EF.trace(Phi_LiH).real();
+        double E_nex = EF.trace(LiH.getNuclei()).real();
+        REQUIRE(E_ext < thrs);
+        REQUIRE(E_nex == Approx(2.0));
+        free(Phi_LiH);
+    }
+    EF.clear();
+}
+
+} //namespace electric_field_operator


### PR DESCRIPTION
The external potential is reintroduced as a simple additional operator in the Fock Operator.

- [x] New input section
- [x] Add external potential to `FockOperator`
- [x] Test
