### PR TITLE
Energy optimizer

### DIFF
--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -63,11 +63,12 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, int spin) {
     FunctionTreeVector<3> dens_vec;
     for (int i = 0; i < Phi.size(); i++) {
         if (mpi::my_orb(Phi[i])) {
-            Density *rho_i = new Density();
-            rho_i->setReal(new mrcpp::FunctionTree<3>(*MRA));
-            mrcpp::copy_grid(rho_i->real(), rho.real());
-            density::compute(mult_prec, *rho_i, Phi[i], spin);
-            dens_vec.push_back(std::make_tuple(1.0, &(rho_i->real())));
+            Density rho_i;
+            rho_i.alloc(NUMBER::Real);
+            mrcpp::copy_grid(rho_i.real(), rho.real());
+            density::compute(mult_prec, rho_i, Phi[i], spin);
+            dens_vec.push_back(std::make_tuple(1.0, &(rho_i.real())));
+            rho_i.clear(); // release FunctionTree pointers to dens_vec
         }
     }
 

--- a/src/qmoperators/two_electron/CoulombPotential.cpp
+++ b/src/qmoperators/two_electron/CoulombPotential.cpp
@@ -30,7 +30,11 @@ CoulombPotential::CoulombPotential(PoissonOperator *P, OrbitalVector *Phi)
           density(), //LUCA: check constructor
           orbitals(Phi),
           poisson(P) {
-    density.setReal(new FunctionTree<3>(*MRA));
+    density.alloc(NUMBER::Real);
+}
+
+CoulombPotential::~CoulombPotential() {
+    this->density.free();
 }
 
 /** @brief prepare operator for application

--- a/src/qmoperators/two_electron/CoulombPotential.h
+++ b/src/qmoperators/two_electron/CoulombPotential.h
@@ -26,6 +26,7 @@ namespace mrchem {
 class CoulombPotential final : public QMPotential {
 public:
     CoulombPotential(mrcpp::PoissonOperator *P, OrbitalVector *Phi = nullptr);
+    ~CoulombPotential();
 
     friend class CoulombOperator;
 

--- a/src/qmoperators/two_electron/FockOperator.cpp
+++ b/src/qmoperators/two_electron/FockOperator.cpp
@@ -50,6 +50,9 @@ FockOperator::FockOperator(KineticOperator  *t,
  * 
  */
 void FockOperator::build() {
+    this->T = RankZeroTensorOperator();
+    if (this->kin  != nullptr) this->T += *this->kin;
+
     this->V = RankZeroTensorOperator();
     if (this->nuc  != nullptr) this->V += *this->nuc;
     if (this->coul != nullptr) this->V += *this->coul;

--- a/src/qmoperators/two_electron/FockOperator.h
+++ b/src/qmoperators/two_electron/FockOperator.h
@@ -31,7 +31,7 @@ public:
                  XCOperator             *xc = nullptr,
                  ElectricFieldOperator *ext = nullptr);
 
-    KineticOperator        &kinetic()       { return *this->kin; }
+    RankZeroTensorOperator &kinetic()       { return this->T; }
     RankZeroTensorOperator &potential()     { return this->V; }
     RankZeroTensorOperator &perturbation()  { return this->H_1; }
 
@@ -58,6 +58,7 @@ public:
     SCFEnergy trace(OrbitalVector &Phi, const ComplexMatrix &F);
 
 protected:
+    RankZeroTensorOperator T;     ///< Total kinetic energy operator
     RankZeroTensorOperator V;     ///< Total potential energy operator
     RankZeroTensorOperator H_1;   ///< Perturbation operators
 

--- a/src/scf_solver/EnergyOptimizer.cpp
+++ b/src/scf_solver/EnergyOptimizer.cpp
@@ -281,6 +281,7 @@ ComplexMatrix EnergyOptimizer::calcFockMatrixUpdate(double prec, OrbitalVector &
     {   // Computing potential matrix excluding nuclear part
         Timer timer;
         FockOperator fock_n(0, 0, j_n, k_n, xc_n);
+        fock_n.build();
         F_n = fock_n(Phi_np1, Phi_n);
         timer.stop();
         double t = timer.getWallTime();
@@ -306,9 +307,9 @@ ComplexMatrix EnergyOptimizer::calcFockMatrixUpdate(double prec, OrbitalVector &
     {   // Computing potential matrix excluding nuclear part
         Timer timer;
         FockOperator fock_np1(0, 0, j_np1, k_np1, xc_np1);
+        fock_np1.build();
         ComplexMatrix F_1 = fock_np1(Phi_n, Phi_n);
         ComplexMatrix F_2 = fock_np1(Phi_n, dPhi_n);
-        fock_np1.clear();
 
         F_np1 = F_1 + F_2 + F_2.transpose();
         //ComplexMatrix F_3 = f_np1(*this->dPhi_n, *this->phi_n);
@@ -318,6 +319,9 @@ ComplexMatrix EnergyOptimizer::calcFockMatrixUpdate(double prec, OrbitalVector &
         double t = timer.getWallTime();
         Printer::printDouble(0, "Fock matrix n+1", t, 5);
     }
+    if (j_np1 != 0)   j_np1->clear();
+    if (k_np1 != 0)   k_np1->clear();
+    if (xc_np1 != 0) xc_np1->clear();
 
     // Re-computing non-orthogonal phi_np1
     orbital::free(Phi_np1);


### PR DESCRIPTION
The helium example crashed in the second SCF procedure (energy optimization) due to a faulty initialization of the n+1 FockOperator. Also fixed a memleak in CoulombPotential.