### PR TITLE
Update XCFun

### DIFF
--- a/src/SCFDriver.h
+++ b/src/SCFDriver.h
@@ -44,11 +44,7 @@ public:
             , imag(im)
             , dir(d)
             , name(n) {}
-
-    bool isDynamic() const {
-        if (std::abs(this->freq) > mrcpp::MachineZero) return true;
-        return false;
-    }
+    bool isDynamic() const { return (std::abs(this->freq) > mrcpp::MachineZero); }
     bool isImaginary() const { return this->imag; }
     std::string getFileSuffix() const {
         std::stringstream suffix;
@@ -71,8 +67,9 @@ public:
         for (int i = 0; i < this->calculations.size(); i++) {
             const ResponseCalculation &i_calc = calculations[i];
             if ((i_calc.pert == rsp_calc.pert) and (std::abs(i_calc.freq - rsp_calc.freq) < mrcpp::MachineZero) and
-                (i_calc.dir == rsp_calc.dir))
+                (i_calc.dir == rsp_calc.dir)) {
                 unique = false;
+            }
         }
         if (unique) this->calculations.push_back(rsp_calc);
     }
@@ -149,7 +146,6 @@ protected:
     // DFT input
     bool dft_spin;
     bool dft_use_gamma;
-    double dft_x_fac;
     double dft_cutoff;
     std::vector<double> dft_func_coefs;
     std::vector<std::string> dft_func_names;

--- a/src/mrchem.in
+++ b/src/mrchem.in
@@ -210,7 +210,6 @@ def setup_keywords(input_dir):
     dft.add_kw('spin',                  'BOOL', False)
     dft.add_kw('orbital_free',          'BOOL', False)
     dft.add_kw('use_gamma',             'BOOL', False)
-    dft.add_kw('exact_exchange',        'DBL', 0.0)
     dft.add_kw('density_cutoff',        'DBL', 0.0)
     dft.add_kw('functionals',           'DATA')
     dft.add_kw('func_coefs',            'DBL_ARRAY')
@@ -514,28 +513,22 @@ def verify_wf(wf):
         'DFT'
     }
     default_functionals = {
-        #functional:exact_exchange
-        'LDA':0.00,
-        'PBE':0.00,
-        'PBE0':0.25,
-        'BLYP':0.0,
-        'B3LYP':0.20,
-        'BP86':0.0,
-        'PW91':0.0
+        'LDA',
+        'PBE',
+        'PBE0',
+        'BLYP',
+        'B3LYP',
+        'BP86',
+        'PW91',
     }
     method = wf['method'][0]
     if method in default_functionals:
         dft = topsect.fetch_sect('DFT')
-        exx = default_functionals[method]
         if dft['functionals'].is_set():
             print('Cannot overwrite default functional: ' + method)
             exit()
-        if dft['exact_exchange'].is_set():
-            print('Cannot overwrite default exact exchange: ' + str(exx))
-            exit()
         wf['method'][0] = 'DFT'
         dft['functionals'].get().append(method + ' 1.00')
-        dft['exact_exchange'][0] = exx
     elif not (method in valid_methods):
         print('Invalid WaveFunction method: ' + method)
         exit()

--- a/src/mrdft/XCFunctional.h
+++ b/src/mrdft/XCFunctional.h
@@ -87,11 +87,18 @@ public:
     void setUseGamma(bool use) { this->use_gamma = use; }
     bool useGamma() const { return this->use_gamma; }
 
+    int getOrder() const { return this->order; }
     bool isLDA() const { return (not(isGGA() or isMetaGGA())); }
     bool isGGA() const { return (xc_is_gga(this->functional)); }
     bool isMetaGGA() const { return (xc_is_metagga(this->functional)); }
+    bool isHybrid() const { return (std::abs(this->amountEXX()) > mrcpp::MachineZero); }
     bool isSpinSeparated() const { return this->spin_separated; }
-    int getOrder() const { return this->order; }
+
+    double amountEXX() const {
+        double exx = 0.0;
+        xc_get(this->functional, "exx", &exx);
+        return exx;
+    }
 
     void evalSetup(int order);
     void setup();

--- a/tests/li_scf_pbe0/mrchem.inp
+++ b/tests/li_scf_pbe0/mrchem.inp
@@ -21,8 +21,8 @@ WaveFunction {
 }
 
 DFT {
-  exact_exchange = 0.25
 $functionals
+EXX     0.25
 PBEX    0.75
 PBEC    1.00
 $end


### PR DESCRIPTION
Incorporate latest changes in XCFun:

- Remove `ENABLE_OMP` compiler flag in XCFun
- Replace `exact_exchange` parameter in MRChem with `EXX` parameter from XCFun
- Update docs with info on new default DFT functionals

Perhaps wait for PR #161 to simplify merging.