### PR TITLE
Dens class

### DIFF
--- a/src/initial_guess/core.cpp
+++ b/src/initial_guess/core.cpp
@@ -40,6 +40,7 @@
 #include "chemistry/Nucleus.h"
 #include "qmfunctions/Orbital.h"
 #include "qmfunctions/orbital_utils.h"
+#include "qmfunctions/qmfunction_utils.h"
 
 #include "qmoperators/one_electron/NuclearOperator.h"
 #include "qmoperators/one_electron/KineticOperator.h"
@@ -126,6 +127,10 @@ OrbitalVector initial_guess::core::setup(double prec,
     t2.stop();
     Printer::printDouble(0, "Diagonalize Fock matrix", t2.getWallTime(), 5);
 
+    // Need to convert to QMFunctions for linear_combination
+    QMFunctionVector funcs;
+    for (auto &phi_i : Phi) funcs.push_back(phi_i);
+
     // Rotate orbitals and fill electrons by Aufbau
     Timer t3;
     OrbitalVector Psi;
@@ -135,9 +140,8 @@ OrbitalVector initial_guess::core::setup(double prec,
         int Np = Nd/2;                  //paired orbitals
         for (int i = 0; i < Np; i++) {
             ComplexVector v_i = U.row(i);
-            Orbital psi_i = orbital::linear_combination(v_i, Phi, prec);
-            psi_i.setOcc(2);
-            psi_i.setSpin(SPIN::Paired);
+            Orbital psi_i(SPIN::Paired);
+            qmfunction::linear_combination(psi_i, v_i, funcs, prec);
             Psi.push_back(psi_i);
         }
     } else {
@@ -147,18 +151,16 @@ OrbitalVector initial_guess::core::setup(double prec,
         OrbitalVector Psi_a;
         for (int i = 0; i < Na; i++) {
             ComplexVector v_i = U.row(i);
-            Orbital psi_i = orbital::linear_combination(v_i, Phi, prec);
-            psi_i.setOcc(1);
-            psi_i.setSpin(SPIN::Alpha);
+            Orbital psi_i(SPIN::Alpha);
+            qmfunction::linear_combination(psi_i, v_i, funcs, prec);
             Psi_a.push_back(psi_i);
         }
 
         OrbitalVector Psi_b;
         for (int i = 0; i < Nb; i++) {
             ComplexVector v_i = U.row(i);
-            Orbital psi_i = orbital::linear_combination(v_i, Phi, prec);
-            psi_i.setOcc(1);
-            psi_i.setSpin(SPIN::Beta);
+            Orbital psi_i(SPIN::Beta);
+            qmfunction::linear_combination(psi_i, v_i, funcs, prec);
             Psi_b.push_back(psi_i);
         }
 

--- a/src/initial_guess/sad.cpp
+++ b/src/initial_guess/sad.cpp
@@ -40,6 +40,7 @@
 #include "qmfunctions/OrbitalIterator.h"
 #include "qmfunctions/Orbital.h"
 #include "qmfunctions/orbital_utils.h"
+#include "qmfunctions/qmfunction_utils.h"
 
 #include "qmoperators/one_electron/NuclearOperator.h"
 #include "qmoperators/one_electron/KineticOperator.h"
@@ -187,15 +188,16 @@ OrbitalVector initial_guess::sad::rotate_orbitals(double prec,
     while (iter.next()) {
         for (int i = 0; i < Psi.size(); i++) {
             if (not mpi::my_orb(Psi[i])) continue;
-            OrbitalVector orb_vec;
+            QMFunctionVector func_vec;
             ComplexVector coef_vec(iter.get_size());
             for (int j = 0; j < iter.get_size(); j++) {
                 int idx_j = iter.idx(j);
                 Orbital &recv_j = iter.orbital(j);
                 coef_vec[j] = U(i, idx_j);
-                orb_vec.push_back(recv_j);
+                func_vec.push_back(recv_j);
             }
-            Orbital tmp_i = orbital::linear_combination(coef_vec, orb_vec, prec);
+            Orbital tmp_i = Psi[i].paramCopy();
+            qmfunction::linear_combination(tmp_i, coef_vec, func_vec, prec);
             Psi[i].add(1.0, tmp_i, prec); // In place addition
             tmp_i.free();
         }

--- a/src/qmfunctions/Density.cpp
+++ b/src/qmfunctions/Density.cpp
@@ -31,40 +31,6 @@
 
 namespace mrchem {
 
-/** @brief Default constructor
- *
- * Initializes the QMFunction with NULL pointers for both real and imaginary part.
- */
-Density::Density()
-        : QMFunction(0, 0),
-          meta({-1, 0, 0, 0, false, 1.0}) {
-}
-
-/** @brief Constructor
- *
- * @param spin: electron spin (SPIN::Alpha/Beta/Paired)
- * @param rank: MPI ownership (-1 means all MPI ranks)
- *
- * Initializes the QMFunction with NULL pointers for both real and imaginary part.
- */
-Density::Density(int spin, int rank)
-        : QMFunction(nullptr, nullptr),
-          meta({rank, spin, 0, 0, false, 1.0}) {
-    if (this->spin() < 0) INVALID_ARG_ABORT;
-}
-
-/** @brief Copy constructor
- *
- * @param dens: density to copy
- *
- * Shallow copy: meta data is copied along with the *re and *im pointers,
- * NO transfer of ownership.
- */
-Density::Density(const Density &dens)
-        : QMFunction(dens),
-          meta(dens.meta) {
-}
-
 /** @brief Assignment operator
  *
  * @param dens: density to copy
@@ -74,19 +40,11 @@ Density::Density(const Density &dens)
  */
 Density& Density::operator=(const Density &dens) {
     if (this != &dens) {
+        this->func_data = dens.func_data;
         this->re = dens.re;
         this->im = dens.im;
-        this->meta = dens.meta;
     }
     return *this;
-}
-
-/** @brief Parameter copy
- *
- * Returns a new density with the same spin and rank_id as *this density.
- */
-Density Density::paramCopy() const {
-    return Density(this->spin(), this->rankID());
 }
 
 /** @brief Deep copy
@@ -111,118 +69,6 @@ Density Density::deepCopy() {
     return out;         // Return shallow copy
 }
 
-/** @brief Complex conjugation
- *
- * Returns a new density which is a shallow copy of *this density, with a flipped
- * conjugate parameter. Pointer ownership is not transferred, so *this and the output
- * density points to the same MW representations of the real and imaginary parts,
- * however, they interpret the imaginary part with opposite sign.
- */
-Density Density::dagger() const {
-    Density out(*this); // Shallow copy
-    out.meta.conjugate = not this->meta.conjugate;
-    return out;         // Return shallow copy
-}
-
-/** @brief Returns the density meta data
- *
- * Tree sizes (nChunks) are flushed before return.
- */
-DensityMeta& Density::getMetaData() {
-    this->meta.nChunksReal = 0;
-    this->meta.nChunksImag = 0;
-    if (this->hasReal()) this->meta.nChunksReal = real().getNChunksUsed();
-    if (this->hasImag()) this->meta.nChunksImag = imag().getNChunksUsed();
-    return this->meta;
-}
-
-/** @brief Returns the norm of the density */
-double Density::norm() const {
-    double norm = this->squaredNorm();
-    if (norm > 0.0) norm = sqrt(norm);
-    return norm;
-}
-
-/** @brief Returns the squared norm of the density */
-double Density::squaredNorm() const {
-    double sq_r = -1.0;
-    double sq_i = -1.0;
-    if (this->hasReal()) sq_r = this->real().getSquareNorm();
-    if (this->hasImag()) sq_i = this->imag().getSquareNorm();
-
-    double sq_norm = 0.0;
-    if (sq_r < 0.0 and sq_i < 0.0) {
-        sq_norm = -1.0;
-    } else {
-        if (sq_r >= 0.0) sq_norm += sq_r;
-        if (sq_i >= 0.0) sq_norm += sq_i;
-    }
-    return sq_norm;
-}
-
-
-///** @brief In place multiply with scalar */
-//void Density::rescale(ComplexDouble c) {
-//    double thrs = mrcpp::MachineZero;
-//    bool cHasReal = (std::abs(c.real()) > thrs);
-//    bool cHasImag = (std::abs(c.imag()) > thrs);
-//
-//    if (cHasReal and cHasImag) {
-//        Density tmp = density::add(c, *this, 0.0, *this);
-//        this->free();
-//        *this = tmp;
-//    }
-//    if (cHasReal and not cHasImag) {
-//        if (this->hasReal()) this->real().rescale(c.real());
-//        if (this->hasImag()) this->imag().rescale(c.real());
-//    }
-//    if (not cHasReal and not cHasImag) {
-//        if (this->hasReal()) this->real().setZero();
-//        if (this->hasImag()) this->imag().setZero();
-//    }
-//    if (not cHasReal and cHasImag) {
-//        double conj = 1.0;
-//        if (this->conjugate()) conj = -1.0;
-//        mrcpp::FunctionTree<3> *tmp_re = this->re;
-//        mrcpp::FunctionTree<3> *tmp_im = this->im;
-//        if (tmp_re != 0) tmp_re->rescale(c.imag());
-//        if (tmp_im != 0) tmp_im->rescale(-1.0*conj*c.imag());
-//        this->clear();
-//        this->setReal(tmp_im);
-//        this->setImag(tmp_re);
-//    }
-//}
-
-///** @brief In place orthogonalize against inp */
-//void Density::orthogonalize(Density inp) {
-//    ComplexDouble overlap = density::dot(inp, *this);
-//    double sq_norm = inp.squaredNorm();
-//    if (std::abs(overlap) > mrcpp::MachineZero) {
-//        this->add(-1.0*(overlap/sq_norm), inp);
-//    }
-//}
-//
-///** @brief In place orthogonalize against all densitys in inp vector */
-//void Density::orthogonalize(DensityVector inp_vec) {
-//    for (int i = 0; i < inp_vec.size(); i++) {
-//        this->orthogonalize(inp_vec[i]);
-//    }
-//}
-
-///** @brief In place addition */
-//void Density::add(ComplexDouble c, Density inp, double prec) {
-//    // The following sets the spin only locally, e.i. the
-//    // original density is NOT changed. The effect of this is to
-//    // disable spin sanity checks in the following addition.
-//    // Since this is an in-place operation, we assume that the spin
-//    // of the result is already defined and that it
-//    // should not change.
-//    inp.setSpin(this->spin());
-//    Density tmp = density::add(1.0, *this, c, inp, prec);
-//    this->free();
-//    *this = tmp;
-//}
-
 /** @brief Write density to disk
  *
  * @param file: file name prefix
@@ -237,12 +83,12 @@ void Density::saveDensity(const std::string &file) {
     metafile << file << ".meta";
 
     //this flushes tree sizes
-    DensityMeta &my_meta = getMetaData();
+    FunctionData &func_data = getFunctionData();
 
     std::fstream f;
     f.open(metafile.str(), std::ios::out | std::ios::binary);
     if (not f.is_open()) MSG_ERROR("Unable to open file");
-    f.write((char *) &my_meta, sizeof(DensityMeta));
+    f.write((char *) &func_data, sizeof(FunctionData));
     f.close();
 
     //writing real part
@@ -277,15 +123,15 @@ void Density::loadDensity(const std::string &file) {
     fmeta << file << ".meta";
 
     //this flushes tree sizes
-    DensityMeta &my_meta = getMetaData();
+    FunctionData &func_data = getFunctionData();
 
     std::fstream f;
     f.open(fmeta.str(), std::ios::in | std::ios::binary);
-    if (f.is_open()) f.read((char *) &my_meta, sizeof(DensityMeta));
+    if (f.is_open()) f.read((char *) &func_data, sizeof(FunctionData));
     f.close();
 
     //reading real part
-    if (meta.nChunksReal > 0) {
+    if (func_data.nChunksReal > 0) {
         std::stringstream fname;
         fname << file << "_re";
         alloc(NUMBER::Real);
@@ -293,33 +139,12 @@ void Density::loadDensity(const std::string &file) {
     }
 
     //reading imaginary part
-    if (meta.nChunksImag > 0) {
+    if (func_data.nChunksImag > 0) {
         std::stringstream fname;
         fname << file << "_im";
         alloc(NUMBER::Imag);
         this->imag().loadTree(fname.str());
     }
-}
-
-/** @brief Returns a character representing the spin (a/b/p) */
-char Density::printSpin() const {
-    char sp = 'u';
-    if (this->spin() == SPIN::Paired) sp = 'p';
-    if (this->spin() == SPIN::Alpha) sp = 'a';
-    if (this->spin() == SPIN::Beta) sp = 'b';
-    return sp;
-}
-
-/** @brief Pretty output of density meta data */
-std::ostream& Density::print(std::ostream &o) const {
-    int oldprec = mrcpp::Printer::setPrecision(12);
-    o << std::setw(6)  << this->rankID();
-    o << std::setw(25) << this->norm();
-    o << std::setw(5)  << this->printSpin();
-    mrcpp::Printer::setPrecision(5);
-    o << std::setw(15) << this->error();
-    mrcpp::Printer::setPrecision(oldprec);
-    return o;
 }
 
 } //namespace mrchem

--- a/src/qmfunctions/Density.h
+++ b/src/qmfunctions/Density.h
@@ -36,8 +36,7 @@
  * Note that there are several options for copying/assignment: the proper copy
  * constructor and assignment operator are *shallow* copies, which means that
  * they simply copy the *re and *im pointers (no transfer of ownership).
- * Additionaly, there is a deepCopy() which returns a *full* copy of the density,
- * and a paramCopy() which returns an empty density with the same rank_id/spin.
+ * Additionaly, there is a deepCopy() which returns a *full* copy of the density.
  *
  * NOTE: since the standard copies are shallow copies and several densitys can
  * point to the same MW functions, it is YOUR responibility to keep track of the
@@ -47,51 +46,15 @@
 
 namespace mrchem {
 
-/* POD struct for density meta data. Used for simple MPI communication. */
-struct DensityMeta {
-    int rank_id;
-    int spin;
-    int nChunksReal;
-    int nChunksImag;
-    bool conjugate;
-    double error;
-};
-
 class Density final : public QMFunction {
 public:
-    Density();
-    Density(int spin, int rank = -1);
-
-    Density(const Density &dens);
+    Density() : QMFunction(nullptr, nullptr) { }
+    Density(const Density &dens) : QMFunction(dens) { }
     Density &operator=(const Density &dens);
-    Density paramCopy() const;
     Density deepCopy();
-    Density dagger() const;
-    
-    void setError(double error) { this->meta.error = error; }
-    void setRankId(int rank) { this->meta.rank_id = rank; }
-    void setSpin(int spin) { this->meta.spin = spin; }
-
-    DensityMeta &getMetaData();
-    int spin() const { return this->meta.spin; }
-    int rankID() const { return this->meta.rank_id; }
-    bool conjugate() const { return this->meta.conjugate; }
-    double error() const { return this->meta.error; }
-    double norm() const;
-    double squaredNorm() const;
-
-    void multiply(Density inp, double prec = -1.0);
     
     void saveDensity(const std::string &file);
     void loadDensity(const std::string &file);
-
-    char printSpin() const;
-    friend std::ostream& operator<<(std::ostream &o, Density dens) { return dens.print(o); }
-
-protected:
-    DensityMeta meta;
-
-    std::ostream& print(std::ostream &o) const;
 };
 
 } //namespace mrchem

--- a/src/qmfunctions/Orbital.h
+++ b/src/qmfunctions/Orbital.h
@@ -48,13 +48,10 @@
 namespace mrchem {
 
 /* POD struct for orbital meta data. Used for simple MPI communication. */
-struct OrbitalMeta {
+struct OrbitalData {
     int rank_id;
     int spin;
     int occ;
-    int nChunksReal;
-    int nChunksImag;
-    bool conjugate;
     double error;
 };
 
@@ -69,25 +66,18 @@ public:
     Orbital deepCopy();
     Orbital dagger() const;
 
-    void setError(double error) { this->meta.error = error; }
-    void setRankId(int rank) { this->meta.rank_id = rank; }
-    void setSpin(int spin) { this->meta.spin = spin; }
-    void setOcc(int occ) { this->meta.occ = occ; }
+    void setOcc(int occ) { this->orb_data.occ = occ; }
+    void setSpin(int spin) { this->orb_data.spin = spin; }
+    void setRankId(int rank) { this->orb_data.rank_id = rank; }
+    void setError(double error) { this->orb_data.error = error; }
 
-    OrbitalMeta &getMetaData();
-    int occ() const { return this->meta.occ; }
-    int spin() const { return this->meta.spin; }
-    int rankID() const { return this->meta.rank_id; }
-    bool conjugate() const { return this->meta.conjugate; }
-    double error() const { return this->meta.error; }
-    double norm() const;
-    double squaredNorm() const;
+    int occ() const { return this->orb_data.occ; }
+    int spin() const { return this->orb_data.spin; }
+    int rankID() const { return this->orb_data.rank_id; }
+    double error() const { return this->orb_data.error; }
+    OrbitalData &getOrbitalData() { return this->orb_data; }
 
-    void add(ComplexDouble c, Orbital inp, double prec = -1.0);
-    void multiply(Orbital inp, double prec = -1.0);
-    void rescale(ComplexDouble c);
-
-    void normalize() { rescale(1.0/this->norm()); }
+    void normalize() { this->rescale(1.0/this->norm()); }
     void orthogonalize(Orbital inp);
     void orthogonalize(OrbitalVector inp_vec);
 
@@ -98,7 +88,7 @@ public:
     friend std::ostream& operator<<(std::ostream &o, Orbital orb) { return orb.print(o); }
 
 protected:
-    OrbitalMeta meta;
+    OrbitalData orb_data;
 
     std::ostream& print(std::ostream &o) const;
 };

--- a/src/qmfunctions/QMFunction.h
+++ b/src/qmfunctions/QMFunction.h
@@ -30,12 +30,17 @@
 
 namespace mrchem {
 
+/* POD struct for function meta data. Used for simple MPI communication. */
+struct FunctionData {
+    int nChunksReal;
+    int nChunksImag;
+    bool conjugate;
+};
+
 class QMFunction {
 public:
-    QMFunction(mrcpp::FunctionTree<3> *r = nullptr,
-               mrcpp::FunctionTree<3> *i = nullptr)
-        : re(r), im(i) { }
-    QMFunction(const QMFunction &func) : re(func.re), im(func.im) { }
+    QMFunction(mrcpp::FunctionTree<3> *r = nullptr, mrcpp::FunctionTree<3> *i = nullptr);
+    QMFunction(const QMFunction &func);
     QMFunction &operator=(const QMFunction &func);
     virtual ~QMFunction() = default;
 
@@ -44,6 +49,15 @@ public:
     void free(int type = NUMBER::Total);
 
     int getNNodes(int type = NUMBER::Total) const;
+    bool conjugate() const { return this->func_data.conjugate; }
+    FunctionData &getFunctionData();
+
+    double norm() const;
+    double squaredNorm() const;
+
+    void add(ComplexDouble c, QMFunction inp, double prec = -1.0);
+    void multiply(QMFunction inp, double prec = -1.0);
+    void rescale(ComplexDouble c);
 
     bool hasReal() const { return (this->re == nullptr) ? false : true; }
     bool hasImag() const { return (this->im == nullptr) ? false : true; }
@@ -58,6 +72,7 @@ public:
     void setImag(mrcpp::FunctionTree<3> *imag) { this->im = imag; }
 
 protected:
+    FunctionData func_data;
     mrcpp::FunctionTree<3> *re;     ///< Real part of function
     mrcpp::FunctionTree<3> *im;     ///< Imaginary part of function
 };

--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -47,17 +47,9 @@ extern mrcpp::MultiResolutionAnalysis<3> *MRA; // Global MRA
  ****************************************/
 
 void density::compute(double prec, Density &rho, Orbital phi, int spin) {
-    double occ_a(0.0), occ_b(0.0), occ_p(0.0);
-    if (phi.spin() == SPIN::Alpha)  occ_a = (double) phi.occ();
-    if (phi.spin() == SPIN::Beta)   occ_b = (double) phi.occ();
-    if (phi.spin() == SPIN::Paired) occ_p = (double) phi.occ();
 
-    double occ(0.0);
-    if (spin == DENSITY::Total) occ = occ_a + occ_b + occ_p;
-    if (spin == DENSITY::Alpha) occ = occ_a + 0.5*occ_p;
-    if (spin == DENSITY::Beta)  occ = occ_b + 0.5*occ_p;
-    if (spin == DENSITY::Spin)  occ = occ_a - occ_b;
-
+    double occ = compute_occupation(phi.spin(), phi.occ(), spin);
+    
     if (std::abs(occ) < mrcpp::MachineZero) {
         rho.real().setZero();
         return;
@@ -82,16 +74,8 @@ void density::compute(double prec, Density &rho, Orbital phi, int spin) {
 }
 
 void density::compute(double prec, Density &rho, Orbital phi, Orbital xi, int spin) {
-    double occ_a(0.0), occ_b(0.0), occ_p(0.0);
-    if (phi.spin() == SPIN::Alpha)  occ_a = (double) phi.occ();
-    if (phi.spin() == SPIN::Beta)   occ_b = (double) phi.occ();
-    if (phi.spin() == SPIN::Paired) occ_p = (double) phi.occ();
-    
-    double occ(0.0);
-    if (spin == DENSITY::Total) occ = occ_a + occ_b + occ_p;
-    if (spin == DENSITY::Alpha) occ = occ_a + 0.5*occ_p;
-    if (spin == DENSITY::Beta)  occ = occ_b + 0.5*occ_p;
-    if (spin == DENSITY::Spin)  occ = occ_a - occ_b;
+
+    double occ = compute_occupation(phi.spin(), phi.occ(), spin);
 
     if (std::abs(occ) < mrcpp::MachineZero) {
         rho.real().setZero();
@@ -186,4 +170,19 @@ void density::compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, i
     mrcpp::project(prec, rho.real(), dens_exp);
 }
 
+double density::compute_occupation(int orb_spin, int orb_occ, int dens_spin) {
+    double occ_a(0.0), occ_b(0.0), occ_p(0.0);
+    if (orb_spin == SPIN::Alpha)  occ_a = (double) orb_occ;
+    if (orb_spin == SPIN::Beta)   occ_b = (double) orb_occ;
+    if (orb_spin == SPIN::Paired) occ_p = (double) orb_occ;
+    
+    double occ(0.0);
+    if (dens_spin == DENSITY::Total) occ = occ_a + occ_b + occ_p;
+    if (dens_spin == DENSITY::Alpha) occ = occ_a + 0.5*occ_p;
+    if (dens_spin == DENSITY::Beta)  occ = occ_b + 0.5*occ_p;
+    if (dens_spin == DENSITY::Spin)  occ = occ_a - occ_b;
+
+    return occ;
+}
+    
 } //namespace mrchem

--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -157,7 +157,7 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVect
     for (int i = 0; i < Phi.size(); i++) {
         if (mpi::my_orb(Phi[i])) {
             Density *rho_i = new Density(); //LUCA: Is it the right creator here (it was Density(*MRA);
-            rho_i->allocReal();
+            rho_i->alloc(NUMBER::Real);
             mrcpp::copy_grid(rho_i->real(), rho.real());
             density::compute(mult_prec, *rho_i, Phi[i], Phi_x[i], spin);
             dens_vec.push_back(std::make_tuple(1.0, &(rho_i->real())));

--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -29,6 +29,8 @@
 
 #include "parallel.h"
 
+#include "QMFunction.h"
+#include "qmfunction_utils.h"
 #include "Density.h"
 #include "density_utils.h"
 #include "Orbital.h"
@@ -46,14 +48,7 @@ extern mrcpp::MultiResolutionAnalysis<3> *MRA; // Global MRA
  * Density related standalone functions *
  ****************************************/
 
-void density::compute(double prec, Density &rho, Orbital phi, int spin) {
-
-    double occ = compute_occupation(phi.spin(), phi.occ(), spin);
-    
-    if (std::abs(occ) < mrcpp::MachineZero) {
-        rho.real().setZero();
-        return;
-    }
+void density::compute(double prec, Density &rho, Orbital phi, double occ) {
 
     FunctionTreeVector<3> sum_vec;
     if (phi.hasReal()) {
@@ -73,35 +68,22 @@ void density::compute(double prec, Density &rho, Orbital phi, int spin) {
     mrcpp::clear(sum_vec, true);
 }
 
-void density::compute(double prec, Density &rho, Orbital phi, Orbital xi, int spin) {
+void density::compute(double prec, Density &rho, Orbital ket, Orbital bra, double coeff, int type) {
 
-    double occ = compute_occupation(phi.spin(), phi.occ(), spin);
-
-    if (std::abs(occ) < mrcpp::MachineZero) {
-        rho.real().setZero();
-        return;
+    double ket_conj(1.0), bra_conj(1.0);
+    if (ket.conjugate()) ket_conj = -1.0;
+    if (bra.conjugate()) bra_conj = -1.0;
+    
+    if (type == NUMBER::Total) {
+        qmfunction::multiply(ket, ket_conj, bra, -1.0 * bra_conj, rho, prec);
+        rho.real().rescale(coeff);
+        rho.imag().rescale(coeff);
+    } else if (type == NUMBER::Real) {
+        qmfunction::multiply_real(ket, ket_conj, bra, -1.0 * bra_conj, rho, prec);
+        rho.real().rescale(coeff);
+    } else {
+        MSG_FATAL("No such case");
     }
-
-    FunctionTreeVector<3> sum_vec;
-    if (phi.hasReal() and xi.hasReal()) {
-        FunctionTree<3> *phir_xir = new FunctionTree<3>(*MRA);
-        //        mrcpp::copy_grid(*phir_xir, phi.real()); LUCA should this be here? Should there be a build_grid?
-        mrcpp::multiply(prec, *phir_xir, 2.0, phi.real(), xi.real());
-        sum_vec.push_back(std::make_tuple(occ, phir_xir));
-    }
-    if (phi.hasImag() and xi.hasImag()) {
-        FunctionTree<3> *phii_xii = new FunctionTree<3>(*MRA);
-        //        mrcpp::copy_grid(*phii_xii, phi.imag()); LUCA should this be here? Should there be a build_grid?
-        mrcpp::multiply(prec, *phii_xii, 2.0, phi.imag(), xi.imag());
-        sum_vec.push_back(std::make_tuple(occ, phii_xii));
-    }
-    mrcpp::build_grid(rho.real(), sum_vec);
-    mrcpp::add(-1.0, rho.real(), sum_vec, 0);
-    mrcpp::clear(sum_vec, true);
-}
-
-void density::compute(double prec, Density &rho, Orbital phi, Orbital xi, Orbital yi, int spin) {
-    MSG_FATAL("NOT IMPLEMENTED ABORT");
 }
 
 void density::compute(double prec, Density &rho, OrbitalVector &Phi, int spin) {
@@ -111,10 +93,12 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, int spin) {
     FunctionTreeVector<3> dens_vec;
     for (int i = 0; i < Phi.size(); i++) {
         if (mpi::my_orb(Phi[i])) {
+            double occ = compute_occupation(Phi[i].spin(), Phi[i].occ(), spin);
+            if (std::abs(occ) < mrcpp::MachineZero) continue;
             Density rho_i;
             rho_i.alloc(NUMBER::Real);
             mrcpp::copy_grid(rho_i.real(), rho.real());
-            density::compute(mult_prec, rho_i, Phi[i], spin);
+            density::compute(mult_prec, rho_i, Phi[i], occ);
             dens_vec.push_back(std::make_tuple(1.0, &(rho_i.real())));
             rho_i.clear(); // release FunctionTree pointers to dens_vec
         }
@@ -132,6 +116,8 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, int spin) {
     mpi::broadcast_density(rho, mpi::comm_orb);
 }
 
+
+//LUCA Is the MPI distribution of Phi identical to Phi_x and Phi_y??? Now I 
 void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, int spin) {
     double mult_prec = prec;            // prec for \rho_i = |\phi_i|^2
     double add_prec = prec/Phi.size();  // prec for \sum_i \rho_i
@@ -140,10 +126,12 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVect
     FunctionTreeVector<3> dens_vec;
     for (int i = 0; i < Phi.size(); i++) {
         if (mpi::my_orb(Phi[i])) {
-            Density *rho_i = new Density(); //LUCA: Is it the right creator here (it was Density(*MRA);
+            double occ = compute_occupation(Phi[i].spin(), Phi[i].occ(), spin);
+            if (std::abs(occ) < mrcpp::MachineZero) continue; //next orbital if this one is not occupied!
+            Density *rho_i = new Density(); 
             rho_i->alloc(NUMBER::Real);
             mrcpp::copy_grid(rho_i->real(), rho.real());
-            density::compute(mult_prec, *rho_i, Phi[i], Phi_x[i], spin);
+            density::compute(mult_prec, *rho_i, Phi[i], Phi_x[i], 2.0 * occ, NUMBER::Real);
             dens_vec.push_back(std::make_tuple(1.0, &(rho_i->real())));
         }
     }
@@ -160,8 +148,56 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVect
     mpi::broadcast_density(rho, mpi::comm_orb);
 }
 
-void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, OrbitalVector &Phy_y, int spin) {
-    MSG_FATAL("NOT IMPLEMENTED ABORT");
+//LUCA Is the MPI distribution of Phi identical to Phi_x and Phi_y??? Now I 
+void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, OrbitalVector &Phi_y, int spin) {
+    double mult_prec = prec;            // prec for \rho_i = |\phi_i|^2
+    double add_prec = prec/Phi.size();  // prec for \sum_i \rho_i
+    if (Phi.size() != Phi_x.size()) MSG_ERROR("Size mismatch");
+    
+    FunctionTreeVector<3> dens_real;
+    FunctionTreeVector<3> dens_imag;
+    for (int i = 0; i < Phi.size(); i++) {
+        if (mpi::my_orb(Phi[i])) {
+            //if(mpi::my_orb(Phi_x[i])) ....
+            double occ = compute_occupation(Phi[i].spin(), Phi[i].occ(), spin);
+            if (std::abs(occ) < mrcpp::MachineZero) continue; //next orbital if this one is not occupied!
+            Density *rho_x = new Density(); 
+            Density *rho_y = new Density(); 
+            rho_x->alloc(NUMBER::Real);
+            rho_y->alloc(NUMBER::Real);
+            rho_x->alloc(NUMBER::Imag);
+            rho_y->alloc(NUMBER::Imag);
+            mrcpp::copy_grid(rho_x->real(), rho.real());
+            mrcpp::copy_grid(rho_y->real(), rho.real());
+            mrcpp::copy_grid(rho_x->imag(), rho.imag());
+            mrcpp::copy_grid(rho_y->imag(), rho.imag());
+            density::compute(mult_prec, *rho_x, Phi_x[i], Phi[i], occ, NUMBER::Total);
+            density::compute(mult_prec, *rho_y, Phi[i], Phi_y[i], occ, NUMBER::Total);
+            dens_real.push_back(std::make_tuple(1.0, &(rho_x->real())));
+            dens_real.push_back(std::make_tuple(1.0, &(rho_y->real())));
+            dens_imag.push_back(std::make_tuple(1.0, &(rho_x->imag())));
+            dens_imag.push_back(std::make_tuple(1.0, &(rho_y->imag())));
+        }
+    }
+
+    if (add_prec > 0.0) {
+        mrcpp::add(add_prec, rho.real(), dens_real);
+        mrcpp::add(add_prec, rho.imag(), dens_imag);
+    } else {
+        if (dens_real.size() > 0) {
+            mrcpp::build_grid(rho.real(), dens_real);
+            mrcpp::add(-1.0,  rho.real(), dens_real, 0);
+        }
+        if (dens_imag.size() > 0) {
+            mrcpp::build_grid(rho.imag(), dens_imag);
+            mrcpp::add(-1.0,  rho.imag(), dens_imag, 0);
+        }
+    }
+    mrcpp::clear(dens_real, true);
+    mrcpp::clear(dens_imag, true);
+
+    mpi::reduce_density(rho, mpi::comm_orb);
+    mpi::broadcast_density(rho, mpi::comm_orb);
 }
 
 void density::compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, int spin) {

--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -48,8 +48,13 @@ extern mrcpp::MultiResolutionAnalysis<3> *MRA; // Global MRA
  * Density related standalone functions *
  ****************************************/
 
+void compute(double prec, Density &rho, Orbital phi, double occ);
+void compute(double prec, Density &rho, Orbital ket, Orbital bra, double coeff, int type);
+
+
 void density::compute(double prec, Density &rho, Orbital phi, double occ) {
 
+    std::cout  << "OCC " << occ << std::endl;
     FunctionTreeVector<3> sum_vec;
     if (phi.hasReal()) {
         FunctionTree<3> *real_2 = new FunctionTree<3>(*MRA);

--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -50,11 +50,10 @@ extern mrcpp::MultiResolutionAnalysis<3> *MRA; // Global MRA
 
 void compute(double prec, Density &rho, Orbital phi, double occ);
 void compute(double prec, Density &rho, Orbital ket, Orbital bra, double coeff, int type);
-
+double compute_occupation(int orb_spin, int orb_occ, int dens_spin);
 
 void density::compute(double prec, Density &rho, Orbital phi, double occ) {
 
-    std::cout  << "OCC " << occ << std::endl;
     FunctionTreeVector<3> sum_vec;
     if (phi.hasReal()) {
         FunctionTree<3> *real_2 = new FunctionTree<3>(*MRA);

--- a/src/qmfunctions/density_utils.h
+++ b/src/qmfunctions/density_utils.h
@@ -28,14 +28,12 @@
 #include "qmfunction_fwd.h"
 
 namespace mrchem {
-
 namespace density {
 
-void compute(double prec, Density &rho, OrbitalVector &Phi, int spin);
 void compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, int spin);
-void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, int spin);
-void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, OrbitalVector &Phi_y, int spin);
- 
-} //namespace density
+void compute(double prec, Density &rho, OrbitalVector &Phi, int spin);
+void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &X, int spin);
+void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &X, OrbitalVector &Y, int spin);
 
+} //namespace density
 } //namespace mrchem

--- a/src/qmfunctions/density_utils.h
+++ b/src/qmfunctions/density_utils.h
@@ -31,15 +31,11 @@ namespace mrchem {
 
 namespace density {
 
-void compute(double prec, Density &rho, Orbital phi, double occ);
-void compute(double prec, Density &rho, Orbital ket, Orbital bra, double coeff, int type);
 void compute(double prec, Density &rho, OrbitalVector &Phi, int spin);
 void compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, int spin);
 void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, int spin);
 void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, OrbitalVector &Phi_y, int spin);
  
-double compute_occupation(int orb_spin, int orb_occ, int dens_spin);
-
 } //namespace density
 
 } //namespace mrchem

--- a/src/qmfunctions/density_utils.h
+++ b/src/qmfunctions/density_utils.h
@@ -31,9 +31,8 @@ namespace mrchem {
 
 namespace density {
 
-void compute(double prec, Density &rho, Orbital phi, int spin);
-void compute(double prec, Density &rho, Orbital phi, Orbital xi, int spin);
-void compute(double prec, Density &rho, Orbital phi, Orbital xi, Orbital yi, int spin);
+void compute(double prec, Density &rho, Orbital phi, double occ);
+void compute(double prec, Density &rho, Orbital ket, Orbital bra, double coeff, int type);
 void compute(double prec, Density &rho, OrbitalVector &Phi, int spin);
 void compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, int spin);
 void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, int spin);

--- a/src/qmfunctions/density_utils.h
+++ b/src/qmfunctions/density_utils.h
@@ -32,8 +32,12 @@ namespace mrchem {
 namespace density {
 
 void compute(double prec, Density &rho, Orbital phi, int spin);
+void compute(double prec, Density &rho, Orbital phi, Orbital xi, int spin);
+void compute(double prec, Density &rho, Orbital phi, Orbital xi, Orbital yi, int spin);
 void compute(double prec, Density &rho, OrbitalVector &Phi, int spin);
 void compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, int spin);
+void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, int spin);
+void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, OrbitalVector &Phi_y, int spin);
 
 } //namespace density
 

--- a/src/qmfunctions/density_utils.h
+++ b/src/qmfunctions/density_utils.h
@@ -38,6 +38,8 @@ void compute(double prec, Density &rho, OrbitalVector &Phi, int spin);
 void compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, int spin);
 void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, int spin);
 void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &Phi_x, OrbitalVector &Phi_y, int spin);
+ 
+double compute_occupation(int orb_spin, int orb_occ, int dens_spin);
 
 } //namespace density
 

--- a/src/qmfunctions/orbital_utils.h
+++ b/src/qmfunctions/orbital_utils.h
@@ -29,7 +29,6 @@
 #include "qmfunction_fwd.h"
 
 namespace mrchem {
-
 namespace orbital {
 
 ComplexDouble dot(Orbital bra, Orbital ket);
@@ -39,12 +38,8 @@ bool compare(const Orbital &orb_a, const Orbital &orb_b);
 int compare_occ(const Orbital &orb_a, const Orbital &orb_b);
 int compare_spin(const Orbital &orb_a, const Orbital &orb_b);
 
-Orbital add(ComplexDouble a, Orbital inp_a, ComplexDouble b, Orbital inp_b, double prec = -1.0);
 OrbitalVector add(ComplexDouble a, OrbitalVector &inp_a, ComplexDouble b, OrbitalVector &inp_b, double prec = -1.0);
-
-Orbital multiply(Orbital inp_a, Orbital inp_b, double prec = -1.0);
-Orbital linear_combination(const ComplexVector &c, OrbitalVector &inp, double prec = -1.0);
-OrbitalVector linear_combination(const ComplexMatrix &U, OrbitalVector &inp, double prec = -1.0);
+OrbitalVector rotate(const ComplexMatrix &U, OrbitalVector &inp, double prec = -1.0);
 
 OrbitalVector deep_copy(OrbitalVector &inp);
 OrbitalVector param_copy(const OrbitalVector &inp);
@@ -91,5 +86,4 @@ DoubleVector get_squared_norms(const OrbitalVector &vec);
 void print(const OrbitalVector &vec);
 
 } //namespace orbital
-
 } //namespace mrchem

--- a/src/qmfunctions/qmfunction_fwd.h
+++ b/src/qmfunctions/qmfunction_fwd.h
@@ -28,7 +28,7 @@
 namespace mrchem {
 
 class QMFunction;
-using QMFunctionVector = std::vector<std::tuple<double, QMFunction>>;
+using QMFunctionVector = std::vector<QMFunction>;
 
 class Orbital;
 using OrbitalChunk = std::vector<std::tuple<int, Orbital>>;

--- a/src/qmfunctions/qmfunction_fwd.h
+++ b/src/qmfunctions/qmfunction_fwd.h
@@ -25,6 +25,22 @@
 
 #pragma once
 
+/** Notes on vectors:
+ * The OrbitalVector (std::vector<Orbital>) is conceptually different from the
+ * QMFunctionVector (std::vector<QMFunction>). The former should be a collection
+ * of orbitals defining a proper Slater determinant, while the latter is any
+ * arbitrary collection of functions (could also be orbitals) used e.g. when
+ * adding several orbitals into one. The difference is important when MPI is
+ * considered, as OrbitalVectors are distributed while QMFunctionVectors are
+ * not. This is reflected in the functionality that is available for the
+ * different vectors, where OrbitalVectors should always be treated as a whole,
+ * e.g. in an orbital rotation Psi = orbital::rotate(U, Phi), where U is a
+ * unitary matrix. This operation is MPI safe and all necessary communication
+ * happen automatically under the hood. This is opposed to the similar linear
+ * combination qmfunction::linear_combination(func_out, coefs_vec, func_vec)
+ * where no MPI is considered.
+ */
+
 namespace mrchem {
 
 class QMFunction;
@@ -35,7 +51,5 @@ using OrbitalChunk = std::vector<std::tuple<int, Orbital>>;
 using OrbitalVector = std::vector<Orbital>;
 
 class Density;
-using DensityChunk = std::vector<std::tuple<int, Density>>;
-using DensityVector = std::vector<Density>;
 
 } //namespace mrchem

--- a/src/qmfunctions/qmfunction_utils.cpp
+++ b/src/qmfunctions/qmfunction_utils.cpp
@@ -37,21 +37,114 @@ using mrcpp::FunctionTreeVector;
 namespace mrchem {
 extern mrcpp::MultiResolutionAnalysis<3> *MRA; // Global MRA
 
-ComplexDouble qmfunction::dot(QMFunction &bra, double bra_conj, QMFunction &ket, double ket_conj) {
+/** @brief Compute <bra|ket> = int bra^\dag(r) * ket(r) dr.
+ *
+ *  Notice that the <bra| position is already complex conjugated.
+ *
+ */
+ComplexDouble qmfunction::dot(QMFunction bra, QMFunction ket) {
     double rr(0.0), ri(0.0), ir(0.0), ii(0.0);
     if (bra.hasReal() and ket.hasReal()) rr = mrcpp::dot(bra.real(), ket.real());
     if (bra.hasReal() and ket.hasImag()) ri = mrcpp::dot(bra.real(), ket.imag());
     if (bra.hasImag() and ket.hasReal()) ir = mrcpp::dot(bra.imag(), ket.real());
     if (bra.hasImag() and ket.hasImag()) ii = mrcpp::dot(bra.imag(), ket.imag());
 
+    double bra_conj = (bra.conjugate()) ? -1.0 : 1.0;
+    double ket_conj = (ket.conjugate()) ? -1.0 : 1.0;
+
     double real_part = rr + bra_conj*ket_conj*ii;
     double imag_part = ket_conj*ri - bra_conj*ir;
     return ComplexDouble(real_part, imag_part);
 }
 
-void qmfunction::multiply_real(QMFunction &inp_a, double conj_a,
-                               QMFunction &inp_b, double conj_b,
-                               QMFunction &out, double prec) {
+/** @brief Frees each function in the vector
+ *
+ * Leaves an empty vector. QMFunctions are freed.
+ *
+ */
+void qmfunction::free(QMFunctionVector &vec) {
+    for (int i = 0; i < vec.size(); i++) vec[i].free();
+    vec.clear();
+}
+
+/** @brief out = a*inp_a + b*inp_b
+ *
+ * Recast into linear_combination.
+ *
+ */
+void qmfunction::add(QMFunction &out, ComplexDouble a, QMFunction inp_a, ComplexDouble b, QMFunction inp_b, double prec) {
+    ComplexVector coefs(2);
+    coefs(0) = a;
+    coefs(1) = b;
+
+    QMFunctionVector funcs;
+    funcs.push_back(inp_a);
+    funcs.push_back(inp_b);
+
+    qmfunction::linear_combination(out, coefs, funcs, prec);
+}
+
+/** @brief out = inp_a * inp_b
+ *
+ */
+void qmfunction::multiply(QMFunction &out, QMFunction inp_a, QMFunction inp_b, double prec) {
+    multiply_real(out, inp_a, inp_b, prec);
+    multiply_imag(out, inp_a, inp_b, prec);
+}
+
+/** @brief out = c_0*inp_0 + c_1*inp_1 + ... + c_N*inp_N
+ *
+ */
+void qmfunction::linear_combination(QMFunction &out, const ComplexVector &c, QMFunctionVector &inp, double prec) {
+    if (out.hasReal()) MSG_ERROR("Output not empty");
+    if (out.hasImag()) MSG_ERROR("Output not empty");
+
+    FunctionTreeVector<3> rvec;
+    FunctionTreeVector<3> ivec;
+
+    double thrs = mrcpp::MachineZero;
+    for (int i = 0; i < inp.size(); i++) {
+        double sign = (inp[i].conjugate()) ? -1.0 : 1.0;
+
+        bool cHasReal = (std::abs(c[i].real()) > thrs);
+        bool cHasImag = (std::abs(c[i].imag()) > thrs);
+
+        if (cHasReal and inp[i].hasReal()) rvec.push_back(std::make_tuple(      c[i].real(), &inp[i].real()));
+        if (cHasImag and inp[i].hasImag()) rvec.push_back(std::make_tuple(-sign*c[i].imag(), &inp[i].imag()));
+
+        if (cHasImag and inp[i].hasReal()) ivec.push_back(std::make_tuple(      c[i].imag(), &inp[i].real()));
+        if (cHasReal and inp[i].hasImag()) ivec.push_back(std::make_tuple( sign*c[i].real(), &inp[i].imag()));
+    }
+
+    if (rvec.size() > 0) {
+        out.alloc(NUMBER::Real);
+        if (prec < 0.0) {
+            mrcpp::build_grid(out.real(), rvec);
+            mrcpp::add(prec, out.real(), rvec, 0);
+        } else {
+            mrcpp::add(prec, out.real(), rvec);
+        }
+    }
+    if (ivec.size() > 0) {
+        out.alloc(NUMBER::Imag);
+        if (prec < 0.0) {
+            mrcpp::build_grid(out.imag(), ivec);
+            mrcpp::add(prec, out.imag(), ivec, 0);
+        } else {
+            mrcpp::add(prec, out.imag(), ivec);
+        }
+    }
+}
+
+/** @brief out = Re(inp_a * inp_b)
+ *
+ */
+void qmfunction::multiply_real(QMFunction &out, QMFunction inp_a, QMFunction inp_b, double prec) {
+    if (out.hasReal()) MSG_ERROR("Output not empty");
+
+    double conj_a = (inp_a.conjugate()) ? -1.0 : 1.0;
+    double conj_b = (inp_b.conjugate()) ? -1.0 : 1.0;
+
     FunctionTreeVector<3> vec;
     if (inp_a.hasReal() and inp_b.hasReal()) {
         FunctionTree<3> *tree = new FunctionTree<3>(*MRA);
@@ -91,9 +184,15 @@ void qmfunction::multiply_real(QMFunction &inp_a, double conj_a,
     }
 }
 
-void qmfunction::multiply_imag(QMFunction &inp_a, double conj_a,
-                               QMFunction &inp_b, double conj_b,
-                               QMFunction &out, double prec) {
+/** @brief out = Im(inp_a * inp_b)
+ *
+ */
+void qmfunction::multiply_imag(QMFunction &out, QMFunction inp_a, QMFunction inp_b, double prec) {
+    if (out.hasImag()) MSG_ERROR("Output not empty");
+
+    double conj_a = (inp_a.conjugate()) ? -1.0 : 1.0;
+    double conj_b = (inp_b.conjugate()) ? -1.0 : 1.0;
+
     FunctionTreeVector<3> vec;
     if (inp_a.hasReal() and inp_b.hasImag()) {
         FunctionTree<3> *tree = new FunctionTree<3>(*MRA);
@@ -132,55 +231,6 @@ void qmfunction::multiply_imag(QMFunction &inp_a, double conj_a,
         mrcpp::build_grid(out.imag(), vec);
         mrcpp::add(prec, out.imag(), vec, 0);
         mrcpp::clear(vec, true);
-    }
-}    
-
-void qmfunction::multiply(QMFunction &inp_a, double conj_a,
-                          QMFunction &inp_b, double conj_b,
-                          QMFunction &out, double prec) {
-    multiply_real(inp_a, conj_a, inp_b, conj_b, out, prec);
-    multiply_imag(inp_a, conj_a, inp_b, conj_b, out, prec);
-    
-}
-
-void qmfunction::linear_combination(const ComplexVector &c,
-                                    QMFunctionVector &inp,
-                                    QMFunction &out,
-                                    double prec) {
-    double thrs = mrcpp::MachineZero;
-    FunctionTreeVector<3> rvec;
-    FunctionTreeVector<3> ivec;
-
-    for (int i = 0; i < inp.size(); i++) {
-        bool cHasReal = (std::abs(c[i].real()) > thrs);
-        bool cHasImag = (std::abs(c[i].imag()) > thrs);
-
-        double sign = std::get<0>(inp[i]);
-        QMFunction &inp_i = std::get<1>(inp[i]);
-        if (cHasReal and inp_i.hasReal()) rvec.push_back(std::make_tuple(      c[i].real(), &inp_i.real()));
-        if (cHasImag and inp_i.hasImag()) rvec.push_back(std::make_tuple(-sign*c[i].imag(), &inp_i.imag()));
-
-        if (cHasImag and inp_i.hasReal()) ivec.push_back(std::make_tuple(      c[i].imag(), &inp_i.real()));
-        if (cHasReal and inp_i.hasImag()) ivec.push_back(std::make_tuple( sign*c[i].real(), &inp_i.imag()));
-    }
-
-    if (rvec.size() > 0) {
-        out.alloc(NUMBER::Real);
-        if (prec < 0.0) {
-            mrcpp::build_grid(out.real(), rvec);
-            mrcpp::add(prec, out.real(), rvec, 0);
-        } else {
-            mrcpp::add(prec, out.real(), rvec);
-        }
-    }
-    if (ivec.size() > 0) {
-        out.alloc(NUMBER::Imag);
-        if (prec < 0.0) {
-            mrcpp::build_grid(out.imag(), ivec);
-            mrcpp::add(prec, out.imag(), ivec, 0);
-        } else {
-            mrcpp::add(prec, out.imag(), ivec);
-        }
     }
 }
 

--- a/src/qmfunctions/qmfunction_utils.h
+++ b/src/qmfunctions/qmfunction_utils.h
@@ -29,29 +29,15 @@
 #include "qmfunction_fwd.h"
 
 namespace mrchem {
-
 namespace qmfunction {
     
-ComplexDouble dot(QMFunction &bra, double bra_conj,
-                  QMFunction &ket, double ket_conj);
- 
-void multiply_real(QMFunction &inp_a, double conj_a,
-                               QMFunction &inp_b, double conj_b,
-                               QMFunction &out, double prec);
- 
-void multiply_imag(QMFunction &inp_a, double conj_a,
-                               QMFunction &inp_b, double conj_b,
-                               QMFunction &out, double prec);
- 
-void multiply(QMFunction &inp_a, double conj_a,
-              QMFunction &inp_b, double conj_b,
-              QMFunction &out,   double prec);
+ComplexDouble dot(QMFunction bra, QMFunction ket);
+void add(QMFunction &out, ComplexDouble a, QMFunction inp_a, ComplexDouble b, QMFunction inp_b, double prec);
+void multiply(QMFunction &out, QMFunction inp_a, QMFunction inp_b, double prec);
+void multiply_real(QMFunction &out, QMFunction inp_a, QMFunction inp_b, double prec);
+void multiply_imag(QMFunction &out, QMFunction inp_a, QMFunction inp_b, double prec);
+void linear_combination(QMFunction &out, const ComplexVector &c, QMFunctionVector &inp, double prec);
+void free(QMFunctionVector &vec);
 
-void linear_combination(const ComplexVector &c,
-                        QMFunctionVector &inp,
-                        QMFunction &out,
-                        double prec);
- 
 } //namespace qmfunction
-
 } //namespace mrchem

--- a/src/qmfunctions/qmfunction_utils.h
+++ b/src/qmfunctions/qmfunction_utils.h
@@ -35,6 +35,14 @@ namespace qmfunction {
 ComplexDouble dot(QMFunction &bra, double bra_conj,
                   QMFunction &ket, double ket_conj);
  
+void multiply_real(QMFunction &inp_a, double conj_a,
+                               QMFunction &inp_b, double conj_b,
+                               QMFunction &out, double prec);
+ 
+void multiply_imag(QMFunction &inp_a, double conj_a,
+                               QMFunction &inp_b, double conj_b,
+                               QMFunction &out, double prec);
+ 
 void multiply(QMFunction &inp_a, double conj_a,
               QMFunction &inp_b, double conj_b,
               QMFunction &out,   double prec);

--- a/src/qmoperators/RankZeroTensorOperator.cpp
+++ b/src/qmoperators/RankZeroTensorOperator.cpp
@@ -30,6 +30,7 @@
 #include "RankZeroTensorOperator.h"
 #include "qmfunctions/Orbital.h"
 #include "qmfunctions/orbital_utils.h"
+#include "qmfunctions/qmfunction_utils.h"
 
 namespace mrchem {
 extern mrcpp::MultiResolutionAnalysis<3> *MRA; // Global MRA
@@ -165,14 +166,15 @@ void RankZeroTensorOperator::clear() {
 Orbital RankZeroTensorOperator::operator()(Orbital inp) {
     if (not mpi::my_orb(inp)) return inp.paramCopy();
 
-    OrbitalVector orb_vec;
+    QMFunctionVector func_vec;
     ComplexVector coef_vec = getCoefVector();
     for (int n = 0; n < this->oper_exp.size(); n++) {
         Orbital out_n = applyOperTerm(n, inp);
-        orb_vec.push_back(out_n);
+        func_vec.push_back(out_n);
     }
-    Orbital out = orbital::linear_combination(coef_vec, orb_vec);
-    orbital::free(orb_vec);
+    Orbital out = inp.paramCopy();
+    qmfunction::linear_combination(out, coef_vec, func_vec, -1.0);
+    qmfunction::free(func_vec);
     return out;
 }
 

--- a/src/qmoperators/one_electron/QMPotential.cpp
+++ b/src/qmoperators/one_electron/QMPotential.cpp
@@ -23,9 +23,9 @@ extern mrcpp::MultiResolutionAnalysis<3> *MRA; // Global MRA
  * beyond this initial refinement.
  */
 QMPotential::QMPotential(int adap)
-        : QMFunction(0, 0),
-          QMOperator(),
-          adap_build(adap) {
+        : QMFunction(nullptr, nullptr)
+        , QMOperator()
+        , adap_build(adap) {
 }
 
 /** @brief destructor

--- a/src/qmoperators/two_electron/CoulombPotential.cpp
+++ b/src/qmoperators/two_electron/CoulombPotential.cpp
@@ -77,10 +77,10 @@ void CoulombPotential::setupDensity(double prec) {
     Density &rho = this->density;
 
     Timer timer;
-    density::compute(-1.0, rho, Phi, DENSITY::Total);
+    density::compute(prec, rho, Phi, DENSITY::Total);
     timer.stop();
     double t = timer.getWallTime();
-    int n = rho.real().getNNodes(); //LUCA this should be implemented also for the IMAG part
+    int n = rho.getNNodes();
     Printer::printTree(0, "Coulomb density", n, t);
 }
 
@@ -100,9 +100,6 @@ void CoulombPotential::setupPotential(double prec) {
     QMPotential &V = *this;
     Density &rho = this->density;
 
-    int nPoints = rho.real().getTDim()*rho.real().getKp1_d();
-    int inpNodes = rho.getNNodes();
-
     // Adjust precision by system size
     double abs_prec = prec/rho.real().integrate();
 
@@ -113,15 +110,6 @@ void CoulombPotential::setupPotential(double prec) {
     int n = V.getNNodes();
     double t = timer.getWallTime();
     Printer::printTree(0, "Coulomb potential", n, t);
-
-    // Prepare density grid for next iteration
-    rho.real().crop(abs_prec, 1.0, false);
-    mrcpp::refine_grid(rho.real(), abs_prec);
-
-    int newNodes = rho.getNNodes() - inpNodes;
-
-    println(0, " Coulomb grid size   " << std::setw(21) << inpNodes << std::setw(17) << nPoints*inpNodes);
-    println(0, " Coulomb grid change " << std::setw(21) << newNodes << std::setw(17) << nPoints*newNodes);
 }
 
 } //namespace mrchem

--- a/src/scf_solver/Accelerator.cpp
+++ b/src/scf_solver/Accelerator.cpp
@@ -103,12 +103,12 @@ void Accelerator::rotate(const ComplexMatrix &U, bool all) {
     if (nOrbs <= 0) { return; }
     for (int i = 0; i < nOrbs; i++) {
         OrbitalVector &Phi = this->orbitals[i];
-        OrbitalVector tmp = orbital::linear_combination(U, Phi);
+        OrbitalVector tmp = orbital::rotate(U, Phi);
         orbital::free(Phi);
         Phi = tmp;
 
         OrbitalVector &dPhi = this->dOrbitals[i];
-        OrbitalVector dTmp = orbital::linear_combination(U, dPhi);
+        OrbitalVector dTmp = orbital::rotate(U, dPhi);
         orbital::free(dPhi);
         dPhi = dTmp;
     }

--- a/src/scf_solver/EnergyOptimizer.cpp
+++ b/src/scf_solver/EnergyOptimizer.cpp
@@ -178,7 +178,7 @@ bool EnergyOptimizer::optimize() {
 
         // Rotate orbitals
         ComplexMatrix U = orbital::calc_lowdin_matrix(Phi_np1);
-        Phi_n = orbital::linear_combination(U, Phi_np1, orb_prec);
+        Phi_n = orbital::rotate(U, Phi_np1, orb_prec);
         F_n = U * F_np1 * U.adjoint();
         orbital::free(Phi_np1);
         orbital::set_errors(Phi_n, errors);

--- a/src/scf_solver/GroundStateSolver.cpp
+++ b/src/scf_solver/GroundStateSolver.cpp
@@ -91,7 +91,7 @@ OrbitalVector GroundStateSolver::setupHelmholtzArguments(FockOperator &fock,
     if (clearFock) fock.clear();
 
     Timer timer_2;
-    OrbitalVector part_2 = orbital::linear_combination(M, Phi);
+    OrbitalVector part_2 = orbital::rotate(M, Phi);
     timer_2.stop();
     Printer::printDouble(0, "Matrix part", timer_2.getWallTime(), 5);
 

--- a/tests/qmfunctions/density.cpp
+++ b/tests/qmfunctions/density.cpp
@@ -44,18 +44,6 @@ TEST_CASE("Density", "[density]") {
         Density rho;
         rho.setReal(new mrcpp::FunctionTree<3>(*MRA));
 
-        SECTION("single orbital") {
-            HydrogenFunction h(1,0,0);
-            Orbital phi(SPIN::Alpha);
-            phi.alloc(NUMBER::Real);
-            mrcpp::project(prec, phi.real(), h);
-            mrcpp::build_grid(rho.real(), phi.real());
-            density::compute(-1.0, rho, phi, DENSITY::Total);
-            REQUIRE( rho.real().integrate() == Approx(1.0) );
-
-            phi.free();
-        }
-        
         SECTION("orbital vector") {
             HydrogenFunction h_1(2,1,0);
             HydrogenFunction h_2(2,1,1);
@@ -88,28 +76,6 @@ TEST_CASE("Density", "[density]") {
         rho_a.setReal(new mrcpp::FunctionTree<3>(*MRA));
         rho_b.setReal(new mrcpp::FunctionTree<3>(*MRA));
 
-        SECTION("single orbital") {
-            HydrogenFunction h(1,0,0);
-            Orbital phi(SPIN::Alpha);
-            phi.alloc(NUMBER::Real);
-            mrcpp::project(prec, phi.real(), h);
-
-            mrcpp::build_grid(rho_t.real(), phi.real());
-            mrcpp::build_grid(rho_s.real(), phi.real());
-            mrcpp::build_grid(rho_a.real(), phi.real());
-            mrcpp::build_grid(rho_b.real(), phi.real());
-            density::compute(-1.0, rho_t, phi, DENSITY::Total);
-            density::compute(-1.0, rho_s, phi, DENSITY::Spin);
-            density::compute(-1.0, rho_a, phi, DENSITY::Alpha);
-            density::compute(-1.0, rho_b, phi, DENSITY::Beta);
-
-            REQUIRE( rho_t.real().integrate() == Approx(1.0) );
-            REQUIRE( rho_s.real().integrate() == Approx(1.0) );
-            REQUIRE( rho_a.real().integrate() == Approx(1.0) );
-            REQUIRE( rho_b.real().integrate() == Approx(0.0) );
-
-            phi.free();
-        }
         SECTION("orbital vector") {
             HydrogenFunction s1(1,0,0);
             HydrogenFunction s2(2,0,0);

--- a/tests/qmfunctions/orbital.cpp
+++ b/tests/qmfunctions/orbital.cpp
@@ -28,6 +28,7 @@
 #include "mrchem.h"
 #include "qmfunctions/Orbital.h"
 #include "qmfunctions/orbital_utils.h"
+#include "qmfunctions/qmfunction_utils.h"
 
 using namespace mrchem;
 
@@ -225,14 +226,16 @@ TEST_CASE("Orbital", "[orbital]") {
         mrcpp::project(prec, phi.imag(), g);
 
         SECTION("scalar conjugate") {
-            Orbital psi = orbital::add(std::conj(c), phi, c, phi);
+            Orbital psi = phi.paramCopy();
+            qmfunction::add(psi, std::conj(c), phi, c, phi, -1.0);
             REQUIRE( psi.real().integrate() == Approx(phi.real().integrate()) );
             REQUIRE( psi.imag().integrate() == Approx(phi.imag().integrate()) );
             psi.free();
         }
 
         SECTION("orbital conjugate") {
-            Orbital psi = orbital::add(c, phi, c, phi.dagger());
+            Orbital psi = phi.paramCopy();
+            qmfunction::add(psi, c, phi, c, phi.dagger(), -1.0);
             REQUIRE( psi.real().integrate() == Approx(phi.real().integrate()) );
             REQUIRE( psi.imag().integrate() == Approx(phi.real().integrate()) );
             psi.free();
@@ -246,7 +249,8 @@ TEST_CASE("Orbital", "[orbital]") {
         mrcpp::project(prec, phi.real(), f);
         mrcpp::project(prec, phi.imag(), g);
 
-        Orbital psi = orbital::multiply(phi.dagger(), phi);
+        Orbital psi = phi.paramCopy();
+        qmfunction::multiply(psi, phi.dagger(), phi, -1.0);
         double f_norm = phi.real().getSquareNorm();
         double g_norm = phi.imag().getSquareNorm();
         REQUIRE( psi.real().integrate() == Approx(f_norm + g_norm) );

--- a/tests/qmfunctions/orbital_vector.cpp
+++ b/tests/qmfunctions/orbital_vector.cpp
@@ -353,7 +353,7 @@ TEST_CASE("OrbitalVector", "[orbital_vector]") {
         U(1,1) =  cos(theta);
 
         SECTION("unitary transformation") {
-            OrbitalVector Psi = linear_combination(U, Phi, prec);
+            OrbitalVector Psi = rotate(U, Phi, prec);
             for (int i = 0; i < nOrbs; i++) {
                 for (int j = 0; j < nOrbs; j++) {
                     ComplexDouble S_ij = orbital::dot(Psi[i], Psi[j]);


### PR DESCRIPTION
I restructured the `QMFunction` to make the `Orbital` and `Density` functionality simpler and more consistent. This will also help in the generalization of shared memory that should be done in #135. It's probably a bit too much for a proper review, but @ilfreddy please have a look at the changes it lead to in the `density::compute()` routines. 