### PR TITLE
Bugfix: Nuclear potential projection precision

### DIFF
--- a/src/analyticfunctions/NuclearFunction.cpp
+++ b/src/analyticfunctions/NuclearFunction.cpp
@@ -35,14 +35,14 @@ void NuclearFunction::push_back(const Nucleus &nuc, double S) {
 }
 
 double NuclearFunction::evalf(const mrcpp::Coord<3> &r) const {
-    double c = -1.0/(3.0*mrcpp::root_pi);
+    double c = -1.0 / (3.0 * mrcpp::root_pi);
     double result = 0.0;
     for (int i = 0; i < this->nuclei.size(); i++) {
         double S_i = this->smooth[i];
         double Z_i = this->nuclei[i].getCharge();
         const mrcpp::Coord<3> &R = this->nuclei[i].getCoord();
-        double R1 = math_utils::calc_distance(R, r)/S_i;
-        double partResult = -std::erf(R1)/R1 + c*(std::exp(-R1*R1) + 16.0*std::exp(-4.0*R1*R1));
+        double R1 = math_utils::calc_distance(R, r) / S_i;
+        double partResult = -std::erf(R1) / R1 + c * (std::exp(-R1 * R1) + 16.0 * std::exp(-4.0 * R1 * R1));
         result += Z_i*partResult/S_i;
     }
     return result;
@@ -56,7 +56,7 @@ bool NuclearFunction::isVisibleAtScale(int scale, int nQuadPts) const {
         }
     }
     double stdDeviation = std::pow(minSmooth, -0.5);
-    int visibleScale = int (floor(std::log2(nQuadPts*5.0*stdDeviation)));
+    int visibleScale = int (std::floor(std::log2(nQuadPts * 5.0 * stdDeviation)));
     if (scale < visibleScale) {
         return false;
     } else {

--- a/src/qmoperators/one_electron/NuclearOperator.cpp
+++ b/src/qmoperators/one_electron/NuclearOperator.cpp
@@ -22,8 +22,8 @@ NuclearPotential::NuclearPotential(const Nuclei &nucs, double prec)
     for (int i = 0; i < nucs.size(); i++) {
         const Nucleus &nuc = nucs[i];
         double Z = nuc.getCharge();
-        double Z_5 = pow(Z, 5.0);
-        double smooth = pow(c / Z_5, 1.0 / 3.0);
+        double Z_5 = std::pow(Z, 5.0);
+        double smooth = std::pow(c / Z_5, 1.0 / 3.0);
         this->func.push_back(nuc, smooth);
 
         std::stringstream symbol;
@@ -38,7 +38,7 @@ NuclearPotential::NuclearPotential(const Nuclei &nucs, double prec)
 
     Timer timer;
     QMPotential &V = *this;
-    qmfunction::project(V, this->func, NUMBER::Real, this->apply_prec);
+    qmfunction::project(V, this->func, NUMBER::Real, prec);
     timer.stop();
     int n = V.getNNodes(NUMBER::Total);
     double t = timer.getWallTime();


### PR DESCRIPTION
Previously, the nuclear potential was re-projected at every SCF iteration using the current `apply_prec` of the operator:
```
NuclearPotential::setup(prec) {
   setApplyPrec(prec);        // set current apply_prec for use in V*phi
   project(this->apply_prec); // project using current apply_prec
}

NuclearPotential::clear() {
  clearApplyPrec(); // set current apply_prec to -1.0
  free();           // free projected function
}
```

Now the projection has been moved to the `NuclearPotential` constructor, but the precision was still set to `this->apply_prec`, which is unset (-1.0) at this point. This means that the nuclear potential was projected non-adaptively on a fixed initial grid. This error was hard to catch since the initial grid is estimated usually quite close to the final grid based on the molecular geometry (thanks @gitpeterwind). 

The appropriate thing to do is to use the precision parameter `prec` that is passed to the constructor, which is supposed to be the final overall `rel_prec` of the calculation. This has been fixed in this patch.
```
NuclearPotential::NuclearPotential(prec) {
   project(prec); // project using given precision
}

NuclearPotential::~NuclearPotential() {
  free(); // free projected function
}

NuclearPotential::setup(prec) {
   setApplyPrec(prec); // set current apply_prec for use in V*phi
}

NuclearPotential::clear() {
  clearApplyPrec(); // set current apply_prec to -1.0
}
```

NB: The `apply_prec` parameter in `setup()` is still used in the *multiplication* of the potential with the orbital `V*phi`, so it is still necessary to `setup(prec)` and `clear()` the operator between iterations.

@gitpeterwind , can you test this patch on some of your failing tests?