### PR TITLE
Extra functionality to the Denisty class

### DIFF
--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -47,17 +47,9 @@ extern mrcpp::MultiResolutionAnalysis<3> *MRA; // Global MRA
  ****************************************/
 
 void density::compute(double prec, Density &rho, Orbital phi, int spin) {
-    double occ_a(0.0), occ_b(0.0), occ_p(0.0);
-    if (phi.spin() == SPIN::Alpha)  occ_a = (double) phi.occ();
-    if (phi.spin() == SPIN::Beta)   occ_b = (double) phi.occ();
-    if (phi.spin() == SPIN::Paired) occ_p = (double) phi.occ();
 
-    double occ(0.0);
-    if (spin == DENSITY::Total) occ = occ_a + occ_b + occ_p;
-    if (spin == DENSITY::Alpha) occ = occ_a + 0.5*occ_p;
-    if (spin == DENSITY::Beta)  occ = occ_b + 0.5*occ_p;
-    if (spin == DENSITY::Spin)  occ = occ_a - occ_b;
-
+    double occ = compute_occupation(phi.spin(), phi.occ(), spin);
+    
     if (std::abs(occ) < mrcpp::MachineZero) {
         rho.real().setZero();
         return;
@@ -82,16 +74,8 @@ void density::compute(double prec, Density &rho, Orbital phi, int spin) {
 }
 
 void density::compute(double prec, Density &rho, Orbital phi, Orbital xi, int spin) {
-    double occ_a(0.0), occ_b(0.0), occ_p(0.0);
-    if (phi.spin() == SPIN::Alpha)  occ_a = (double) phi.occ();
-    if (phi.spin() == SPIN::Beta)   occ_b = (double) phi.occ();
-    if (phi.spin() == SPIN::Paired) occ_p = (double) phi.occ();
-    
-    double occ(0.0);
-    if (spin == DENSITY::Total) occ = occ_a + occ_b + occ_p;
-    if (spin == DENSITY::Alpha) occ = occ_a + 0.5*occ_p;
-    if (spin == DENSITY::Beta)  occ = occ_b + 0.5*occ_p;
-    if (spin == DENSITY::Spin)  occ = occ_a - occ_b;
+
+    double occ = compute_occupation(phi.spin(), phi.occ(), spin);
 
     if (std::abs(occ) < mrcpp::MachineZero) {
         rho.real().setZero();
@@ -186,4 +170,19 @@ void density::compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, i
     mrcpp::project(prec, rho.real(), dens_exp);
 }
 
+double density::compute_occupation(int orb_spin, int orb_occ, int dens_spin) {
+    double occ_a(0.0), occ_b(0.0), occ_p(0.0);
+    if (orb_spin == SPIN::Alpha)  occ_a = (double) orb_occ;
+    if (orb_spin == SPIN::Beta)   occ_b = (double) orb_occ;
+    if (orb_spin == SPIN::Paired) occ_p = (double) orb_occ;
+    
+    double occ(0.0);
+    if (dens_spin == DENSITY::Total) occ = occ_a + occ_b + occ_p;
+    if (dens_spin == DENSITY::Alpha) occ = occ_a + 0.5*occ_p;
+    if (dens_spin == DENSITY::Beta)  occ = occ_b + 0.5*occ_p;
+    if (dens_spin == DENSITY::Spin)  occ = occ_a - occ_b;
+
+    return occ;
+}
+    
 } //namespace mrchem

--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -157,7 +157,7 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVect
     for (int i = 0; i < Phi.size(); i++) {
         if (mpi::my_orb(Phi[i])) {
             Density *rho_i = new Density(); //LUCA: Is it the right creator here (it was Density(*MRA);
-            rho_i->allocReal();
+            rho_i->alloc(NUMBER::Real);
             mrcpp::copy_grid(rho_i->real(), rho.real());
             density::compute(mult_prec, *rho_i, Phi[i], Phi_x[i], spin);
             dens_vec.push_back(std::make_tuple(1.0, &(rho_i->real())));

--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -29,6 +29,8 @@
 
 #include "parallel.h"
 
+#include "QMFunction.h"
+#include "qmfunction_utils.h"
 #include "Density.h"
 #include "density_utils.h"
 #include "Orbital.h"
@@ -46,14 +48,7 @@ extern mrcpp::MultiResolutionAnalysis<3> *MRA; // Global MRA
  * Density related standalone functions *
  ****************************************/
 
-void density::compute(double prec, Density &rho, Orbital phi, int spin) {
-
-    double occ = compute_occupation(phi.spin(), phi.occ(), spin);
-    
-    if (std::abs(occ) < mrcpp::MachineZero) {
-        rho.real().setZero();
-        return;
-    }
+void density::compute(double prec, Density &rho, Orbital phi, double occ) {
 
     FunctionTreeVector<3> sum_vec;
     if (phi.hasReal()) {
@@ -73,35 +68,22 @@ void density::compute(double prec, Density &rho, Orbital phi, int spin) {
     mrcpp::clear(sum_vec, true);
 }
 
-void density::compute(double prec, Density &rho, Orbital phi, Orbital xi, int spin) {
+void density::compute(double prec, Density &rho, Orbital ket, Orbital bra, double coeff, int type) {
 
-    double occ = compute_occupation(phi.spin(), phi.occ(), spin);
-
-    if (std::abs(occ) < mrcpp::MachineZero) {
-        rho.real().setZero();
-        return;
+    double ket_conj(1.0), bra_conj(1.0);
+    if (ket.conjugate()) ket_conj = -1.0;
+    if (bra.conjugate()) bra_conj = -1.0;
+    
+    if (type == NUMBER::Total) {
+        qmfunction::multiply(ket, ket_conj, bra, -1.0 * bra_conj, rho, prec);
+        rho.real().rescale(coeff);
+        rho.imag().rescale(coeff);
+    } else if (type == NUMBER::Real) {
+        qmfunction::multiply_real(ket, ket_conj, bra, -1.0 * bra_conj, rho, prec);
+        rho.real().rescale(coeff);
+    } else {
+        MSG_FATAL("No such case");
     }
-
-    FunctionTreeVector<3> sum_vec;
-    if (phi.hasReal() and xi.hasReal()) {
-        FunctionTree<3> *phir_xir = new FunctionTree<3>(*MRA);
-        //        mrcpp::copy_grid(*phir_xir, phi.real()); LUCA should this be here? Should there be a build_grid?
-        mrcpp::multiply(prec, *phir_xir, 2.0, phi.real(), xi.real());
-        sum_vec.push_back(std::make_tuple(occ, phir_xir));
-    }
-    if (phi.hasImag() and xi.hasImag()) {
-        FunctionTree<3> *phii_xii = new FunctionTree<3>(*MRA);
-        //        mrcpp::copy_grid(*phii_xii, phi.imag()); LUCA should this be here? Should there be a build_grid?
-        mrcpp::multiply(prec, *phii_xii, 2.0, phi.imag(), xi.imag());
-        sum_vec.push_back(std::make_tuple(occ, phii_xii));
-    }
-    mrcpp::build_grid(rho.real(), sum_vec);
-    mrcpp::add(-1.0, rho.real(), sum_vec, 0);
-    mrcpp::clear(sum_vec, true);
-}
-
-void density::compute(double prec, Density &rho, Orbital phi, Orbital xi, Orbital yi, int spin) {
-    MSG_FATAL("NOT IMPLEMENTED ABORT");
 }
 
 void density::compute(double prec, Density &rho, OrbitalVector &Phi, int spin) {
@@ -111,10 +93,12 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, int spin) {
     FunctionTreeVector<3> dens_vec;
     for (int i = 0; i < Phi.size(); i++) {
         if (mpi::my_orb(Phi[i])) {
+            double occ = compute_occupation(Phi[i].spin(), Phi[i].occ(), spin);
+            if (std::abs(occ) < mrcpp::MachineZero) continue;
             Density rho_i;
             rho_i.alloc(NUMBER::Real);
             mrcpp::copy_grid(rho_i.real(), rho.real());
-            density::compute(mult_prec, rho_i, Phi[i], spin);
+            density::compute(mult_prec, rho_i, Phi[i], occ);
             dens_vec.push_back(std::make_tuple(1.0, &(rho_i.real())));
             rho_i.clear(); // release FunctionTree pointers to dens_vec
         }
@@ -132,6 +116,8 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, int spin) {
     mpi::broadcast_density(rho, mpi::comm_orb);
 }
 
+
+//LUCA Is the MPI distribution of Phi identical to Phi_x and Phi_y??? Now I 
 void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, int spin) {
     double mult_prec = prec;            // prec for \rho_i = |\phi_i|^2
     double add_prec = prec/Phi.size();  // prec for \sum_i \rho_i
@@ -140,10 +126,12 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVect
     FunctionTreeVector<3> dens_vec;
     for (int i = 0; i < Phi.size(); i++) {
         if (mpi::my_orb(Phi[i])) {
-            Density *rho_i = new Density(); //LUCA: Is it the right creator here (it was Density(*MRA);
+            double occ = compute_occupation(Phi[i].spin(), Phi[i].occ(), spin);
+            if (std::abs(occ) < mrcpp::MachineZero) continue; //next orbital if this one is not occupied!
+            Density *rho_i = new Density(); 
             rho_i->alloc(NUMBER::Real);
             mrcpp::copy_grid(rho_i->real(), rho.real());
-            density::compute(mult_prec, *rho_i, Phi[i], Phi_x[i], spin);
+            density::compute(mult_prec, *rho_i, Phi[i], Phi_x[i], 2.0 * occ, NUMBER::Real);
             dens_vec.push_back(std::make_tuple(1.0, &(rho_i->real())));
         }
     }
@@ -160,8 +148,56 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVect
     mpi::broadcast_density(rho, mpi::comm_orb);
 }
 
-void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, OrbitalVector &Phy_y, int spin) {
-    MSG_FATAL("NOT IMPLEMENTED ABORT");
+//LUCA Is the MPI distribution of Phi identical to Phi_x and Phi_y??? Now I 
+void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, OrbitalVector &Phi_y, int spin) {
+    double mult_prec = prec;            // prec for \rho_i = |\phi_i|^2
+    double add_prec = prec/Phi.size();  // prec for \sum_i \rho_i
+    if (Phi.size() != Phi_x.size()) MSG_ERROR("Size mismatch");
+    
+    FunctionTreeVector<3> dens_real;
+    FunctionTreeVector<3> dens_imag;
+    for (int i = 0; i < Phi.size(); i++) {
+        if (mpi::my_orb(Phi[i])) {
+            //if(mpi::my_orb(Phi_x[i])) ....
+            double occ = compute_occupation(Phi[i].spin(), Phi[i].occ(), spin);
+            if (std::abs(occ) < mrcpp::MachineZero) continue; //next orbital if this one is not occupied!
+            Density *rho_x = new Density(); 
+            Density *rho_y = new Density(); 
+            rho_x->alloc(NUMBER::Real);
+            rho_y->alloc(NUMBER::Real);
+            rho_x->alloc(NUMBER::Imag);
+            rho_y->alloc(NUMBER::Imag);
+            mrcpp::copy_grid(rho_x->real(), rho.real());
+            mrcpp::copy_grid(rho_y->real(), rho.real());
+            mrcpp::copy_grid(rho_x->imag(), rho.imag());
+            mrcpp::copy_grid(rho_y->imag(), rho.imag());
+            density::compute(mult_prec, *rho_x, Phi_x[i], Phi[i], occ, NUMBER::Total);
+            density::compute(mult_prec, *rho_y, Phi[i], Phi_y[i], occ, NUMBER::Total);
+            dens_real.push_back(std::make_tuple(1.0, &(rho_x->real())));
+            dens_real.push_back(std::make_tuple(1.0, &(rho_y->real())));
+            dens_imag.push_back(std::make_tuple(1.0, &(rho_x->imag())));
+            dens_imag.push_back(std::make_tuple(1.0, &(rho_y->imag())));
+        }
+    }
+
+    if (add_prec > 0.0) {
+        mrcpp::add(add_prec, rho.real(), dens_real);
+        mrcpp::add(add_prec, rho.imag(), dens_imag);
+    } else {
+        if (dens_real.size() > 0) {
+            mrcpp::build_grid(rho.real(), dens_real);
+            mrcpp::add(-1.0,  rho.real(), dens_real, 0);
+        }
+        if (dens_imag.size() > 0) {
+            mrcpp::build_grid(rho.imag(), dens_imag);
+            mrcpp::add(-1.0,  rho.imag(), dens_imag, 0);
+        }
+    }
+    mrcpp::clear(dens_real, true);
+    mrcpp::clear(dens_imag, true);
+
+    mpi::reduce_density(rho, mpi::comm_orb);
+    mpi::broadcast_density(rho, mpi::comm_orb);
 }
 
 void density::compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, int spin) {

--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -48,8 +48,13 @@ extern mrcpp::MultiResolutionAnalysis<3> *MRA; // Global MRA
  * Density related standalone functions *
  ****************************************/
 
+void compute(double prec, Density &rho, Orbital phi, double occ);
+void compute(double prec, Density &rho, Orbital ket, Orbital bra, double coeff, int type);
+
+
 void density::compute(double prec, Density &rho, Orbital phi, double occ) {
 
+    std::cout  << "OCC " << occ << std::endl;
     FunctionTreeVector<3> sum_vec;
     if (phi.hasReal()) {
         FunctionTree<3> *real_2 = new FunctionTree<3>(*MRA);

--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -50,11 +50,10 @@ extern mrcpp::MultiResolutionAnalysis<3> *MRA; // Global MRA
 
 void compute(double prec, Density &rho, Orbital phi, double occ);
 void compute(double prec, Density &rho, Orbital ket, Orbital bra, double coeff, int type);
-
+double compute_occupation(int orb_spin, int orb_occ, int dens_spin);
 
 void density::compute(double prec, Density &rho, Orbital phi, double occ) {
 
-    std::cout  << "OCC " << occ << std::endl;
     FunctionTreeVector<3> sum_vec;
     if (phi.hasReal()) {
         FunctionTree<3> *real_2 = new FunctionTree<3>(*MRA);

--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -52,7 +52,7 @@ void compute(double prec, Density &rho, Orbital phi, double occ);
 void compute(double prec, Density &rho, Orbital ket, Orbital bra, double coeff, int type);
 double compute_occupation(int orb_spin, int orb_occ, int dens_spin);
 
-void density::compute(double prec, Density &rho, Orbital phi, double occ) {
+void compute(double prec, Density &rho, Orbital phi, double occ) {
 
     FunctionTreeVector<3> sum_vec;
     if (phi.hasReal()) {
@@ -72,7 +72,7 @@ void density::compute(double prec, Density &rho, Orbital phi, double occ) {
     mrcpp::clear(sum_vec, true);
 }
 
-void density::compute(double prec, Density &rho, Orbital ket, Orbital bra, double coeff, int type) {
+void compute(double prec, Density &rho, Orbital ket, Orbital bra, double coeff, int type) {
 
     double ket_conj(1.0), bra_conj(1.0);
     if (ket.conjugate()) ket_conj = -1.0;
@@ -102,7 +102,7 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, int spin) {
             Density rho_i;
             rho_i.alloc(NUMBER::Real);
             mrcpp::copy_grid(rho_i.real(), rho.real());
-            density::compute(mult_prec, rho_i, Phi[i], occ);
+            compute(mult_prec, rho_i, Phi[i], occ);
             dens_vec.push_back(std::make_tuple(1.0, &(rho_i.real())));
             rho_i.clear(); // release FunctionTree pointers to dens_vec
         }
@@ -135,7 +135,7 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVect
             Density *rho_i = new Density(); 
             rho_i->alloc(NUMBER::Real);
             mrcpp::copy_grid(rho_i->real(), rho.real());
-            density::compute(mult_prec, *rho_i, Phi[i], Phi_x[i], 2.0 * occ, NUMBER::Real);
+            compute(mult_prec, *rho_i, Phi[i], Phi_x[i], 2.0 * occ, NUMBER::Real);
             dens_vec.push_back(std::make_tuple(1.0, &(rho_i->real())));
         }
     }
@@ -175,8 +175,8 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVect
             mrcpp::copy_grid(rho_y->real(), rho.real());
             mrcpp::copy_grid(rho_x->imag(), rho.imag());
             mrcpp::copy_grid(rho_y->imag(), rho.imag());
-            density::compute(mult_prec, *rho_x, Phi_x[i], Phi[i], occ, NUMBER::Total);
-            density::compute(mult_prec, *rho_y, Phi[i], Phi_y[i], occ, NUMBER::Total);
+            compute(mult_prec, *rho_x, Phi_x[i], Phi[i], occ, NUMBER::Total);
+            compute(mult_prec, *rho_y, Phi[i], Phi_y[i], occ, NUMBER::Total);
             dens_real.push_back(std::make_tuple(1.0, &(rho_x->real())));
             dens_real.push_back(std::make_tuple(1.0, &(rho_y->real())));
             dens_imag.push_back(std::make_tuple(1.0, &(rho_x->imag())));
@@ -210,7 +210,7 @@ void density::compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, i
     mrcpp::project(prec, rho.real(), dens_exp);
 }
 
-double density::compute_occupation(int orb_spin, int orb_occ, int dens_spin) {
+double compute_occupation(int orb_spin, int orb_occ, int dens_spin) {
     double occ_a(0.0), occ_b(0.0), occ_p(0.0);
     if (orb_spin == SPIN::Alpha)  occ_a = (double) orb_occ;
     if (orb_spin == SPIN::Beta)   occ_b = (double) orb_occ;

--- a/src/qmfunctions/density_utils.h
+++ b/src/qmfunctions/density_utils.h
@@ -31,15 +31,11 @@ namespace mrchem {
 
 namespace density {
 
-void compute(double prec, Density &rho, Orbital phi, double occ);
-void compute(double prec, Density &rho, Orbital ket, Orbital bra, double coeff, int type);
 void compute(double prec, Density &rho, OrbitalVector &Phi, int spin);
 void compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, int spin);
 void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, int spin);
 void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, OrbitalVector &Phi_y, int spin);
  
-double compute_occupation(int orb_spin, int orb_occ, int dens_spin);
-
 } //namespace density
 
 } //namespace mrchem

--- a/src/qmfunctions/density_utils.h
+++ b/src/qmfunctions/density_utils.h
@@ -31,9 +31,8 @@ namespace mrchem {
 
 namespace density {
 
-void compute(double prec, Density &rho, Orbital phi, int spin);
-void compute(double prec, Density &rho, Orbital phi, Orbital xi, int spin);
-void compute(double prec, Density &rho, Orbital phi, Orbital xi, Orbital yi, int spin);
+void compute(double prec, Density &rho, Orbital phi, double occ);
+void compute(double prec, Density &rho, Orbital ket, Orbital bra, double coeff, int type);
 void compute(double prec, Density &rho, OrbitalVector &Phi, int spin);
 void compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, int spin);
 void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, int spin);

--- a/src/qmfunctions/density_utils.h
+++ b/src/qmfunctions/density_utils.h
@@ -32,8 +32,12 @@ namespace mrchem {
 namespace density {
 
 void compute(double prec, Density &rho, Orbital phi, int spin);
+void compute(double prec, Density &rho, Orbital phi, Orbital xi, int spin);
+void compute(double prec, Density &rho, Orbital phi, Orbital xi, Orbital yi, int spin);
 void compute(double prec, Density &rho, OrbitalVector &Phi, int spin);
 void compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, int spin);
+void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, int spin);
+void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, OrbitalVector &Phi_y, int spin);
 
 } //namespace density
 

--- a/src/qmfunctions/density_utils.h
+++ b/src/qmfunctions/density_utils.h
@@ -38,6 +38,8 @@ void compute(double prec, Density &rho, OrbitalVector &Phi, int spin);
 void compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, int spin);
 void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, int spin);
 void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, OrbitalVector &Phi_y, int spin);
+ 
+double compute_occupation(int orb_spin, int orb_occ, int dens_spin);
 
 } //namespace density
 

--- a/src/qmfunctions/qmfunction_utils.h
+++ b/src/qmfunctions/qmfunction_utils.h
@@ -35,6 +35,14 @@ namespace qmfunction {
 ComplexDouble dot(QMFunction &bra, double bra_conj,
                   QMFunction &ket, double ket_conj);
  
+void multiply_real(QMFunction &inp_a, double conj_a,
+                               QMFunction &inp_b, double conj_b,
+                               QMFunction &out, double prec);
+ 
+void multiply_imag(QMFunction &inp_a, double conj_a,
+                               QMFunction &inp_b, double conj_b,
+                               QMFunction &out, double prec);
+ 
 void multiply(QMFunction &inp_a, double conj_a,
               QMFunction &inp_b, double conj_b,
               QMFunction &out,   double prec);

--- a/tests/qmfunctions/density.cpp
+++ b/tests/qmfunctions/density.cpp
@@ -44,18 +44,6 @@ TEST_CASE("Density", "[density]") {
         Density rho;
         rho.setReal(new mrcpp::FunctionTree<3>(*MRA));
 
-        SECTION("single orbital") {
-            HydrogenFunction h(1,0,0);
-            Orbital phi(SPIN::Alpha);
-            phi.alloc(NUMBER::Real);
-            mrcpp::project(prec, phi.real(), h);
-            mrcpp::build_grid(rho.real(), phi.real());
-            density::compute(-1.0, rho, phi, DENSITY::Total);
-            REQUIRE( rho.real().integrate() == Approx(1.0) );
-
-            phi.free();
-        }
-        
         SECTION("orbital vector") {
             HydrogenFunction h_1(2,1,0);
             HydrogenFunction h_2(2,1,1);
@@ -88,28 +76,6 @@ TEST_CASE("Density", "[density]") {
         rho_a.setReal(new mrcpp::FunctionTree<3>(*MRA));
         rho_b.setReal(new mrcpp::FunctionTree<3>(*MRA));
 
-        SECTION("single orbital") {
-            HydrogenFunction h(1,0,0);
-            Orbital phi(SPIN::Alpha);
-            phi.alloc(NUMBER::Real);
-            mrcpp::project(prec, phi.real(), h);
-
-            mrcpp::build_grid(rho_t.real(), phi.real());
-            mrcpp::build_grid(rho_s.real(), phi.real());
-            mrcpp::build_grid(rho_a.real(), phi.real());
-            mrcpp::build_grid(rho_b.real(), phi.real());
-            density::compute(-1.0, rho_t, phi, DENSITY::Total);
-            density::compute(-1.0, rho_s, phi, DENSITY::Spin);
-            density::compute(-1.0, rho_a, phi, DENSITY::Alpha);
-            density::compute(-1.0, rho_b, phi, DENSITY::Beta);
-
-            REQUIRE( rho_t.real().integrate() == Approx(1.0) );
-            REQUIRE( rho_s.real().integrate() == Approx(1.0) );
-            REQUIRE( rho_a.real().integrate() == Approx(1.0) );
-            REQUIRE( rho_b.real().integrate() == Approx(0.0) );
-
-            phi.free();
-        }
         SECTION("orbital vector") {
             HydrogenFunction s1(1,0,0);
             HydrogenFunction s2(2,0,0);


### PR DESCRIPTION
The density class is now augmented with functionality required for linear response calculations:
We need to be able to compute these objects:

1. |phi><x| + |y><phi|
2. |phi><x| + cc

And sums of 1 and 2 over all orbitals.

The single orbital routines are now hidden to avoid problems with the MPI implementation.