### PR TITLE
Use specific Docker image tag, rather than latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 variables:
   ubuntu-1804: &ubuntu-1804
     docker:
-      - image: mrchemsoft/circleci_ubuntu-18.04
+      - image: mrchemsoft/circleci_ubuntu-18.04:0f3e70749f6e
         name: tsubame
         user: merzbow
     working_directory: ~/mrchem


### PR DESCRIPTION
When setting the Docker image to `mrchemsoft/circleci_ubuntu-18.04` we default to using `latest`. That is, however, a moving target and can make it hard to reproduce build failures locally. With a tagged Docker image we now exactly which version was used.