### PR TITLE
Fix performance issues with shared density

### DIFF
--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -204,9 +204,10 @@ void mpi::recv_orbital(Orbital &orb, int src, int tag) {
 #endif
 }
 
-//send a density with MPI
+//send a function with MPI
 void mpi::send_function(QMFunction &func, int dst, int tag, MPI_Comm comm) {
 #ifdef HAVE_MPI
+    if (func.isShared()) MSG_WARN("Sending a shared function is not recommended");
     FunctionData &funcinfo = func.getFunctionData();
     MPI_Send(&funcinfo, sizeof(FunctionData), MPI_BYTE, dst, 0, comm);
 
@@ -215,9 +216,10 @@ void mpi::send_function(QMFunction &func, int dst, int tag, MPI_Comm comm) {
 #endif
 }
 
-//receive a denstity with MPI
+//receive a function with MPI
 void mpi::recv_function(QMFunction &func, int src, int tag, MPI_Comm comm) {
 #ifdef HAVE_MPI
+    if (func.isShared()) MSG_WARN("Receiving a shared function is not recommended");
     MPI_Status status;
 
     FunctionData &funcinfo = func.getFunctionData();


### PR DESCRIPTION
It seems there's a problem if we call `mpi::send_function()` with a shared density, e.i. the grand master sends a density from its shared memory to the sub masters who receives into their shared memory.

Old compute density algorithm
--------------------------------------
1) All ranks compute a non-shared local density from own orbitals
2) All local densities are sent to the grand master who adds the contributions in place into its non-shared local density
3) Grand master copies the result into shared memory
4) Grand master distributes the shared density to the sub masters who shares it with their sibling ranks

New compute density algorithm
--------------------------------------
1) All ranks compute a non-shared local density from own orbitals
2) All local densities are sent to the grand master who adds the contributions in place into its non-shared local density
3) Grand master distributes the non-shared total density to the sub masters
4) Sub masters copies the density into shared memory and shares with their sibling ranks

Status
--------
Waiting on final confirmation that the performance is back to normal from a set of test calculations.
- [x] Ready to review
- [ ] Ready to merge