### PR TITLE
Write perturbed orbitals on disk

### DIFF
--- a/src/SCFDriver.cpp
+++ b/src/SCFDriver.cpp
@@ -328,7 +328,7 @@ void SCFDriver::setup() {
         molecule->initMagnetizability();
         for (int d = 0; d < 3; d++) {
             if (rsp_directions[d] == 0) continue;
-            rsp_calculations.push_back(h_B, 0.0, true, d);
+            rsp_calculations.push_back(h_B, 0.0, true, d, "H_B");
         }
     }
     if (calc_nmr_shielding) {
@@ -338,13 +338,14 @@ void SCFDriver::setup() {
             if (nmr_perturbation == "B") {
                 for (int d = 0; d < 3; d++) {
                     if (rsp_directions[d] == 0) continue;
-                    rsp_calculations.push_back(h_B, 0.0, true, d);
+                    rsp_calculations.push_back(h_B, 0.0, true, d, "H_B");
                 }
             } else {
                 const double *r_K = molecule->getNucleus(K).getCoord();
                 for (int d = 0; d < 3; d++) {
                     if (rsp_directions[d] == 0) continue;
-                    rsp_calculations.push_back(h_M[K], 0.0, true, d);
+                    std::string name = "H_M" + std::to_string(K);
+                    rsp_calculations.push_back(h_M[K], 0.0, true, d, name);
                 }
             }
         }
@@ -710,9 +711,15 @@ void SCFDriver::runLinearResponse(const ResponseCalculation &rsp_calc) {
         solver->clearUnperturbed();
         delete solver;
     }
-
-    if (rsp_write_orbitals) NOT_IMPLEMENTED_ABORT;
-
+    if (rsp_write_orbitals) {
+        std::string suffix_x = rsp_calc.name + "_X_";
+        orbital::save_orbitals(*phi_x, file_final_orbitals, suffix_x);
+        if(dynamic) {
+            std::string suffix_y = rsp_calc.name + "_Y_";
+            orbital::save_orbitals(*phi_y, file_final_orbitals, suffix_y);
+        }
+    }
+    
     // Compute requested properties
     if (converged) calcLinearResponseProperties(rsp_calc);
 

--- a/src/SCFDriver.h
+++ b/src/SCFDriver.h
@@ -38,8 +38,8 @@ class MagneticFieldOperator;
 
 class ResponseCalculation final {
 public:
-    ResponseCalculation(RankOneTensorOperator<3> *h, double w, bool im, int d)
-        : pert(h), freq(w), imag(im), dir(d) { }
+ ResponseCalculation(RankOneTensorOperator<3> *h, double w, bool im, int d, const std::string &n)
+     : pert(h), freq(w), imag(im), dir(d), name(n) { }
 
     bool isDynamic() const { if (std::abs(this->freq) > mrcpp::MachineZero) return true; return false; }
     bool isImaginary() const { return this->imag; }
@@ -48,12 +48,13 @@ public:
     double freq;
     bool imag;
     int dir;
+    std::string name;
 };
 
 class ResponseCalculations final {
 public:
-    void push_back(RankOneTensorOperator<3> *h, double w, bool im, int d) {
-        ResponseCalculation rsp_calc(h, w, im, d);
+    void push_back(RankOneTensorOperator<3> *h, double w, bool im, int d, const std::string &n) {
+        ResponseCalculation rsp_calc(h, w, im, d, n);
         bool unique = true;
         for (int i = 0; i < this->calculations.size(); i++) {
             const ResponseCalculation &i_calc = calculations[i];
@@ -75,7 +76,7 @@ protected:
     std::vector<ResponseCalculation> calculations;
 };
 
-class SCFDriver final {
+ class SCFDriver final {
 public:
     SCFDriver(Getkw &input);
     ~SCFDriver() { }

--- a/src/properties/Magnetizability.h
+++ b/src/properties/Magnetizability.h
@@ -99,6 +99,7 @@ public:
 protected:
     DoubleMatrix diamagnetic;
     DoubleMatrix paramagnetic;
+    static const std::string name;
 };
 
 } //namespace mrchem

--- a/src/qmfunctions/orbital_utils.cpp
+++ b/src/qmfunctions/orbital_utils.cpp
@@ -252,13 +252,13 @@ OrbitalVector orbital::disjoin(OrbitalVector &inp, int spin) {
  * imaginary ("phi_0_im.tree") parts. Negative n_orbs means that all orbitals in the
  * vector are saved.
  */
-void orbital::save_orbitals(OrbitalVector &Phi, const std::string &file, int n_orbs) {
+void orbital::save_orbitals(OrbitalVector &Phi, const std::string &file, const std::string &suffix, int n_orbs) {
     if (n_orbs < 0) n_orbs = Phi.size();
     if (n_orbs > Phi.size()) MSG_ERROR("Index out of bounds");
     for (int i = 0; i < n_orbs; i++) {
         if (not mpi::my_orb(Phi[i])) continue; //only save own orbitals
         std::stringstream orbname;
-        orbname << file << "_" << i;
+        orbname << file << "_" << suffix << i;
         Phi[i].saveOrbital(orbname.str());
     }
 }
@@ -273,13 +273,13 @@ void orbital::save_orbitals(OrbitalVector &Phi, const std::string &file, int n_o
  * imaginary ("phi_0_im.tree") parts. Negative n_orbs means that all orbitals matching
  * the prefix name will be read.
  */
-OrbitalVector orbital::load_orbitals(const std::string &file, int n_orbs) {
+OrbitalVector orbital::load_orbitals(const std::string &file, const std::string &suffix, int n_orbs) {
     OrbitalVector Phi;
     for (int i = 0; true; i++) {
         if (n_orbs > 0 and i >= n_orbs) break;
         Orbital phi_i;
         std::stringstream orbname;
-        orbname << file << "_" << i;
+        orbname << file << "_" << suffix << i;
         phi_i.loadOrbital(orbname.str());
         phi_i.setRankId(mpi::orb_rank);
         if (phi_i.hasReal() or phi_i.hasImag()) {

--- a/src/qmfunctions/orbital_utils.h
+++ b/src/qmfunctions/orbital_utils.h
@@ -47,8 +47,8 @@ OrbitalVector param_copy(const OrbitalVector &inp);
 OrbitalVector adjoin(OrbitalVector &inp_a, OrbitalVector &inp_b);
 OrbitalVector disjoin(OrbitalVector &inp, int spin);
 
-void save_orbitals(OrbitalVector &Phi, const std::string &file, int n_orbs = -1);
-OrbitalVector load_orbitals(const std::string &file, int n_orbs = -1);
+void save_orbitals(OrbitalVector &Phi, const std::string &file, const std::string &suffix = "", int n_orbs = -1);
+OrbitalVector load_orbitals(const std::string &file, const std::string &suffix = "", int n_orbs = -1);
 
 void free(OrbitalVector &vec);
 void normalize(OrbitalVector &vec);


### PR DESCRIPTION
Perturbed orbitals are written on disk in the same folder as the ground state orbitals. In order to distinguish them, they bear a suffix in the name, which stems from the perturbation. The name is derived from the corresponding `ResponsePerturbation` object, which in turns gets it from the corresponding perturbation operator. The naming is for the time being done "by hand" but it would be better to assign a name directly to the operators and then use it.