### PR TITLE
Response solver

### DIFF
--- a/src/SCFDriver.cpp
+++ b/src/SCFDriver.cpp
@@ -542,7 +542,6 @@ LinearResponseSolver* SCFDriver::setupLinearResponseSolver(bool dynamic) {
     lrs->setMaxIterations(rsp_max_iter);
     lrs->setThreshold(rsp_orbital_thrs, rsp_property_thrs);
     lrs->setOrbitalPrec(rsp_orbital_prec[0], rsp_orbital_prec[1]);
-    lrs->setupUnperturbed(rsp_orbital_prec[1], fock, phi, &F);
 
     return lrs;
 }
@@ -679,9 +678,11 @@ void SCFDriver::runLinearResponse(const ResponseCalculation &rsp_calc) {
     bool converged = true;
     if (rsp_run) {
         LinearResponseSolver *solver = setupLinearResponseSolver(dynamic);
+        solver->setupUnperturbed(rsp_orbital_prec[1], fock, phi, &F);
         solver->setup(d_fock, phi_x);
         converged = solver->optimize();
         solver->clear();
+        solver->clearUnperturbed();
         delete solver;
     }
 

--- a/src/SCFDriver.cpp
+++ b/src/SCFDriver.cpp
@@ -280,7 +280,7 @@ void SCFDriver::setup() {
     h_M = new H_M_pso*[nNucs];
     for (int k = 0; k < nNucs; k++) {
         const double *r_K = molecule->getNucleus(k).getCoord();
-        new H_M_pso(*(useDerivative(diff_pso)), r_K);
+        h_M[k] = new H_M_pso(*(useDerivative(diff_pso)), r_K);
     }
 
     // Setting up properties
@@ -400,7 +400,7 @@ void SCFDriver::setup() {
         fock->setXCOperator(XC);
     }
     //HACK we need a better way to decide whether to initialize the external potential operator
-    if(ext_electric) {
+    if (ext_electric) {
         Vext = new ElectricFieldOperator(ext_electric_field);
     }
     fock->setExtOperator(Vext);
@@ -432,6 +432,7 @@ void SCFDriver::clear() {
     if (xcfun != 0) delete xcfun;
 
     if (fock != 0) delete fock;
+    if (Vext != 0) delete Vext;
     if (XC != 0) delete XC;
     if (K != 0) delete K;
     if (J != 0) delete J;

--- a/src/qmoperators/RankZeroTensorOperator.cpp
+++ b/src/qmoperators/RankZeroTensorOperator.cpp
@@ -296,7 +296,6 @@ ComplexDouble RankZeroTensorOperator::trace(OrbitalVector &Phi) {
 ComplexDouble RankZeroTensorOperator::trace(OrbitalVector &Phi,
                                             OrbitalVector &X,
                                             OrbitalVector &Y) {
-    NEEDS_TESTING;
     RankZeroTensorOperator &O = *this;
 
     ComplexDouble result(0.0, 0.0);

--- a/src/qmoperators/two_electron/FockOperator.cpp
+++ b/src/qmoperators/two_electron/FockOperator.cpp
@@ -72,6 +72,7 @@ void FockOperator::setup(double prec) {
     Printer::printSeparator(0, '-');
     this->T.setup(prec);
     this->V.setup(prec);
+    this->H_1.setup(prec);
     if (this->ex != 0) this->ex->setupInternal(prec);
     timer.stop();
     Printer::printFooter(0, timer, 2);
@@ -85,6 +86,7 @@ void FockOperator::setup(double prec) {
 void FockOperator::clear() {
     this->T.clear();
     this->V.clear();
+    this->H_1.clear();
 }
 
 /** @brief rotate orbitals of two-electron operators

--- a/src/qmoperators/two_electron/FockOperator.h
+++ b/src/qmoperators/two_electron/FockOperator.h
@@ -30,10 +30,10 @@ public:
                  ExchangeOperator       *k = 0,
                  XCOperator             *xc = 0,
                  ElectricFieldOperator  *ext = 0);
-    ~FockOperator() { }
 
-    RankZeroTensorOperator& kinetic()   { return this->T; }
-    RankZeroTensorOperator& potential() { return this->V; }
+    RankZeroTensorOperator& kinetic()       { return this->T; }
+    RankZeroTensorOperator& potential()     { return this->V; }
+    RankZeroTensorOperator& perturbation()  { return this->H_1; }
 
     KineticOperator        *getKineticOperator()  { return this->kin;  }
     NuclearOperator        *getNuclearOperator()  { return this->nuc;  }
@@ -60,14 +60,14 @@ public:
 protected:
     RankZeroTensorOperator T;     ///< Total kinetic energy operator
     RankZeroTensorOperator V;     ///< Total potential energy operator
+    RankZeroTensorOperator H_1;   ///< Perturbation operators
 
     KineticOperator        *kin;
     NuclearOperator        *nuc;
     CoulombOperator        *coul;
     ExchangeOperator       *ex;
     XCOperator             *xc;
-    ElectricFieldOperator  *ext; ///< Total external potential
-
+    ElectricFieldOperator  *ext;  ///< Total external potential
 };
 
 } //namespace mrchem

--- a/src/scf_solver/CMakeLists.txt
+++ b/src/scf_solver/CMakeLists.txt
@@ -5,5 +5,6 @@ target_sources(mrchem PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/KAIN.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/OrbitalOptimizer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/GroundStateSolver.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/LinearResponseSolver.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/SCF.cpp
     )

--- a/src/scf_solver/HelmholtzVector.cpp
+++ b/src/scf_solver/HelmholtzVector.cpp
@@ -231,7 +231,7 @@ Orbital HelmholtzVector::operator()(int i, Orbital inp) {
  */
 OrbitalVector HelmholtzVector::operator()(OrbitalVector &inp) {
     Printer::printHeader(0, "Applying Helmholtz operators");
-    println(0, " Orb  RealNorm     ImagNorm      nNodes     Error   Timing   ");
+    println(0, " Orb    RealNorm   Nodes     ImagNorm   Nodes     Timing");
     Printer::printSeparator(0, '-');
     int oldprec = Printer::setPrecision(5);
 
@@ -247,7 +247,6 @@ OrbitalVector HelmholtzVector::operator()(OrbitalVector &inp) {
 
         int rNodes = out[i].getNNodes(NUMBER::Real);
         int iNodes = out[i].getNNodes(NUMBER::Imag);
-        double dNorm = std::abs(out[i].norm() - 1.0);
         double rNorm = 0.0;
         double iNorm = 0.0;
         if (out[i].hasReal()) rNorm = std::sqrt(out[i].real().getSquareNorm());
@@ -256,13 +255,11 @@ OrbitalVector HelmholtzVector::operator()(OrbitalVector &inp) {
         timer.stop();
         Printer::setPrecision(5);
         printout(0, std::setw(3) << i);
-        printout(0, " " << std::setw(12) << rNorm);
-        printout(0, " " << std::setw(12) << iNorm);
-        Printer::setPrecision(1);
+        printout(0, " " << std::setw(14) << rNorm);
         printout(0, " " << std::setw(5) << rNodes);
+        printout(0, " " << std::setw(14) << iNorm);
         printout(0, " " << std::setw(5) << iNodes);
-        printout(0, " " << std::setw(8) << dNorm);
-        printout(0, std::setw(9) << timer.getWallTime() << std::endl);
+        printout(0, std::setw(14) << timer.getWallTime() << std::endl);
     }
 
 #ifdef HAVE_MPI

--- a/src/scf_solver/LinearResponseSolver.cpp
+++ b/src/scf_solver/LinearResponseSolver.cpp
@@ -12,6 +12,18 @@ using mrcpp::Timer;
 
 namespace mrchem {
 
+/** @brief constructor
+ *
+ * @param h: Helmholtz operators
+ * @param k_x: Iterative accelerator X orbitals
+ * @param k_y: Iterative accelerator Y orbitals
+ *
+ * SCF solver will NOT take ownership of the HelmholtzVector or the Accelerators,
+ * so the original objects must be taken care of externally (do not delete until
+ * SCF goes out of scope). Fock matrix, FockOperator and OrbitalVector are not
+ * initialized at this stage, so the SCF solver needs to be "setup()" before
+ * "optimize()".
+ */
 LinearResponseSolver::LinearResponseSolver(HelmholtzVector &h,
                                            Accelerator *k_x,
                                            Accelerator *k_y)
@@ -30,6 +42,19 @@ LinearResponseSolver::LinearResponseSolver(HelmholtzVector &h,
           kain_y(k_y) {
 }
 
+/** @brief Prepare the unperturbed parts of the response solver for optimization
+ *
+ * @param prec: Precision
+ * @param fock: Unperturbed Fock operator
+ * @param Phi: Unperturbed orbitals to optimize
+ * @param F: Unperturbed Fock matrix
+ *
+ * The unperturbed part of the response solver remains unchanged during the SCF
+ * procedure and for all types and directions of the perturbation, so it needs to
+ * be setup only once (unlike the perturbed parts which must be updated in each
+ * iteration). SCF solver will NOT take ownership of the input, so these objects
+ * must be taken care of externally (do not delete until SCF goes out of scope).
+ */
 void LinearResponseSolver::setupUnperturbed(double prec,
                                             FockOperator *fock,
                                             OrbitalVector *Phi,
@@ -40,6 +65,11 @@ void LinearResponseSolver::setupUnperturbed(double prec,
     this->fOper_0->setup(prec);
 }
 
+/** @brief Clear the unperturbed parts of the response solver after optimization
+ *
+ * Clear pointers that was set during setupUnperturbed. Solver can be re-used after
+ * another setupUnperturbed.
+ */
 void LinearResponseSolver::clearUnperturbed() {
     this->fOper_0->clear();
     this->fOper_0 = nullptr;
@@ -47,6 +77,14 @@ void LinearResponseSolver::clearUnperturbed() {
     this->fMat_0 = nullptr;
 }
 
+/** @brief Prepare solver for optimization, static version
+ *
+ * @param fock: Perturbed Fock operator (V_1 + h_1)
+ * @param X: Perturbed orbitals to optimize (epsilon + omega)
+ *
+ * SCF solver will NOT take ownership of the input, so these objects must be taken
+ * care of externally (do not delete until SCF goes out of scope).
+ */
 void LinearResponseSolver::setup(FockOperator *fock, OrbitalVector *X) {
     if (this->orbitals_0 == nullptr) MSG_ERROR("Unperturbed system not set up");
 
@@ -64,43 +102,30 @@ void LinearResponseSolver::setup(FockOperator *fock, OrbitalVector *X) {
     *this->fMat_x = *this->fMat_0;
 }
 
+/** @brief Prepare solver for optimization, dynamic version
+ *
+ * @param omega: Frequency of perturbing field
+ * @param fock: Perturbed Fock operator (V_1 + h_1)
+ * @param X: Perturbed orbitals to optimize (epsilon + omega)
+ * @param Y: Perturbed orbitals to optimize (epsilon - omega)
+ *
+ * SCF solver will NOT take ownership of the input, so these objects must be taken
+ * care of externally (do not delete until SCF goes out of scope).
+ */
 void LinearResponseSolver::setup(double omega,
                                  FockOperator *fock,
                                  OrbitalVector *X,
                                  OrbitalVector *Y) {
     NOT_IMPLEMENTED_ABORT;
-    /*
-    if (this->orbitals_0 == 0) MSG_ERROR("Unperturbed system not set up");
-
-    this->dynamic = true;
-    this->frequency = omega;
-
-    this->fOper_1 = &f_oper;
-    XCOperator *xc = this->fOper_1->getXCOperator();
-    if (xc != 0) xc->setupUnperturbed();
-
-    this->phi_x = &orbs_x;
-    this->phi_y = &orbs_y;
-    this->dPhi_x = new OrbitalVector("dOrbs_x", orbs_x);
-    this->dPhi_y = new OrbitalVector("dOrbs_y", orbs_y);
-
-    bool im = this->fOper_1->getPerturbationOperator(0).isImaginary();
-    this->phi_x->setImaginary(im);
-    this->phi_y->setImaginary(im);
-
-    int nOrbs = this->phi_0->size();
-    MatrixXd Omega = MatrixXd::Identity(nOrbs,nOrbs);
-    Omega *= omega;
-    this->fMat_x = new MatrixXd;
-    this->fMat_y = new MatrixXd;
-    *this->fMat_x = *this->fMat_0 + Omega;
-    *this->fMat_y = *this->fMat_0 - Omega;
-    */
 }
 
+/** @brief Clear solver after optimization
+ *
+ * Clear pointers that was set during setup, and reset the precision parameter
+ * (only the current precision orbPrec[0], not the boundary values orbPrec[1,2]).
+ * Solver can be re-used after another setup.
+ */
 void LinearResponseSolver::clear() {
-    this->clearUnperturbed();
-
     if (this->fMat_x != nullptr) delete this->fMat_x;
     if (this->fMat_y != nullptr) delete this->fMat_y;
 
@@ -117,11 +142,28 @@ void LinearResponseSolver::clear() {
     resetPrecision();
 }
 
+/** @brief Run orbital optimization
+ *
+ * Optimize orbitals until convergence thresholds are met. This algorithm iterates
+ * the Sternheimer response equations in integral form. Common implementation for
+ * static and dynamic response. Main points of the algorithm:
+ *
+ * Pre SCF: setup Helmholtz operators with unperturbed energies
+ *
+ *  1) Setup perturbed Fock operator
+ *  2) For X and Y orbitals do:
+ *     a) Apply Helmholtz operator on all orbitals
+ *     b) Project out occupied space (1 - rho_0)
+ *     c) Compute updates and errors
+ *     d) Compute KAIN updates
+ *  4) Compute property
+ *  5) Check for convergence
+ *
+ */
 bool LinearResponseSolver::optimize() {
     ComplexMatrix &F = *this->fMat_0;
-    ComplexMatrix *F_x = this->fMat_x;
-    ComplexMatrix *F_y = this->fMat_y;
-    FockOperator &fock_0 = *this->fOper_0;
+    ComplexMatrix &F_x = *this->fMat_x;
+    ComplexMatrix &F_y = *this->fMat_y;
     FockOperator &fock_1 = *this->fOper_1;
     OrbitalVector &Phi = *this->orbitals_0;
     OrbitalVector *X_n = this->orbitals_x;
@@ -133,6 +175,14 @@ bool LinearResponseSolver::optimize() {
     double err_t = 1.0;
     double err_p = 1.0;
 
+    // Setup Helmholtz operators (fixed, based on unperturbed system)
+    H.setup(orb_prec, F.real().diagonal());
+    ComplexMatrix L = H.getLambdaMatrix();
+
+    // Placeholders for orbital errors
+    DoubleVector errors_x = DoubleVector::Zero(Phi.size());
+    DoubleVector errors_y = DoubleVector::Zero(Phi.size());
+
     int nIter = 0;
     bool converged = false;
     while(nIter++ < this->maxIter or this->maxIter < 0) {
@@ -141,43 +191,58 @@ bool LinearResponseSolver::optimize() {
         printCycleHeader(nIter);
         orb_prec = adjustPrecision(err_o);
 
+        // Setup perturbed Fock operator
         fock_1.setup(orb_prec);
-        double prop = calcProperty();
-        this->property.push_back(prop);
 
-        DoubleVector errors_x = DoubleVector::Zero(Phi.size());
-        DoubleVector errors_y = DoubleVector::Zero(Phi.size());
-
-        H.setup(orb_prec, F.real().diagonal());
+        // Iterate X orbitals
         if (X_n != nullptr) {
-            ComplexMatrix L = H.getLambdaMatrix();
-            OrbitalVector Psi_n = setupHelmholtzArguments(*X_n, L-F, false);
+            // Compute argument: psi_i = V_0*x_i - sum_j [L-F]_ij*x_j + (1 - rho_0)phi_i
+            OrbitalVector Psi_n = setupHelmholtzArguments(*X_n, L-F_x, false);
+
+            // Apply Helmholtz operators
             OrbitalVector X_np1 = H(Psi_n);
+            orbital::free(Psi_n);
+
+            // Orthogonalize: X_np1 = (1 - rho_0)X_np1
             orbital::orthogonalize(X_np1, Phi);
+
+            // Compute update and errors
             OrbitalVector dX_n = orbital::add(1.0, X_np1, -1.0, *X_n);
             errors_x = orbital::get_norms(dX_n);
+
+            // Compute KAIN update:
             if (this->kain_x != nullptr) {
                 orbital::free(X_np1);
                 this->kain_x->accelerate(orb_prec, *X_n, dX_n);
                 X_np1 = orbital::add(1.0, *X_n, 1.0, dX_n);
             }
+
+            // Free orbitals
             orbital::free(*X_n);
             orbital::free(dX_n);
+
+            // Prepare for next iteration
             *X_n = X_np1;
             orbital::set_errors(*X_n, errors_x);
             printOrbitals(orbital::get_norms(*X_n), *X_n, 0);
         }
-        if (Y_n != nullptr) {
-            NOT_IMPLEMENTED_ABORT;
-        }
-        H.clear();
-        fock_1.clear();
 
-        err_p = calcPropertyError();
+        // Iterate Y orbitals
+        if (Y_n != nullptr) NOT_IMPLEMENTED_ABORT;
+
+        // Compute property
+        double prop = calcProperty();
+        this->property.push_back(prop);
+
+        // Compute errors
+        err_p = std::abs(getUpdate(this->property, nIter, false));
         err_o = std::max(errors_x.maxCoeff(), errors_y.maxCoeff());
         err_t = std::sqrt(errors_x.dot(errors_x) + errors_y.dot(errors_y));
-        this->orbError.push_back(err_t);
         converged = checkConvergence(err_o, err_p);
+        this->orbError.push_back(err_t);
+
+        // Clear perturbed Fock operator
+        fock_1.clear();
 
         // Finalize SCF cycle
         timer.stop();
@@ -187,17 +252,38 @@ bool LinearResponseSolver::optimize() {
         if (converged) break;
     }
 
+    // Clear KAIN history and Helmholtz operators
     if (this->kain_x != nullptr) this->kain_x->clear();
     if (this->kain_y != nullptr) this->kain_y->clear();
+    H.clear();
 
     printConvergence(converged);
     return converged;
 }
 
+/** @brief Computes the Helmholtz argument for the all orbitals
+ *
+ * @param Phi_1: Perturbed orbitals
+ * @param M: Rotation matrix for second term
+ * @param adjoint: Use adjoint of Fock operator
+ *
+ * Argument contains the unperturbed potential operator acting on perturbed
+ * orbital i, and the sum of all perturbed orbitals weighted by the unperturbed
+ * Fock matrix, and finally the perturbed Fock operator acting on the unperturbed
+ * orbitals (projected out occupied space). The effect of using inexact Helmholtz
+ * operators are included in Lambda, which is a diagonal matrix with the actual
+ * lambda parameters used in the Helmholtz operators (input matrix M is assumed
+ * to be L-F).
+ *
+ * psi_j = \hat{V}^0 phi^1_i
+ *       - \sum_j (\Lambda_{ij}-F^0_{ij})phi^1_j
+ *       + (1 - rho^0) V^1 phi^0_i
+ *
+ */
 OrbitalVector LinearResponseSolver::setupHelmholtzArguments(OrbitalVector &Phi_1,
                                                             const ComplexMatrix &M,
                                                             bool adjoint) {
-    Timer timer_tot;
+    Timer timer_tot, timer_1(false), timer_2(false), timer_3(false);
     Printer::printHeader(0, "Setting up Helmholtz arguments");
     int oldprec = Printer::setPrecision(5);
 
@@ -208,15 +294,20 @@ OrbitalVector LinearResponseSolver::setupHelmholtzArguments(OrbitalVector &Phi_1
     OrbitalVector out = orbital::param_copy(Phi_1);
     for (int i = 0; i < Phi_1.size(); i++) {
         OrbitalVector arg_parts;
+        timer_1.start();
         if (Phi_1[i].norm() > 0.1*this->orbThrs) {
             Orbital part_1 = V_0(Phi_1[i]);
             arg_parts.push_back(part_1);
         }
+        timer_1.stop();
+        timer_2.start();
         if (M.row(i).norm() > 0.1*this->orbThrs) {
             ComplexVector c = M.row(i);
             Orbital part_2 = orbital::multiply(c, Phi_1);
             arg_parts.push_back(part_2);
         }
+        timer_2.stop();
+        timer_3.start();
         Orbital part_3;
         if (adjoint) {
             part_3 = V_1.dagger(Phi_0[i]);
@@ -224,12 +315,17 @@ OrbitalVector LinearResponseSolver::setupHelmholtzArguments(OrbitalVector &Phi_1
             part_3 = V_1(Phi_0[i]);
         }
         part_3.orthogonalize(Phi_0);
+        timer_3.stop();
         arg_parts.push_back(part_3);
 
         ComplexVector c = ComplexVector::Constant(arg_parts.size(), -1.0/(2.0*MATHCONST::pi));
         out[i] = orbital::multiply(c, arg_parts, -1.0);
         orbital::free(arg_parts);
     }
+
+    Printer::printDouble(0, "            V_0 phi_1", timer_1.getWallTime(), 5);
+    Printer::printDouble(0, "            F_0 phi_1", timer_2.getWallTime(), 5);
+    Printer::printDouble(0, "(1 - rho_0) V_1 phi_0", timer_3.getWallTime(), 5);
 
     timer_tot.stop();
     Printer::printFooter(0, timer_tot, 2);
@@ -238,6 +334,7 @@ OrbitalVector LinearResponseSolver::setupHelmholtzArguments(OrbitalVector &Phi_1
     return out;
 }
 
+/** @brief Computes the expectation value with the perturbing operator(s) */
 double LinearResponseSolver::calcProperty() {
     FockOperator &F_1 = *this->fOper_1;
     OrbitalVector &Phi = *this->orbitals_0;
@@ -249,17 +346,15 @@ double LinearResponseSolver::calcProperty() {
     return F_1.perturbation().trace(Phi, *X, *Y).real();
 }
 
-double LinearResponseSolver::calcPropertyError() const {
-    int iter = this->property.size();
-    return std::abs(getUpdate(this->property, iter, false));
-}
-
+/** @brief Pretty printing of the computed property with update */
 void LinearResponseSolver::printProperty() const {
     double prop_0(0.0), prop_1(0.0);
     int iter = this->property.size();
     if (iter > 1) prop_0 = this->property[iter - 2];
     if (iter > 0) prop_1 = this->property[iter - 1];
-    printUpdate(" Property ",  prop_1,  prop_1 -  prop_0);
+    Printer::printHeader(0, "                    Value                  Update      Done ");
+    printUpdate(" Property   ",  prop_1,  prop_1 -  prop_0);
+    Printer::printSeparator(0, '=');
 }
 
 }  //namespace mrchem

--- a/src/scf_solver/LinearResponseSolver.cpp
+++ b/src/scf_solver/LinearResponseSolver.cpp
@@ -1,0 +1,265 @@
+#include "MRCPP/Printer"
+#include "MRCPP/Timer"
+
+#include "LinearResponseSolver.h"
+#include "HelmholtzVector.h"
+#include "FockOperator.h"
+#include "Accelerator.h"
+#include "Orbital.h"
+
+using mrcpp::Printer;
+using mrcpp::Timer;
+
+namespace mrchem {
+
+LinearResponseSolver::LinearResponseSolver(HelmholtzVector &h,
+                                           Accelerator *k_x,
+                                           Accelerator *k_y)
+        : SCF(h),
+          dynamic(false),
+          frequency(0.0),
+          fOper_0(nullptr),
+          fOper_1(nullptr),
+          fMat_0(nullptr),
+          fMat_x(nullptr),
+          fMat_y(nullptr),
+          orbitals_0(nullptr),
+          orbitals_x(nullptr),
+          orbitals_y(nullptr),
+          kain_x(k_x),
+          kain_y(k_y) {
+}
+
+void LinearResponseSolver::setupUnperturbed(double prec,
+                                            FockOperator *fock,
+                                            OrbitalVector *Phi,
+                                            ComplexMatrix *F) {
+    this->fOper_0 = fock;
+    this->orbitals_0 = Phi;
+    this->fMat_0 = F;
+    this->fOper_0->setup(prec);
+}
+
+void LinearResponseSolver::clearUnperturbed() {
+    this->fOper_0->clear();
+    this->fOper_0 = nullptr;
+    this->orbitals_0 = nullptr;
+    this->fMat_0 = nullptr;
+}
+
+void LinearResponseSolver::setup(FockOperator *fock, OrbitalVector *X) {
+    if (this->orbitals_0 == nullptr) MSG_ERROR("Unperturbed system not set up");
+
+    this->dynamic = false;
+    this->frequency = 0.0;
+
+    this->fOper_1 = fock;
+
+    this->orbitals_x = X;
+    this->orbitals_y = nullptr;
+
+    this->fMat_x = new ComplexMatrix;
+    this->fMat_y = nullptr;
+
+    *this->fMat_x = *this->fMat_0;
+}
+
+void LinearResponseSolver::setup(double omega,
+                                 FockOperator *fock,
+                                 OrbitalVector *X,
+                                 OrbitalVector *Y) {
+    NOT_IMPLEMENTED_ABORT;
+    /*
+    if (this->orbitals_0 == 0) MSG_ERROR("Unperturbed system not set up");
+
+    this->dynamic = true;
+    this->frequency = omega;
+
+    this->fOper_1 = &f_oper;
+    XCOperator *xc = this->fOper_1->getXCOperator();
+    if (xc != 0) xc->setupUnperturbed();
+
+    this->phi_x = &orbs_x;
+    this->phi_y = &orbs_y;
+    this->dPhi_x = new OrbitalVector("dOrbs_x", orbs_x);
+    this->dPhi_y = new OrbitalVector("dOrbs_y", orbs_y);
+
+    bool im = this->fOper_1->getPerturbationOperator(0).isImaginary();
+    this->phi_x->setImaginary(im);
+    this->phi_y->setImaginary(im);
+
+    int nOrbs = this->phi_0->size();
+    MatrixXd Omega = MatrixXd::Identity(nOrbs,nOrbs);
+    Omega *= omega;
+    this->fMat_x = new MatrixXd;
+    this->fMat_y = new MatrixXd;
+    *this->fMat_x = *this->fMat_0 + Omega;
+    *this->fMat_y = *this->fMat_0 - Omega;
+    */
+}
+
+void LinearResponseSolver::clear() {
+    this->clearUnperturbed();
+
+    if (this->fMat_x != nullptr) delete this->fMat_x;
+    if (this->fMat_y != nullptr) delete this->fMat_y;
+
+    this->orbitals_x = nullptr;
+    this->orbitals_y = nullptr;
+    this->fOper_1 = nullptr;
+
+    if (this->kain_x != nullptr) this->kain_x->clear();
+    if (this->kain_y != nullptr) this->kain_y->clear();
+
+    this->orbError.clear();
+    this->property.clear();
+
+    resetPrecision();
+}
+
+bool LinearResponseSolver::optimize() {
+    ComplexMatrix &F = *this->fMat_0;
+    ComplexMatrix *F_x = this->fMat_x;
+    ComplexMatrix *F_y = this->fMat_y;
+    FockOperator &fock_0 = *this->fOper_0;
+    FockOperator &fock_1 = *this->fOper_1;
+    OrbitalVector &Phi = *this->orbitals_0;
+    OrbitalVector *X_n = this->orbitals_x;
+    OrbitalVector *Y_n = this->orbitals_y;
+    HelmholtzVector &H = *this->helmholtz;
+
+    double orb_prec = this->orbPrec[0];
+    double err_o = 1.0;
+    double err_t = 1.0;
+    double err_p = 1.0;
+
+    int nIter = 0;
+    bool converged = false;
+    while(nIter++ < this->maxIter or this->maxIter < 0) {
+        // Initialize SCF cycle
+        Timer timer;
+        printCycleHeader(nIter);
+        orb_prec = adjustPrecision(err_o);
+
+        fock_1.setup(orb_prec);
+        double prop = calcProperty();
+        this->property.push_back(prop);
+
+        DoubleVector errors_x = DoubleVector::Zero(Phi.size());
+        DoubleVector errors_y = DoubleVector::Zero(Phi.size());
+
+        H.setup(orb_prec, F.real().diagonal());
+        if (X_n != nullptr) {
+            ComplexMatrix L = H.getLambdaMatrix();
+            OrbitalVector Psi_n = setupHelmholtzArguments(*X_n, L-F, false);
+            OrbitalVector X_np1 = H(Psi_n);
+            orbital::orthogonalize(X_np1, Phi);
+            OrbitalVector dX_n = orbital::add(1.0, X_np1, -1.0, *X_n);
+            errors_x = orbital::get_norms(dX_n);
+            if (this->kain_x != nullptr) {
+                orbital::free(X_np1);
+                this->kain_x->accelerate(orb_prec, *X_n, dX_n);
+                X_np1 = orbital::add(1.0, *X_n, 1.0, dX_n);
+            }
+            orbital::free(*X_n);
+            orbital::free(dX_n);
+            *X_n = X_np1;
+            orbital::set_errors(*X_n, errors_x);
+            printOrbitals(orbital::get_norms(*X_n), *X_n, 0);
+        }
+        if (Y_n != nullptr) {
+            NOT_IMPLEMENTED_ABORT;
+        }
+        H.clear();
+        fock_1.clear();
+
+        err_p = calcPropertyError();
+        err_o = std::max(errors_x.maxCoeff(), errors_y.maxCoeff());
+        err_t = std::sqrt(errors_x.dot(errors_x) + errors_y.dot(errors_y));
+        this->orbError.push_back(err_t);
+        converged = checkConvergence(err_o, err_p);
+
+        // Finalize SCF cycle
+        timer.stop();
+        printProperty();
+        printCycleFooter(timer.getWallTime());
+
+        if (converged) break;
+    }
+
+    if (this->kain_x != nullptr) this->kain_x->clear();
+    if (this->kain_y != nullptr) this->kain_y->clear();
+
+    printConvergence(converged);
+    return converged;
+}
+
+OrbitalVector LinearResponseSolver::setupHelmholtzArguments(OrbitalVector &Phi_1,
+                                                            const ComplexMatrix &M,
+                                                            bool adjoint) {
+    Timer timer_tot;
+    Printer::printHeader(0, "Setting up Helmholtz arguments");
+    int oldprec = Printer::setPrecision(5);
+
+    OrbitalVector &Phi_0 = *this->orbitals_0;
+    RankZeroTensorOperator &V_0 = this->fOper_0->potential();
+    RankZeroTensorOperator V_1 = this->fOper_1->potential() + this->fOper_1->perturbation();
+
+    OrbitalVector out = orbital::param_copy(Phi_1);
+    for (int i = 0; i < Phi_1.size(); i++) {
+        OrbitalVector arg_parts;
+        if (Phi_1[i].norm() > 0.1*this->orbThrs) {
+            Orbital part_1 = V_0(Phi_1[i]);
+            arg_parts.push_back(part_1);
+        }
+        if (M.row(i).norm() > 0.1*this->orbThrs) {
+            ComplexVector c = M.row(i);
+            Orbital part_2 = orbital::multiply(c, Phi_1);
+            arg_parts.push_back(part_2);
+        }
+        Orbital part_3;
+        if (adjoint) {
+            part_3 = V_1.dagger(Phi_0[i]);
+        } else {
+            part_3 = V_1(Phi_0[i]);
+        }
+        part_3.orthogonalize(Phi_0);
+        arg_parts.push_back(part_3);
+
+        ComplexVector c = ComplexVector::Constant(arg_parts.size(), -1.0/(2.0*MATHCONST::pi));
+        out[i] = orbital::multiply(c, arg_parts, -1.0);
+        orbital::free(arg_parts);
+    }
+
+    timer_tot.stop();
+    Printer::printFooter(0, timer_tot, 2);
+    Printer::setPrecision(oldprec);
+
+    return out;
+}
+
+double LinearResponseSolver::calcProperty() {
+    FockOperator &F_1 = *this->fOper_1;
+    OrbitalVector &Phi = *this->orbitals_0;
+    OrbitalVector *X = this->orbitals_x;
+    OrbitalVector *Y = this->orbitals_y;
+
+    // Static response
+    if (Y == nullptr) Y = X;
+    return F_1.perturbation().trace(Phi, *X, *Y).real();
+}
+
+double LinearResponseSolver::calcPropertyError() const {
+    int iter = this->property.size();
+    return std::abs(getUpdate(this->property, iter, false));
+}
+
+void LinearResponseSolver::printProperty() const {
+    double prop_0(0.0), prop_1(0.0);
+    int iter = this->property.size();
+    if (iter > 1) prop_0 = this->property[iter - 2];
+    if (iter > 0) prop_1 = this->property[iter - 1];
+    printUpdate(" Property ",  prop_1,  prop_1 -  prop_0);
+}
+
+}  //namespace mrchem

--- a/src/scf_solver/LinearResponseSolver.h
+++ b/src/scf_solver/LinearResponseSolver.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "SCF.h"
+
+/** @class LinearResponseSolver
+ *
+ */
+
+namespace mrchem {
+
+class LinearResponseSolver final : public SCF {
+public:
+    LinearResponseSolver(HelmholtzVector &h, Accelerator *k_x = 0, Accelerator *k_y = 0);
+
+    void setupUnperturbed(double prec, FockOperator *fock, OrbitalVector *Phi, ComplexMatrix *F);
+    void clearUnperturbed();
+
+    void setup(FockOperator *fock, OrbitalVector *X);
+    void setup(double omega, FockOperator *fock, OrbitalVector *X, OrbitalVector *Y);
+    void clear();
+
+    bool optimize();
+
+protected:
+    bool dynamic;
+    double frequency;
+
+    FockOperator *fOper_0;
+    FockOperator *fOper_1;
+
+    ComplexMatrix *fMat_0;
+    ComplexMatrix *fMat_x;
+    ComplexMatrix *fMat_y;
+
+    OrbitalVector *orbitals_0;
+    OrbitalVector *orbitals_x;
+    OrbitalVector *orbitals_y;
+
+    Accelerator *kain_x;
+    Accelerator *kain_y;
+
+    OrbitalVector setupHelmholtzArguments(OrbitalVector &dPhi,
+                                          const ComplexMatrix &M,
+                                          bool adjoint);
+
+    double calcProperty();
+    double calcPropertyError() const;
+    void printProperty() const;
+};
+
+} //namespace mrchem

--- a/src/scf_solver/LinearResponseSolver.h
+++ b/src/scf_solver/LinearResponseSolver.h
@@ -43,9 +43,8 @@ protected:
                                           const ComplexMatrix &M,
                                           bool adjoint);
 
-    double calcProperty();
-    double calcPropertyError() const;
     void printProperty() const;
+    double calcProperty();
 };
 
 } //namespace mrchem

--- a/src/scf_solver/OrbitalOptimizer.cpp
+++ b/src/scf_solver/OrbitalOptimizer.cpp
@@ -50,7 +50,7 @@ void OrbitalOptimizer::setup(FockOperator &fock,
 /** @brief Clear solver after optimization
  *
  * Clear pointers that was set during setup, and reset the precision parameter
- * (only the current precision orbPrec[0], not the bounaary values orbPrec[1,2]).
+ * (only the current precision orbPrec[0], not the boundary values orbPrec[1,2]).
  * Solver can be re-used after another setup.
  */
 void OrbitalOptimizer::clear() {


### PR DESCRIPTION
Imported preliminary LinearResponseSolver from the old code. Only works for imaginary perturbations in pure DFT where the electronic Hessian contribution vanishes, e.i. static magnetic perturbations. Tested for LDA magnetizabilities. The structure is likely to change in the future, but it is a starting point for implementing and testing the Hessians.