### PR TITLE
Activate MPI test case on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,7 @@ jobs:
       - *report
       - *configure-mpi
       - *build
+      - *tests
 
 workflows:
   version: 2

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ Profiling*
 build*
 debug*
 release*
+install*
 intel*
 pilot
 mrcpp.config

--- a/cmake/custom/testing_macros.cmake
+++ b/cmake/custom/testing_macros.cmake
@@ -1,5 +1,5 @@
 macro(add_integration_test)
-  set(oneValueArgs NAME COST)
+  set(oneValueArgs NAME COST LAUNCH_AGENT)
   set(multiValueArgs LABELS DEPENDS REFERENCE_FILES)
   cmake_parse_arguments(_integration_test
     "${options}"
@@ -15,6 +15,7 @@ macro(add_integration_test)
       ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/test
       --binary=$<TARGET_FILE_DIR:mrchem.x>
       --work-dir=${CMAKE_CURRENT_BINARY_DIR}
+      --launch-agent ${_integration_test_LAUNCH_AGENT}
       --verbose
       # The input file
     WORKING_DIRECTORY

--- a/tests/h2/CMakeLists.txt
+++ b/tests/h2/CMakeLists.txt
@@ -1,5 +1,12 @@
+set(_h2_launcher " ")
+
+if(ENABLE_MPI)
+    set(_h2_launcher "mpirun -np 1")
+endif()
+
 add_integration_test(
   NAME h2
   LABELS "mrchem;h2"
-  COST 50
+  COST 100
+  LAUNCH_AGENT ${_h2_launcher}
   )

--- a/tests/h2/test
+++ b/tests/h2/test
@@ -11,19 +11,19 @@ from runtest_config import configure  # isort:skip
 assert version_info.major == 2
 
 f = [
-    get_filter(string='Sum orbital energy:',           rel_tolerance=1.0e-9),
-    get_filter(string='Kinetic energy:',               rel_tolerance=1.0e-9),
-    get_filter(string='E-N energy:',                   rel_tolerance=1.0e-9),
-    get_filter(string='Coulomb energy:',               rel_tolerance=1.0e-9),
-    get_filter(string='Exchange energy:',              rel_tolerance=1.0e-9),
-    get_filter(string='X-C energy:',                   rel_tolerance=1.0e-9),
-    get_filter(string='Electronic energy:',            rel_tolerance=1.0e-9),
-    get_filter(string='Nuclear energy:',               rel_tolerance=1.0e-9),
-    get_filter(string='Total energy       (au)',       rel_tolerance=1.0e-9),
-    get_filter(string='                   (kJ/mol)',   rel_tolerance=1.0e-9),
-    get_filter(string='                   (kcal/mol)', rel_tolerance=1.0e-9),
-    get_filter(string='                   (eV)',       rel_tolerance=1.0e-9),
-    get_filter(string='(Debye)',                       abs_tolerance=1.0e-9),
+    get_filter(string='Sum orbital energy:',           rel_tolerance=1.0e-6),
+    get_filter(string='Kinetic energy:',               rel_tolerance=1.0e-6),
+    get_filter(string='E-N energy:',                   rel_tolerance=1.0e-6),
+    get_filter(string='Coulomb energy:',               rel_tolerance=1.0e-6),
+    get_filter(string='Exchange energy:',              rel_tolerance=1.0e-6),
+    get_filter(string='X-C energy:',                   rel_tolerance=1.0e-6),
+    get_filter(string='Electronic energy:',            rel_tolerance=1.0e-6),
+    get_filter(string='Nuclear energy:',               rel_tolerance=1.0e-6),
+    get_filter(string='Total energy       (au)',       rel_tolerance=1.0e-6),
+    get_filter(string='                   (kJ/mol)',   rel_tolerance=1.0e-6),
+    get_filter(string='                   (kcal/mol)', rel_tolerance=1.0e-6),
+    get_filter(string='                   (eV)',       rel_tolerance=1.0e-6),
+    get_filter(string='(Debye)',                       abs_tolerance=1.0e-6),
 ]
 
 options = cli()

--- a/tests/h2o/CMakeLists.txt
+++ b/tests/h2o/CMakeLists.txt
@@ -1,5 +1,12 @@
+set(_h2o_launcher " ")
+
+if(ENABLE_MPI)
+    set(_h2o_launcher "mpirun -np 5")
+endif()
+
 add_integration_test(
   NAME h2o
   LABELS "mrchem;h2o"
   COST 100
+  LAUNCH_AGENT ${_h2o_launcher}
   )

--- a/tests/h2o/test
+++ b/tests/h2o/test
@@ -11,19 +11,19 @@ from runtest_config import configure  # isort:skip
 assert version_info.major == 2
 
 f = [
-    get_filter(string='Sum orbital energy:',           rel_tolerance=1.0e-9),
-    get_filter(string='Kinetic energy:',               rel_tolerance=1.0e-9),
-    get_filter(string='E-N energy:',                   rel_tolerance=1.0e-9),
-    get_filter(string='Coulomb energy:',               rel_tolerance=1.0e-9),
-    get_filter(string='Exchange energy:',              rel_tolerance=1.0e-9),
-    get_filter(string='X-C energy:',                   rel_tolerance=1.0e-9),
-    get_filter(string='Electronic energy:',            rel_tolerance=1.0e-9),
-    get_filter(string='Nuclear energy:',               rel_tolerance=1.0e-9),
-    get_filter(string='Total energy       (au)',       rel_tolerance=1.0e-9),
-    get_filter(string='                   (kJ/mol)',   rel_tolerance=1.0e-9),
-    get_filter(string='                   (kcal/mol)', rel_tolerance=1.0e-9),
-    get_filter(string='                   (eV)',       rel_tolerance=1.0e-9),
-    get_filter(string='(Debye)',                       abs_tolerance=1.0e-9),
+    get_filter(string='Sum orbital energy:',           rel_tolerance=1.0e-6),
+    get_filter(string='Kinetic energy:',               rel_tolerance=1.0e-6),
+    get_filter(string='E-N energy:',                   rel_tolerance=1.0e-6),
+    get_filter(string='Coulomb energy:',               rel_tolerance=1.0e-6),
+    get_filter(string='Exchange energy:',              rel_tolerance=1.0e-6),
+    get_filter(string='X-C energy:',                   rel_tolerance=1.0e-6),
+    get_filter(string='Electronic energy:',            rel_tolerance=1.0e-6),
+    get_filter(string='Nuclear energy:',               rel_tolerance=1.0e-6),
+    get_filter(string='Total energy       (au)',       rel_tolerance=1.0e-6),
+    get_filter(string='                   (kJ/mol)',   rel_tolerance=1.0e-6),
+    get_filter(string='                   (kcal/mol)', rel_tolerance=1.0e-6),
+    get_filter(string='                   (eV)',       rel_tolerance=1.0e-6),
+    get_filter(string='(Debye)',                       abs_tolerance=1.0e-6),
 ]
 
 options = cli()

--- a/tests/li/CMakeLists.txt
+++ b/tests/li/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_integration_test(
   NAME li
   LABELS "mrchem;li"
+  COST 100
   )

--- a/tests/li/CMakeLists.txt
+++ b/tests/li/CMakeLists.txt
@@ -1,5 +1,12 @@
+set(_li_launcher " ")
+
+if(ENABLE_MPI)
+    set(_li_launcher "mpirun -np 2")
+endif()
+
 add_integration_test(
   NAME li
   LABELS "mrchem;li"
   COST 100
+  LAUNCH_AGENT ${_li_launcher}
   )

--- a/tests/li/test
+++ b/tests/li/test
@@ -11,18 +11,18 @@ from runtest_config import configure  # isort:skip
 assert version_info.major == 2
 
 f = [
-    get_filter(string='Sum orbital energy:',           rel_tolerance=1.0e-9),
-    get_filter(string='Kinetic energy:',               rel_tolerance=1.0e-9),
-    get_filter(string='E-N energy:',                   rel_tolerance=1.0e-9),
-    get_filter(string='Coulomb energy:',               rel_tolerance=1.0e-9),
-    get_filter(string='Exchange energy:',              rel_tolerance=1.0e-9),
-    get_filter(string='X-C energy:',                   rel_tolerance=1.0e-9),
-    get_filter(string='Electronic energy:',            rel_tolerance=1.0e-9),
-    get_filter(string='Nuclear energy:',               rel_tolerance=1.0e-9),
-    get_filter(string='Total energy       (au)',       rel_tolerance=1.0e-9),
-    get_filter(string='                   (kJ/mol)',   rel_tolerance=1.0e-9),
-    get_filter(string='                   (kcal/mol)', rel_tolerance=1.0e-9),
-    get_filter(string='                   (eV)',       rel_tolerance=1.0e-9),
+    get_filter(string='Sum orbital energy:',           rel_tolerance=1.0e-6),
+    get_filter(string='Kinetic energy:',               rel_tolerance=1.0e-6),
+    get_filter(string='E-N energy:',                   rel_tolerance=1.0e-6),
+    get_filter(string='Coulomb energy:',               rel_tolerance=1.0e-6),
+    get_filter(string='Exchange energy:',              rel_tolerance=1.0e-6),
+    get_filter(string='X-C energy:',                   rel_tolerance=1.0e-6),
+    get_filter(string='Electronic energy:',            rel_tolerance=1.0e-6),
+    get_filter(string='Nuclear energy:',               rel_tolerance=1.0e-6),
+    get_filter(string='Total energy       (au)',       rel_tolerance=1.0e-6),
+    get_filter(string='                   (kJ/mol)',   rel_tolerance=1.0e-6),
+    get_filter(string='                   (kcal/mol)', rel_tolerance=1.0e-6),
+    get_filter(string='                   (eV)',       rel_tolerance=1.0e-6),
 ]
 
 options = cli()

--- a/tests/runtest/cli.py
+++ b/tests/runtest/cli.py
@@ -17,12 +17,17 @@ def cli():
                       '-b',
                       action='store',
                       default=caller_dir,
-                      help='directory containing the binary/launcher [default: %default]')
+                      help='directory containing the binary/runscript [default: %default]')
     parser.add_option('--work-dir',
                       '-w',
                       action='store',
                       default=caller_dir,
                       help='working directory [default: %default]')
+    parser.add_option('--launch-agent',
+                      '-l',
+                      action='store',
+                      default=None,
+                      help='prepend a launch agent command (e.g. "mpirun -np 8" or "valgrind --leak-check=yes") [default: %default]')
     parser.add_option('--verbose',
                       '-v',
                       action='store_true',

--- a/tests/runtest/run.py
+++ b/tests/runtest/run.py
@@ -22,6 +22,9 @@ def run(options, configure, input_files, extra_args=None, filters=None, accepted
 
     launcher, command, output_prefix, relative_reference_path = configure(options, input_files, extra_args)
 
+    if options.launch_agent is not None:
+        command = '{0} {1}'.format(options.launch_agent, command)
+
     launch_script_path = os.path.normpath(os.path.join(options.binary_dir, launcher))
 
     if not options.skip_run and not os.path.exists(launch_script_path):
@@ -51,10 +54,18 @@ def run(options, configure, input_files, extra_args=None, filters=None, accepted
         else:
             _output_prefix = os.path.join(options.work_dir, output_prefix) + '.'
         with open('{0}{1}'.format(_output_prefix, 'stdout'), 'w') as f:
-            f.write(stdout)
+            try:
+                _s = stdout.decode('UTF-8')
+            except AttributeError:
+                _s = stdout
+            f.write(_s)
 
         with open('{0}{1}'.format(_output_prefix, 'stderr'), 'w') as f:
-            f.write(stderr)
+            try:
+                _s = stderr.decode('UTF-8')
+            except AttributeError:
+                _s = stderr
+            f.write(_s)
 
         if process.returncode != 0:
             sys.stdout.write('ERROR: crash during {0}\n{1}'.format(command, stderr))

--- a/tests/runtest/version.py
+++ b/tests/runtest/version.py
@@ -1,6 +1,6 @@
 from collections import namedtuple
 
-__version__ = '2.1.1-rc-1'
+__version__ = '2.2.0-rc-1'
 
 version_info = namedtuple('version_info', ['major', 'minor', 'micro', 'releaselevel'])
 

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -2,6 +2,7 @@
 #include "catch.hpp"
 
 #include "mrchem.h"
+#include "parallel.h"
 
 #include "MRCPP/MWFunctions"
 
@@ -12,6 +13,7 @@ void finalize_mra();
 
 int main(int argc, char *argv[]) {
     // global setup
+    mrchem::mpi::initialize(argc, argv);
     initialize_mra();
 
     // run tests
@@ -19,7 +21,7 @@ int main(int argc, char *argv[]) {
 
     // global cleanup
     finalize_mra();
-
+    mrchem::mpi::finalize();
     return (result < 0xff ? result : 0xff);
 }
 
@@ -29,8 +31,8 @@ void initialize_mra() {
     int max_depth = 25;
 
     // Constructing world box
-    int corner[3] = {-1,-1,-1};
-    int boxes[3]  = { 2, 2, 2};
+    int corner[3] = {-1, -1, -1};
+    int boxes[3] = {2, 2, 2};
     mrcpp::BoundingBox<3> world(min_scale, corner, boxes);
 
     // Constructing basis
@@ -45,4 +47,3 @@ void finalize_mra() {
     if (mrchem::MRA != 0) delete mrchem::MRA;
     mrchem::MRA = 0;
 }
-


### PR DESCRIPTION
Unit tests
------------
- Added `MPI_Init` and `MPI_Finalize` so that the tests run without failing, but all test cases are fully sequential

Integration tests
--------------------
- Update `runtest` to allow for `mpirun` launch agent
- The test cases are run with a fixed number of MPI processes when compiled with MPI options
- Relaxed the success criterion for the properties, since we currently cannot expect identical results when running with different number of MPI procs

Not at all sure if this is a sensible way of passing arguments from CMake -> CTest -> runtest