### PR TITLE
[WIP] Refactoring XCFunctional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,5 @@ doc/html/
 doc/xml/
 
 .direnv/
+*_inst
+*_build

--- a/src/SCFDriver.cpp
+++ b/src/SCFDriver.cpp
@@ -596,7 +596,7 @@ void SCFDriver::setupPerturbedOperators(const ResponseCalculation &rsp_calc) {
         xFac = 1.0;
     } else if (wf_method == "dft") {
         xFac = xcfun->amountEXX();
-        xcfun = setupFunctional(MRDFT::Hessian);
+        xcfun = setupFunctional(MRDFT::Hessian, 2);
         dXC = new XCOperator(xcfun, phi, phi_x, phi_y);
     }
     if (xFac > mrcpp::MachineZero) NOT_IMPLEMENTED_ABORT;
@@ -997,7 +997,7 @@ void SCFDriver::setupInitialGrid(mrdft::XCFunctional &func, const Molecule &mol)
  *
  */
 
-mrdft::XCFunctional *SCFDriver::setupFunctional(int order) {
+mrdft::XCFunctional *SCFDriver::setupFunctional(int order, int n_dens) {
     mrdft::XCFunctional *fun = new mrdft::XCFunctional(*MRA, dft_spin);
     for (int i = 0; i < dft_func_names.size(); i++) {
         double f_coef = dft_func_coefs[i];
@@ -1006,8 +1006,9 @@ mrdft::XCFunctional *SCFDriver::setupFunctional(int order) {
     }
     fun->setUseGamma(dft_use_gamma);
     fun->setDensityCutoff(dft_cutoff);
+    fun->setNDensities(n_dens);
     fun->evalSetup(order);
-    // setupInitialGrid(*fun, *molecule);
+    fun->allocateDensities();
     return fun;
 }
 

--- a/src/SCFDriver.cpp
+++ b/src/SCFDriver.cpp
@@ -1005,6 +1005,7 @@ mrdft::XCFunctional *SCFDriver::setupFunctional(int order, int n_dens) {
         const std::string &f_name = dft_func_names[i];
         fun->setFunctional(f_name, f_coef);
     }
+    if(dft_use_gamma) NOT_IMPLEMENTED_ABORT;
     fun->setUseGamma(dft_use_gamma);
     fun->setDensityCutoff(dft_cutoff);
     fun->setNDensities(n_dens);

--- a/src/SCFDriver.cpp
+++ b/src/SCFDriver.cpp
@@ -694,10 +694,11 @@ void SCFDriver::runLinearResponse(const ResponseCalculation &rsp_calc) {
     setupPerturbedOrbitals(rsp_calc);
     setupPerturbedOperators(rsp_calc);
 
-    d_fock->getXCOperator()->setupDensity(rel_prec); // Luca: maybe this is not the best place to do this....
+    /*
+    d_fock->getXCOperator()->setupDensity(rel_prec); //Luca: maybe this is not the best place to do this....
     d_fock->getXCOperator()->setupPotential(rel_prec);
-    d_fock->getXCOperator()->setupDensity(rel_prec); // Luca: maybe this is not the best place to do this....
-
+    d_fock->getXCOperator()->setupDensity(rel_prec); //Luca: maybe this is not the best place to do this....
+    */
     bool converged = true;
     if (rsp_run) {
         LinearResponseSolver *solver = setupLinearResponseSolver(dynamic);

--- a/src/SCFDriver.h
+++ b/src/SCFDriver.h
@@ -261,7 +261,7 @@ protected:
     void calcGroundStateProperties();
     void calcLinearResponseProperties(const ResponseCalculation &rsp_calc);
 
-    mrdft::XCFunctional *setupFunctional(int order);
+    mrdft::XCFunctional *setupFunctional(int order, int n_dens = 1);
     void setupInitialGrid(mrdft::XCFunctional &func, const Molecule &mol);
     void setupInitialGroundState();
     void setupPerturbedOperators(const ResponseCalculation &rsp_calc);

--- a/src/initial_guess/sad.cpp
+++ b/src/initial_guess/sad.cpp
@@ -94,12 +94,12 @@ OrbitalVector initial_guess::sad::setup(double prec, const Molecule &mol, bool r
 
     // Compute XC density
     if (restricted) {
-        mrcpp::FunctionTree<3> &rho_xc = XC.getDensity(DENSITY::Total);
+        mrcpp::FunctionTree<3> &rho_xc = XC.getDensity(DENSITY::DensityType::Total);
         mrcpp::copy_grid(rho_xc, rho_j.real());
         mrcpp::copy_func(rho_xc, rho_j.real());
     } else {
-        mrcpp::FunctionTree<3> &rho_a = XC.getDensity(DENSITY::Alpha);
-        mrcpp::FunctionTree<3> &rho_b = XC.getDensity(DENSITY::Beta);
+        mrcpp::FunctionTree<3> &rho_a = XC.getDensity(DENSITY::DensityType::Alpha);
+        mrcpp::FunctionTree<3> &rho_b = XC.getDensity(DENSITY::DensityType::Beta);
         mrcpp::add(prec, rho_a, 1.0, rho_j.real(), -1.0 * Nb / Ne, rho_j.real());
         mrcpp::add(prec, rho_b, 1.0, rho_j.real(), -1.0 * Na / Ne, rho_j.real());
 

--- a/src/initial_guess/sad.cpp
+++ b/src/initial_guess/sad.cpp
@@ -78,7 +78,10 @@ OrbitalVector initial_guess::sad::setup(double prec, const Molecule &mol, bool r
     mrdft::XCFunctional xcfun(*MRA, not restricted);
     xcfun.setFunctional("SLATERX");
     xcfun.setFunctional("VWN5C");
-    xcfun.evalSetup(1);
+    xcfun.evalSetup(MRDFT::Gradient);
+    xcfun.setNDensities(1);
+    xcfun.allocateDensities();
+    
     KineticOperator T(D);
     NuclearOperator V_nuc(mol.getNuclei(), prec);
     CoulombOperator J(&P);

--- a/src/mrchem.h
+++ b/src/mrchem.h
@@ -15,6 +15,7 @@
 
 #include "MRCPP/MWFunctions"
 #include "config.h"
+#include "mrenum.h"
 
 class Getkw;
 
@@ -40,9 +41,7 @@ const double sqrt_pi =    1.7724538509055160273;
 
 namespace SPIN { enum type { Paired, Alpha, Beta }; }
 namespace NUMBER { enum type { Total, Real, Imag }; }
-namespace DENSITY { enum type { Total, Spin, Alpha, Beta }; }
 namespace MRDFT {enum type {Function, Gradient, Hessian}; }
-
 
 using ComplexInt = std::complex<int>;
 using ComplexDouble = std::complex<double>;

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -217,8 +217,8 @@ FunctionTree<3> &XCFunctional::getDensity(FunctionTreeVector<3> &density, int in
     return mrcpp::get_func(density, index);
 }
 
-void XCFunctional::setDensity(FunctionTree<3> *density, DensityType type, int index) {
-    FunctionTreeVector<3> dens_vec = getDensityVector(type);
+void XCFunctional::setDensity(FunctionTree<3> *density, DensityType spin, int index) {
+    FunctionTreeVector<3> dens_vec = getDensityVector(spin);
     if (dens_vec.size() != index) {
         MSG_FATAL("Index mismatch");
     }

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -144,7 +144,8 @@ bool XCFunctional::hasDensity() const {
 bool checkDensity(FunctionTreeVector<3> density) const {
     bool out = true;
     if (density.size() < nDensities) out = false;
-    for (int i = 0; i < order; i++) {
+    std::cout << 'HACK Check only GS density for now...' << std::eendl;
+    for (int i = 0; i < 1; i++) {
         FunctionTree<3> dens = mrcpp::get_func(density, i);
         if (temp->getSquareNorm() < 0.0) out = false;
     }
@@ -158,14 +159,35 @@ bool checkDensity(FunctionTreeVector<3> density) const {
  * Returns a reference to the internal vector of density functions so that it can be
  * computed by the host program. This needs to be done before setup().
  */
-FunctionTreeVector<3> & XCFunctional::getDensity(DensityType type) {
+FunctionTreeVector<3> & XCFunctional::getDensityVector(DensityType type) {
     switch (type) {
         case DensityType::Total:
-            if (checkDensity(rho_t)) return rho_t;
+            return rho_t;
         case DensityType::Alpha:
-            if (checkDensity(rho_a)) return rho_a;
+            return rho_a;
         case DensityType::Beta:
-            if (checkDensity(rho_b)) return rho_b;
+            return rho_b;
+        default:
+            MSG_FATAL("Invalid density type");
+    }
+    MSG_FATAL("Total density functions not properly initialized");
+}
+
+/** @brief Return FunctionTree for the input density
+ *
+ * @param[in] type Which density to return (alpha, beta or total)
+ *
+ * Returns a reference to the internal vector of density functions so that it can be
+ * computed by the host program. This needs to be done before setup().
+ */
+FunctionTree<3> & XCFunctional::getDensity(DensityType type, int index) {
+    switch (type) {
+        case DensityType::Total:
+            return mrcpp::get_func(rho_t, index);
+        case DensityType::Alpha:
+            return mrcpp::get_func(rho_a, index);
+        case DensityType::Beta:
+            return mrcpp::get_func(rho_b, index);
         default:
             MSG_FATAL("Invalid density type");
     }

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -125,6 +125,27 @@ bool XCFunctional::hasDensity() const {
     return out;
 }
 
+/** @brief Allocate the elements of the density vector arrays
+ *
+ * The density arrays which will contain the GS and the perturbed
+ * densities are allocated as empty FunctinTree objects. The pointers
+ * ae then stored in the corresponding FunctionTreeVector
+ */
+void XCFunctional::allocateDensities() {
+    bool out = true;
+    for (int i = 0; i < nDensities; i ++) {
+        if (isSpinSeparated()) {
+            FunctionTree<3> *temp_a = new FunctionTree<3>(MRA);
+            FunctionTree<3> *temp_b = new FunctionTree<3>(MRA);
+            rho_a.push_back(std::make_tuple(1.0, temp_a));
+            rho_b.push_back(std::make_tuple(1.0, temp_b));
+        } else {
+            FunctionTree<3> *temp_t = new FunctionTree<3>(MRA);
+            rho_t.push_back(std::make_tuple(1.0, temp_t));
+        }
+    }
+}
+
 /** @brief Check whether the density vector has all required components
  *
  * Checks if the required input densities have been computed and are
@@ -138,9 +159,9 @@ bool XCFunctional::hasDensity() const {
  */
 bool XCFunctional::checkDensity(FunctionTreeVector<3> density) const {
     bool out = true;
-    if (density.size() < nDensities) out = false;
+    if (density.size() < nDensities) out = false; //Not all required densities are present and we should make them
     std::cout << "HACK Check only GS density for now..." << std::endl;
-    for (int i = 0; i < 1; i++) {
+    for (int i = 0; i < nDensities; i++) {
         FunctionTree<3> &dens = mrcpp::get_func(density, i);
         if (dens.getSquareNorm() < 0.0) out = false;
     }

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -60,10 +60,7 @@ XCFunctional::XCFunctional(mrcpp::MultiResolutionAnalysis<3> &mra, bool spin)
         , use_gamma(false)
         , cutoff(-1.0)
         , functional(xc_new_functional())
-        , derivative(nullptr)
-        , rho_a(nullptr)
-        , rho_b(nullptr)
-        , rho_t(nullptr) {
+        , derivative(nullptr) {
     derivative = new mrcpp::ABGVOperator<3>(MRA, 0.0, 0.0);
     if (isSpinSeparated()) {
         rho_a = new FunctionTree<3>(MRA);
@@ -76,9 +73,9 @@ XCFunctional::XCFunctional(mrcpp::MultiResolutionAnalysis<3> &mra, bool spin)
 /** @brief Destructor */
 XCFunctional::~XCFunctional() {
     xc_free_functional(functional);
-    if (rho_a != nullptr) delete rho_a;
-    if (rho_b != nullptr) delete rho_b;
-    if (rho_t != nullptr) delete rho_t;
+    if (rho_a.size() > 0) mrcpp::clear(rho_a, true);
+    if (rho_b.size() > 0) mrcpp::clear(rho_b, true);
+    if (rho_t.size() > 0) mrcpp::clear(rho_t, true);
     if (derivative != nullptr) delete derivative;
 }
 
@@ -89,17 +86,18 @@ XCFunctional::~XCFunctional() {
  * Prepare the XCFun object for evaluation based on the chosen parameters.
  */
 void XCFunctional::evalSetup(int ord) {
+    if (mod != 1 and mod != 3) {
+        MSG_FATAL("Only contracted or partial derivative modes are available")
+    }
+    mode = mod;
+    order = ord; //!< update the order parameter in the object
     unsigned int func_type = isGGA(); //!< only LDA and GGA supported for now
-    unsigned int dens_type =
-        1 + isSpinSeparated();  //!< only n (dens_type = 1) or alpha & beta (denst_type = 2) supported now.
-    unsigned int mode_type = 1; //!< only derivatives (neither potential nor contracted)
+    unsigned int dens_type = 1 + isSpinSeparated();  //!< only n (dens_type = 1) or alpha & beta (denst_type = 2) supported now.
     unsigned int laplacian = 0; //!< no laplacian
     unsigned int kinetic = 0;   //!< no kinetic energy density
     unsigned int current = 0;   //!< no current density
     unsigned int exp_derivative = not useGamma(); //!< use gamma or explicit derivatives
-    order = ord;                                  //!< update the order parameter in the object
-    if (isLDA())
-        exp_derivative = 0; //!< fall back to gamma-type derivatives if LDA (bad hack: no der are actually needed here!)
+    if (isLDA()) exp_derivative = 0; //!< fall back to gamma-type derivatives if LDA (bad hack: no der are actually needed here!)
     xc_user_eval_setup(functional, order, func_type, dens_type, mode_type, laplacian, kinetic, current, exp_derivative);
 }
 
@@ -118,17 +116,37 @@ void XCFunctional::setFunctional(const std::string &name, double coef) {
 
 /** @brief Check whether the density has been computed
  *
- * Checks if the required input densities has been computed and are valid
+ * Checks if the required input densities have been computed and are valid
  * function representations. For spin separated functionals both the alpha
  * and beta densities are tested, otherwise only the total density.
  */
 bool XCFunctional::hasDensity() const {
-    bool out = true;
     if (isSpinSeparated()) {
-        if (rho_a->getSquareNorm() < 0.0) out = false;
-        if (rho_b->getSquareNorm() < 0.0) out = false;
+        out = checkDensity(rho_a);
+        out = checkDensity(rho_b);
     } else {
-        if (rho_t->getSquareNorm() < 0.0) out = false;
+        out = checkDensity(rho_t);
+    }
+    return out;
+}
+
+/** @brief Check whether the density vector has all required components
+ *
+ * Checks if the required input densities have been computed and are
+ * valid function representations. The density vector shall contain a
+ * number of densities up to the requested order (or higher)
+ *
+ * LUCA: I envisage a possible problem here. We might want to
+ * initialize the functional with a higher order although that will
+ * not be used in reality.
+ *
+ */
+bool checkDensity(FunctionTreeVector<3> density) const {
+    bool out = true;
+    if (density.size() < nDensities) out = false;
+    for (int i = 0; i < order; i++) {
+        FunctionTree<3> dens = mrcpp::get_func(density, i);
+        if (temp->getSquareNorm() < 0.0) out = false;
     }
     return out;
 }
@@ -137,34 +155,34 @@ bool XCFunctional::hasDensity() const {
  *
  * @param[in] type Which density to return (alpha, beta or total)
  *
- * Returns a reference to the internal density function so that it can be
+ * Returns a reference to the internal vector of density functions so that it can be
  * computed by the host program. This needs to be done before setup().
  */
-FunctionTree<3> &XCFunctional::getDensity(DensityType type) {
+FunctionTreeVector<3> & XCFunctional::getDensity(DensityType type) {
     switch (type) {
         case DensityType::Total:
-            if (rho_t == nullptr) MSG_FATAL("Total density not allocated");
-            return *rho_t;
+            if (checkDensity(rho_t)) return rho_t;
         case DensityType::Alpha:
-            if (rho_a == nullptr) MSG_FATAL("Alpha density not allocated");
-            return *rho_a;
+            if (checkDensity(rho_a)) return rho_a;
         case DensityType::Beta:
-            if (rho_b == nullptr) MSG_FATAL("Beta density not allocated");
-            return *rho_b;
+            if (checkDensity(rho_b)) return rho_b;
         default:
             MSG_FATAL("Invalid density type");
-            break;
     }
+    MSG_FATAL("Total density functions not properly initialized");
 }
 
 /** @brief Return the number of nodes in the density grid (including branch nodes)*/
 int XCFunctional::getNNodes() const {
     int nodes = 0;
     if (isSpinSeparated()) {
-        nodes = rho_a->getNNodes();
-        if (nodes != rho_b->getNNodes()) MSG_ERROR("Alpha and beta grids not equal");
+        FunctionTree<3> &rho_gs_a = mrcpp::get_func(rho_a, 0);
+        FunctionTree<3> &rho_gs_b = mrcpp::get_func(rho_b, 0);
+        nodes = rho_gs_a->getNNodes();
+        if (nodes != rho_gs_b->getNNodes()) MSG_ERROR("Alpha and beta grids not equal");
     } else {
-        nodes = rho_t->getNNodes();
+        FunctionTree<3> &rho_gs_t = mrcpp::get_func(rho_t, 0);
+        nodes = rho_gs_t->getNNodes();
     }
     return nodes;
 }
@@ -174,10 +192,13 @@ int XCFunctional::getNPoints() const {
     int nodes = 0;
     int points = 0;
     if (isSpinSeparated()) {
-        nodes = rho_a->getNEndNodes();
-        points = rho_a->getTDim() * rho_a->getKp1_d();
-        if (nodes != rho_b->getNEndNodes()) MSG_ERROR("Alpha and beta grids not equal");
+        FunctionTree<3> &rho_gs_a = mrcpp::get_func(rho_a, 0);
+        FunctionTree<3> &rho_gs_b = mrcpp::get_func(rho_b, 0);
+        nodes = rho_gs_a->getNEndNodes();
+        points = rho_gs_a->getTDim()*rho_a->getKp1_d();
+        if (nodes != rho_gs_b->getNEndNodes()) MSG_ERROR("Alpha and beta grids not equal");
     } else {
+        FunctionTree<3> &rho_gs_t = mrcpp::get_func(rho_t, 0);
         nodes = rho_t->getNEndNodes();
         points = rho_t->getTDim() * rho_t->getKp1_d();
     }
@@ -198,90 +219,74 @@ void XCFunctional::buildGrid(double Z, const mrcpp::Coord<3> &R) {
     for (int i = 0; i < 5; i++) {
         mrcpp::GaussFunc<3> gauss(std::pow(Z, i), 1.0, R);
         if (isSpinSeparated()) {
-            if (rho_a == nullptr) MSG_FATAL("Uninitialized alpha density");
-            if (rho_b == nullptr) MSG_FATAL("Uninitialized beta density");
-            mrcpp::build_grid(*rho_a, gauss);
-            mrcpp::build_grid(*rho_b, gauss);
+            FunctionTree<3> &rho_gs_a = mrcpp::get_func(rho_a, 0);
+            FunctionTree<3> &rho_gs_b = mrcpp::get_func(rho_b, 0);
+            mrcpp::build_grid(rho_gs_a, gauss);
+            mrcpp::build_grid(rho_gs_b, gauss);
+            distributeGrid(rho_a)
+            distributeGrid(rho_b)
         } else {
-            if (rho_t == nullptr) MSG_FATAL("Uninitialized total density");
-            mrcpp::build_grid(*rho_t, gauss);
+            FunctionTree<3> &rho_gs_t = mrcpp::get_func(rho_t, 0);
+            mrcpp::build_grid(rho_gs_t, gauss);
+            distributeGrid(rho_t)
         }
     }
 }
 
-/** @brief Remove excess grid nodes based on precision
+/** @brief Copy the grid from the ground state densities to the perturbed ones
  *
- * @param[in] prec Requested precision
- * @param[in] abs_prec Use absolute or relative precision
- *
- * This will _remove_ from the density grid nodes that are found unnecessary
- * in order to reach the requested precision. The density must already have
- * been computed for this to take effect.
+ * In contracted mode XCFun needs pointwise information about all
+ * functions, therefore all grids must be identical to the ground
+ * state grid
  */
-void XCFunctional::pruneGrid(double prec, bool abs_prec) {
-    if (not hasDensity()) return;
-
-    double scale = 1.0;
-    if (isSpinSeparated()) {
-        if (rho_a == nullptr) MSG_FATAL("Uninitialized alpha density");
-        if (rho_b == nullptr) MSG_FATAL("Uninitialized beta density");
-        if (abs_prec) scale = rho_a->integrate() + rho_b->integrate();
-        rho_a->crop(prec / scale, 1.0, false);
-        rho_b->crop(prec / scale, 1.0, false);
-        mrcpp::refine_grid(*rho_a, *rho_b);
-        mrcpp::refine_grid(*rho_b, *rho_a);
-    } else {
-        if (rho_t == nullptr) MSG_FATAL("Uninitialized total density");
-        if (abs_prec) scale = rho_t->integrate();
-        rho_t->crop(prec / scale, 1.0, false);
+void XCFunctional::copyGrid(FunctionTreeVector<3> densities) {
+    mrcpp::FunctionTree<3> &rho0 = mrcpp::get_func(densities, 0);
+    for (int i = 1; i < densities.size(); i++) {
+        mrcpp::FunctionTree<3> &rho = mrcpp::get_func(densities, i);
+        mrcpp::build_grid(rho, rho0);
     }
 }
 
-/** @brief Add extra grid nodes based on precision
- *
- * @param[in] prec Requested precision
- * @param[in] abs_prec Use absolute or relative precision
- *
- * This will _add_ to the density grid extra nodes where the local error is found
- * to be unsatisfactory (it does _not_ guarantee that the new grid is sufficient).
- * The density must already have been computed for this to take effect.
- */
-void XCFunctional::refineGrid(double prec, bool abs_prec) {
-    if (not hasDensity()) return;
-
-    double scale = 1.0;
-    if (isSpinSeparated()) {
-        if (rho_a == nullptr) MSG_FATAL("Uninitialized alpha density");
-        if (rho_b == nullptr) MSG_FATAL("Uninitialized beta density");
-        if (abs_prec) scale = rho_a->integrate() + rho_b->integrate();
-        mrcpp::refine_grid(*rho_a, prec / scale);
-        mrcpp::refine_grid(*rho_b, prec / scale);
-
-        // Extend to union grid
-        int nNodes = 1;
-        while (nNodes > 0) {
-            int nAlpha = mrcpp::refine_grid(*rho_a, *rho_b);
-            int nBeta = mrcpp::refine_grid(*rho_b, *rho_a);
-            nNodes = nAlpha + nBeta;
-        }
-    } else {
-        if (rho_t == nullptr) MSG_FATAL("Uninitialized total density");
-        if (abs_prec) scale = rho_t->integrate();
-        mrcpp::refine_grid(*rho_t, prec / scale);
-    }
-}
-
-/** @brief Remove all grid refinement
+/** @brief Remove all grid refinement for all density vectors
  *
  * This will _remove_ all existing grid refinement and leave only root nodes
  * in the density grids.
  */
 void XCFunctional::clearGrid() {
-    if (rho_a != nullptr) rho_a->clear();
-    if (rho_b != nullptr) rho_b->clear();
-    if (rho_t != nullptr) rho_t->clear();
+    if (rho_a.size() > 0) clearGrid(rho_a);
+    if (rho_b.size() > 0) clearGrid(rho_b);
+    if (rho_t.size() > 0) clearGrid(rho_t);
 }
 
+/** @brief Remove all grid refinement for a given density vector
+ *
+ * This will _remove_ all existing grid refinement and leave only root nodes
+ * in the density grids.
+ */
+void XCFunctional::clearGrid(densities) {
+    for (int i = 0; i < densities.size(); i++) {
+        FunctionTree<3> &rho = mrcpp::get_func(densities, i);
+        rho_a.clear();
+    }
+}
+
+void XCFunctional::setup() {
+    switch (mode) {
+    case 1:
+        setup_partial();
+        break;
+    case 3:
+        setup_contracted();
+        break;
+    default:
+        MSG_FATAL("Not implemented: abort");
+    }
+}
+
+
+void XCFunctional::setup_contracted() {
+    MSG_FATAL("Not implemented: abort");
+}
 /** @brief Prepare for xcfun evaluation
  *
  * This computes the necessary input functions (gradients and gamma) and
@@ -290,35 +295,49 @@ void XCFunctional::clearGrid() {
  * Assumes that the density functions rho_t or rho_a/rho_b have already
  * been computed.
  */
-void XCFunctional::setup() {
+void XCFunctional::setup_partial() {
+    if (isSpinSeparated()) {
+        FunctionTreeVector &rho_gs_a = mrcpp::get_function(rho_a, 0);
+        FunctionTreeVector &rho_gs_b = mrcpp::get_function(rho_b, 0);
+        setup_partial(rho_gs_a, rho_gs_b);
+    } else {
+        FunctionTreeVector &rho_gs_t = mrcpp::get_function(rho_t, 0);
+        setup_partial(rho_gs_t);
+    }
+}
+
+void XCFunctional::setup_partial(FunctionTree<3> &rho_a, FunctionTree<3> &rho_b) {
     if (isGGA()) {
-        if (isSpinSeparated()) {
-            grad_a = mrcpp::gradient(*derivative, *rho_a);
-            grad_b = mrcpp::gradient(*derivative, *rho_b);
-        } else {
-            grad_t = mrcpp::gradient(*derivative, *rho_t);
-        }
+        grad_a = mrcpp::gradient(*derivative, rho_a);
+        grad_b = mrcpp::gradient(*derivative, rho_b);
     }
     if (useGamma()) {
-        if (isSpinSeparated()) {
-            FunctionTree<3> *gamma_aa = new FunctionTree<3>(MRA);
-            FunctionTree<3> *gamma_ab = new FunctionTree<3>(MRA);
-            FunctionTree<3> *gamma_bb = new FunctionTree<3>(MRA);
-            mrcpp::build_grid(*gamma_aa, *rho_a);
-            mrcpp::build_grid(*gamma_ab, *rho_a);
-            mrcpp::build_grid(*gamma_bb, *rho_a);
-            mrcpp::dot(-1.0, *gamma_aa, grad_a, grad_a);
-            mrcpp::dot(-1.0, *gamma_ab, grad_a, grad_b);
-            mrcpp::dot(-1.0, *gamma_bb, grad_b, grad_b);
-            gamma.push_back(std::make_tuple(1.0, gamma_aa));
-            gamma.push_back(std::make_tuple(1.0, gamma_ab));
-            gamma.push_back(std::make_tuple(1.0, gamma_bb));
-        } else {
-            FunctionTree<3> *gamma_tt = new FunctionTree<3>(MRA);
-            mrcpp::build_grid(*gamma_tt, *rho_t);
-            mrcpp::dot(-1.0, *gamma_tt, grad_t, grad_t);
-            gamma.push_back(std::make_tuple(1.0, gamma_tt));
-        }
+        FunctionTree<3> *gamma_aa = new FunctionTree<3>(MRA);
+        FunctionTree<3> *gamma_ab = new FunctionTree<3>(MRA);
+        FunctionTree<3> *gamma_bb = new FunctionTree<3>(MRA);
+        mrcpp::build_grid(*gamma_aa, rho_a);
+        mrcpp::build_grid(*gamma_ab, rho_a);
+        mrcpp::build_grid(*gamma_bb, rho_a);
+        mrcpp::dot(-1.0, *gamma_aa, grad_a, grad_a);
+        mrcpp::dot(-1.0, *gamma_ab, grad_a, grad_b);
+        mrcpp::dot(-1.0, *gamma_bb, grad_b, grad_b);
+        gamma.push_back(std::make_tuple(1.0, gamma_aa));
+        gamma.push_back(std::make_tuple(1.0, gamma_ab));
+        gamma.push_back(std::make_tuple(1.0, gamma_bb));
+    }
+    setupXCInput();
+    setupXCOutput();
+}
+
+void XCFunctional::setup_partial(FunctionTree<3> &rho_t) {
+    if (isGGA()) {
+        grad_t = mrcpp::gradient(*derivative, rho_t);
+    }
+    if (useGamma()) {
+        FunctionTree<3> *gamma_tt = new FunctionTree<3>(MRA);
+        mrcpp::build_grid(*gamma_tt, rho_t);
+        mrcpp::dot(-1.0, *gamma_tt, grad_t, grad_t);
+        gamma.push_back(std::make_tuple(1.0, gamma_tt));
     }
     setupXCInput();
     setupXCOutput();
@@ -372,12 +391,12 @@ int XCFunctional::setupXCInputDensity() {
     if (isSpinSeparated()) {
         if (rho_a == nullptr) MSG_FATAL("Invalid alpha density");
         if (rho_b == nullptr) MSG_FATAL("Invalid beta density");
-        xcInput.push_back(std::make_tuple(1.0, rho_a));
-        xcInput.push_back(std::make_tuple(1.0, rho_b));
+        xcInput.push_back(rho_a[0]);
+        xcInput.push_back(rho_b[0]);
         nUsed = 2;
     } else {
         if (rho_t == nullptr) MSG_FATAL("Invalid total density");
-        xcInput.push_back(std::make_tuple(1.0, rho_t));
+        xcInput.push_back(rho_t[0]);
         nUsed = 1;
     }
     return nUsed;
@@ -824,33 +843,6 @@ FunctionTree<3> *XCFunctional::calcGradientGGA(FunctionTree<3> &df_drho, Functio
     mrcpp::add(-1.0, *V, funcs);
     delete tmp;
     return V;
-}
-
-FunctionTree<3> *XCFunctional::doubleDivergence(FunctionTreeVector<3> &df2dg2) {
-    FunctionTreeVector<3> tmp;
-    tmp.push_back(df2dg2[0]); // xx
-    tmp.push_back(df2dg2[1]); // xy
-    tmp.push_back(df2dg2[2]); // xz
-    tmp.push_back(df2dg2[1]); // yx --> xy
-    tmp.push_back(df2dg2[3]); // yy
-    tmp.push_back(df2dg2[4]); // yz
-    tmp.push_back(df2dg2[2]); // zx --> xz
-    tmp.push_back(df2dg2[4]); // zy --> yz
-    tmp.push_back(df2dg2[5]); // zz
-    FunctionTreeVector<3> gradient;
-    for (int i = 0; i < 3; i++) {
-        FunctionTree<3> *component = new FunctionTree<3>(MRA);
-        FunctionTreeVector<3> grad_comp(tmp.begin() + 3 * i, tmp.begin() + 3 * (i + 1));
-        mrcpp::build_grid(*component, grad_comp);
-        mrcpp::divergence(*component, *derivative, grad_comp);
-        gradient.push_back(std::make_tuple(1.0, component));
-    }
-    FunctionTree<3> *output = new FunctionTree<3>(MRA);
-    mrcpp::build_grid(*output, gradient);
-    mrcpp::divergence(*output, *derivative, gradient);
-    mrcpp::clear(tmp, false);
-    mrcpp::clear(gradient, true);
-    return output;
 }
 
 /** @brief Helper function to compute divergence of a vector field times a function

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -40,6 +40,12 @@ using mrcpp::Timer;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 
+namespace {
+MatrixXi build_output_mask(bool is_lda, bool is_spin_sep, int order);
+VectorXi build_density_mask(bool is_lda, bool is_spin_sep, int order);
+void fill_output_mask(MatrixXi &mask, int start);
+}
+
 namespace mrdft {
 
 /** @brief Constructor
@@ -83,7 +89,7 @@ void XCFunctional::evalSetup(int ord, int mod) {
     if (mod != 1 and mod != 3) {
         MSG_FATAL("Only contracted or partial derivative modes are available")
     }
-    mode = mod;
+    mode = ModeType::Partial; //! HACK HACK HACK
     order = ord; //!< update the order parameter in the object
     unsigned int func_type = isGGA(); //!< only LDA and GGA supported for now
     unsigned int dens_type = 1 + isSpinSeparated();  //!< only n (dens_type = 1) or alpha & beta (denst_type = 2) supported now.
@@ -114,13 +120,13 @@ void XCFunctional::setFunctional(const std::string &name, double coef) {
  * function representations. For spin separated functionals both the alpha
  * and beta densities are tested, otherwise only the total density.
  */
-bool XCFunctional::hasDensity() const {
+bool XCFunctional::hasDensity(int n_dens) const {
     bool out = true;
     if (isSpinSeparated()) {
-        out = checkDensity(rho_a);
-        out = checkDensity(rho_b);
+        out = checkDensity(rho_a, nDens);
+        out = checkDensity(rho_b, nDens);
     } else {
-        out = checkDensity(rho_t);
+        out = checkDensity(rho_t, nDens);
     }
     return out;
 }
@@ -133,7 +139,7 @@ bool XCFunctional::hasDensity() const {
  */
 void XCFunctional::allocateDensities() {
     bool out = true;
-    for (int i = 0; i < nDensities; i ++) {
+    for (int i = 0; i < nDensities; i++) {
         if (isSpinSeparated()) {
             FunctionTree<3> *temp_a = new FunctionTree<3>(MRA);
             FunctionTree<3> *temp_b = new FunctionTree<3>(MRA);
@@ -144,6 +150,7 @@ void XCFunctional::allocateDensities() {
             rho_t.push_back(std::make_tuple(1.0, temp_t));
         }
     }
+    
 }
 
 /** @brief Check whether the density vector has all required components
@@ -157,11 +164,10 @@ void XCFunctional::allocateDensities() {
  * not be used in reality.
  *
  */
-bool XCFunctional::checkDensity(FunctionTreeVector<3> density) const {
+bool XCFunctional::checkDensity(FunctionTreeVector<3> density, int n_dens) const {
     bool out = true;
-    if (density.size() < nDensities) out = false; //Not all required densities are present and we should make them
-    std::cout << "HACK Check only GS density for now..." << std::endl;
-    for (int i = 0; i < nDensities; i++) {
+    if (density.size() < n_dens) out = false; //Not all required densities are present and we should make them
+    for (int i = 0; i < n_dens; i++) {
         FunctionTree<3> &dens = mrcpp::get_func(density, i);
         if (dens.getSquareNorm() < 0.0) out = false;
     }
@@ -322,9 +328,73 @@ void XCFunctional::setup() {
 }
 
 
-void XCFunctional::setup_contracted() {
-    MSG_FATAL("Not implemented: abort");
+void XCFunctional::setupContracted() {
+    if (not hasDensity(order)) {
+        MSG_ABORT("Not enough density functions initialized");
+    }
+    setupGradient(order);
+    setupGamma(order);
+    setupXCInputContracted();
+    setupXCOutputContracted();
 }
+
+void XCFunctional::setupGradient() {
+    if(isLDA()) return;
+    int n_grad;
+    for (int i = 0; i < nDensities; i++) {
+        if(isSpinSeparated()) {
+            FunctionTreeVector<3> temp_a = mrcpp::gradient(*derivative, getDensity(DensityType::Alpha, i));
+            FunctionTreeVector<3> temp_b = mrcpp::gradient(*derivative, getDensity(DensityType::Beta, i));
+            grad_a.insert(grad_a.end(), temp_a.begin(), temp_a.end());
+            grad_b.insert(grad_b.end(), temp_b.begin(), temp_b.end());
+        } else {
+            FunctionTreeVector<3> temp_t = mrcpp::gradient(*derivative, getDensity(DensityType::Total, i));
+            grad_t.insert(grad_t.end(), temp_t.begin(), temp_t.end());
+        }
+    }
+    
+}
+
+void XCFunuctional::setupGamma() {
+    if (isLDA() or not useGamma()) return;
+    for (int i = 0; i < 3*nDensities; i+=3) {
+        if(isSpinSeparated()) {
+            FunctionTreeVector<3> temp_a(grad_a.begin()+i, grad_a.begin()+i+3);
+            FunctionTreeVector<3> temp_b(grad_b.begin()+i, grad_b.begin()+i+3);
+            FunctionTreeVector<3> temp_g = buildGamma(temp_a, temp_b);
+            gamma.insert(gamma.end(), temp_g.begin(), temp_g.end());
+        } else {
+            FunctionTreeVector<3> temp_t(grad_t.begin()+i, grad_t.begin()+i+3);
+            gamma.push_back(std::make_tuple(1.0, buildGamma(temp_t)));
+        }
+    }
+    return;
+}
+
+FunctionTree<3>* XCFunctional::buildGamma(FunctionTreeVector<3> &grad) {
+    FunctionTree<3> *gamma = new FunctionTree<3>(MRA);
+    mrcpp::build_grid(*gamma, grad);
+    mrcpp::dot(-1.0, *gamma, grad, grad);
+    return gamma;
+}
+
+FunctionTreeVector<3> XCFunctional::buildGamma(FunctionTreeVector<3> &grad_a, FunctionTreeVector<3> &grad_b) {
+    FunctionTree<3> *gamma_aa = new FunctionTree<3>(MRA);
+    FunctionTree<3> *gamma_ab = new FunctionTree<3>(MRA);
+    FunctionTree<3> *gamma_bb = new FunctionTree<3>(MRA);
+    mrcpp::build_grid(*gamma_aa, grad_a);
+    mrcpp::build_grid(*gamma_ab, grad_a);
+    mrcpp::build_grid(*gamma_bb, grad_a);
+    mrcpp::dot(-1.0, *gamma_aa, grad_a, grad_a);
+    mrcpp::dot(-1.0, *gamma_ab, grad_a, grad_b);
+    mrcpp::dot(-1.0, *gamma_bb, grad_b, grad_b);
+    FunctionTreeVector<3> temp_gamma;
+    temp_gamma.push_back(std::make_tuple(1.0, gamma_aa));
+    temp_gamma.push_back(std::make_tuple(1.0, gamma_ab));
+    temp_gamma.push_back(std::make_tuple(1.0, gamma_bb));
+    return temp_gamma
+}
+
 /** @brief Prepare for xcfun evaluation
  *
  * This computes the necessary input functions (gradients and gamma) and
@@ -342,6 +412,8 @@ void XCFunctional::setup_partial() {
         FunctionTree<3> &rho_gs_t = mrcpp::get_func(rho_t, 0);
         setup_partial(rho_gs_t);
     }
+    setupXCInput();
+    setupXCOutput();
 }
 
 void XCFunctional::setup_partial(FunctionTree<3> &rho_a, FunctionTree<3> &rho_b) {
@@ -363,8 +435,6 @@ void XCFunctional::setup_partial(FunctionTree<3> &rho_a, FunctionTree<3> &rho_b)
         gamma.push_back(std::make_tuple(1.0, gamma_ab));
         gamma.push_back(std::make_tuple(1.0, gamma_bb));
     }
-    setupXCInput();
-    setupXCOutput();
 }
 
 void XCFunctional::setup_partial(FunctionTree<3> &rho_t) {
@@ -377,8 +447,6 @@ void XCFunctional::setup_partial(FunctionTree<3> &rho_t) {
         mrcpp::dot(-1.0, *gamma_tt, grad_t, grad_t);
         gamma.push_back(std::make_tuple(1.0, gamma_tt));
     }
-    setupXCInput();
-    setupXCOutput();
 }
 
 /** @brief Cleanup after xcfun evaluation
@@ -446,17 +514,20 @@ int XCFunctional::setupXCInputDensity() {
  */
 int XCFunctional::setupXCInputGradient() {
     int nUsed = 0;
+    int nFetch = 3;
     if (useGamma()) {
-        xcInput.insert(xcInput.end(), gamma.begin(), gamma.end());
-        nUsed += gamma.size();
+ //in all cases except closed shell with gamma we need three functions.
+        if (not isSpinSeparated()) nFetch = 1;
+        xcInput.insert(xcInput.end(), gamma.begin(), gamma.begin() + nFetch);
+        nUsed += nFetch;
     } else {
         if (isSpinSeparated()) {
-            xcInput.insert(xcInput.end(), grad_a.begin(), grad_a.end());
-            xcInput.insert(xcInput.end(), grad_b.begin(), grad_b.end());
-            nUsed += grad_a.size() + grad_b.size();
+            xcInput.insert(xcInput.end(), grad_a.begin(), grad_a.begin() + nFetch);
+            xcInput.insert(xcInput.end(), grad_b.begin(), grad_b.begin() + nFetch);
+            nUsed += 2 * nFetch;
         } else {
-            xcInput.insert(xcInput.end(), grad_t.begin(), grad_t.end());
-            nUsed += grad_t.size();
+            xcInput.insert(xcInput.end(), grad_t.begin(), grad_t.begin() + nFetch);
+            nUsed += nFetch;
         }
     }
     return nUsed;
@@ -475,7 +546,7 @@ void XCFunctional::setupXCOutput() {
     // Fetch density grid to copy
     FunctionTree<3> &grid = mrcpp::get_func(xcInput, 0);
 
-    int nOut = getOutputLength();
+    int nOut = getContractedLength();
     for (int i = 0; i < nOut; i++) {
         FunctionTree<3> *tmp = new FunctionTree<3>(MRA);
         mrcpp::copy_grid(*tmp, grid);
@@ -495,29 +566,65 @@ void XCFunctional::evaluate() {
     Timer timer;
     println(2, "Evaluating");
 
-    int nInp = getInputLength();
-    int nOut = getOutputLength();
+    int nInp = getInputLength();          // Input parameters to XCFun
+    int nOut = getOutputLength();         // Output parameters from XCFun
+    int nCon = getContractedLength();     // Contracted parameters to XCPotential 
+    int nPts = getNodeLength();           // Number of gridpoints in a node
+        
 
+    
+    
 #pragma omp parallel firstprivate(nInp, nOut)
     {
         int nNodes = mrcpp::get_func(xcInput, 0).getNEndNodes();
 #pragma omp for schedule(guided)
         for (int n = 0; n < nNodes; n++) {
-            MatrixXd inpData, outData;
+            MatrixXd inpData, outData, conData, denData;
+            inpData = MatrixXd::Zero(nPts, nInp);
+            outData = MatrixXd::Zero(nPts, nOut);
+            conData = MatrixXd::Zero(nPts, nCon);
             compressNodeData(n, nInp, xcInput, inpData);
             evaluateBlock(inpData, outData);
-            expandNodeData(n, nOut, xcOutput, outData);
+            contractNodeData(n, outData, conData);
+            expandNodeData(n, nCon, xcOutput, conData);
         }
     }
     for (int i = 0; i < nOut; i++) {
         mrcpp::get_func(xcOutput, i).mwTransform(mrcpp::BottomUp);
         mrcpp::get_func(xcOutput, i).calcSquareNorm();
     }
-
     timer.stop();
     Printer::printTree(0, "XC evaluate xcfun", mrcpp::sum_nodes(xcOutput), timer.getWallTime());
     printout(2, std::endl);
 }
+
+
+
+void XCFunctional::contractNodeData(int n, int n_coefs, MatrixXd &out_data, MatrixXd &con_data) {
+
+    MatrixXi output_mask = build_output_mask(isLDA(), isSpinSeparated(), order);
+    VectorXi density_mask = build_density_mask(isLDA(), isSpinSeparated(), order);
+    if(output_mask.rows() != density_mask.size()) MSG_FATAL("Inconsistent lengths");
+
+    VectorXd cont_i;
+    for (int i = 0; i < output_mask.cols()) {
+        cont_i = VectorXd::Zero(n_coefs);
+        for (int j = 0; i < output_mask.rows()) {
+            int out_index = output_mask(i,j);
+            int den_index = density_mask(j);
+            if(den_index >= 0) {
+                FunctionNode<3> &dens_node = mrcpp::get_func(xcDensity, density_index(i)).getEndFuncNode(n);
+                VectorXd dens_i;
+                dens_node.getValues(dens_i);
+                cont_i += out_data.col(out_index).array() * dens_i.array();
+            } else if (density_index(i) == -1) {
+                cont_i += out_data.col(output_index(i));
+            }
+        }
+        con_data.col(i) = cont_i;
+    }
+}
+
 
 /** \brief Evaluates XC functional and derivatives
  *
@@ -684,34 +791,13 @@ FunctionTreeVector<3> XCFunctional::calcPotential() {
  * deep copied into the corresponding potential functions.
  */
 void XCFunctional::calcPotentialLDA(FunctionTreeVector<3> &potentials) {
-    int nPotentials = 1;
-    int nStart = this->order; // PROBLEM: if I use a higher order than necessary this wil fail miserably!
-    if (isSpinSeparated()) {
-        nPotentials = this->order + 1;
-        nStart = this->order * (this->order + 1) / 2;
-    }
+    int nPotentials = isSpinSeparated()? 2 : 1
     for (int i = 0; i < nPotentials; i++) {
-        FunctionTree<3> &out_i = mrcpp::get_func(xcOutput, nStart + i);
+        FunctionTree<3> &out_i = mrcpp::get_func(xcOutput, i);
         FunctionTree<3> *pot = new FunctionTree<3>(MRA);
         mrcpp::copy_grid(*pot, out_i);
         mrcpp::copy_func(*pot, out_i);
         potentials.push_back(std::make_tuple(1.0, pot));
-    }
-}
-
-/** @brief Potential calculation for GGA functionals
- *
- */
-void XCFunctional::calcPotentialGGA(FunctionTreeVector<3> &potentials) {
-    switch (this->order) {
-        case 1:
-            calcGradientGGA(potentials);
-            break;
-        case 2:
-            calcHessianGGA(potentials);
-            break;
-        default:
-            NOT_IMPLEMENTED_ABORT;
     }
 }
 
@@ -721,84 +807,25 @@ void XCFunctional::calcPotentialGGA(FunctionTreeVector<3> &potentials) {
  * The method used depends on whether the functional is spin-separated
  * and whether explicit or gamma-type derivatives have been used in xcfun.
  */
-void XCFunctional::calcGradientGGA(FunctionTreeVector<3> &potentials) {
+void XCFunctional::calcPotentialGGA(FunctionTreeVector<3> &potentials) {
+    if (useGamma()) NOT_IMPLEMENTED_ABORT;
     FunctionTree<3> *pot;
     if (isSpinSeparated()) {
-        FunctionTree<3> &df_da = mrcpp::get_func(xcOutput, 1);
-        FunctionTree<3> &df_db = mrcpp::get_func(xcOutput, 2);
-        if (useGamma()) {
-            FunctionTree<3> &df_dgaa = mrcpp::get_func(xcOutput, 3);
-            FunctionTree<3> &df_dgab = mrcpp::get_func(xcOutput, 4);
-            FunctionTree<3> &df_dgbb = mrcpp::get_func(xcOutput, 5);
-            pot = calcGradientGGA(df_da, df_dgaa, df_dgab, grad_a, grad_b);
-            potentials.push_back(std::make_tuple(1.0, pot));
-            pot = calcGradientGGA(df_db, df_dgbb, df_dgab, grad_b, grad_a);
-            potentials.push_back(std::make_tuple(1.0, pot));
-        } else {
-            FunctionTreeVector<3> df_dga;
-            FunctionTreeVector<3> df_dgb;
-            df_dga.push_back(xcOutput[3]);
-            df_dga.push_back(xcOutput[4]);
-            df_dga.push_back(xcOutput[5]);
-            df_dgb.push_back(xcOutput[6]);
-            df_dgb.push_back(xcOutput[7]);
-            df_dgb.push_back(xcOutput[8]);
-            pot = calcGradientGGA(df_da, df_dga);
-            potentials.push_back(std::make_tuple(1.0, pot));
-            pot = calcGradientGGA(df_db, df_dgb);
-            potentials.push_back(std::make_tuple(1.0, pot));
-        }
+        FunctionTree<3> &df_da = mrcpp::get_func(xcOutput, 0);
+        FunctionTree<3> &df_db = mrcpp::get_func(xcOutput, 4);
+        FunctionTreeVector<3> df_dga(xcOutput.begin() + 1, xcOutput.begin() + 4);
+        FunctionTreeVector<3> df_dgb(xcOutput.begin() + 5, xcOutput.begin() + 8);
+        pot = calcPotentialGGA(df_da, df_dga);
+        potentials.push_back(std::make_tuple(1.0, pot));
+        pot = calcPotentialGGA(df_db, df_dgb);
+        potentials.push_back(std::make_tuple(1.0, pot));
     } else {
-        FunctionTree<3> &df_dt = mrcpp::get_func(xcOutput, 1);
-        if (useGamma()) {
-            FunctionTree<3> &df_dgamma = mrcpp::get_func(xcOutput, 2);
-            pot = calcGradientGGA(df_dt, df_dgamma, grad_t);
-            potentials.push_back(std::make_tuple(1.0, pot));
-        } else {
-            FunctionTreeVector<3> df_dgt;
-            df_dgt.push_back(xcOutput[2]);
-            df_dgt.push_back(xcOutput[3]);
-            df_dgt.push_back(xcOutput[4]);
-            pot = calcGradientGGA(df_dt, df_dgt);
-            potentials.push_back(std::make_tuple(1.0, pot));
-        }
+        FunctionTree<3> &df_dt = mrcpp::get_func(xcOutput, 0);
+        FunctionTreeVector<3> df_dgt(xcOutput.begin() + 1, xcOutput.begin() + 4);
+        pot = calcPotentialGGA(df_dt, df_dgt);
+        potentials.push_back(std::make_tuple(1.0, pot));
     }
     pot = nullptr;
-}
-
-void XCFunctional::calcHessianGGA(FunctionTreeVector<3> &potentials) {
-    if (isSpinSeparated()) NOT_IMPLEMENTED_ABORT;
-    if (useGamma()) {
-        calcHessianGGAgamma(potentials);
-    } else {
-        calcHessianGGAgrad(potentials);
-    }
-}
-
-void XCFunctional::calcHessianGGAgamma(FunctionTreeVector<3> &potentials) {
-    // 0 1    2    3      4       5
-    // f dfdr dfdg df2dr2 df2drdg df2dg2
-
-    for (int i = 2; i < 6; i++) {
-        FunctionTree<3> &out_i = mrcpp::get_func(xcOutput, i);
-        FunctionTree<3> *pot = new FunctionTree<3>(MRA);
-        mrcpp::copy_grid(*pot, out_i);
-        mrcpp::copy_func(*pot, out_i);
-        potentials.push_back(std::make_tuple(1.0, pot));
-    }
-}
-
-void XCFunctional::calcHessianGGAgrad(FunctionTreeVector<3> &potentials) {
-    // 0 1    2-4  5      6-8     9-14
-    // f dfdr dfdg df2dr2 df2drdg df2dg2
-
-    for (int i = 5; i < 15; i++) {
-        FunctionTree<3> &out_i = mrcpp::get_func(xcOutput, i);
-        FunctionTree<3> *pot = new FunctionTree<3>(MRA);
-        mrcpp::copy_grid(*pot, out_i);
-        mrcpp::copy_func(*pot, out_i);
-        potentials.push_back(std::make_tuple(1.0, pot));
-    }
 }
 
 /** @brief XC potential calculation
@@ -810,7 +837,7 @@ void XCFunctional::calcHessianGGAgrad(FunctionTreeVector<3> &potentials) {
  * Computes the XC potential for a non-spin separated functional and
  * gamma-type derivatives.
  */
-FunctionTree<3> *XCFunctional::calcGradientGGA(FunctionTree<3> &df_drho,
+FunctionTree<3> *XCFunctional::calcPotentialGGA(FunctionTree<3> &df_drho,
                                                FunctionTree<3> &df_dgamma,
                                                FunctionTreeVector<3> grad_rho) {
     FunctionTreeVector<3> funcs;
@@ -839,7 +866,7 @@ FunctionTree<3> *XCFunctional::calcGradientGGA(FunctionTree<3> &df_drho,
  * gamma-type derivatives. Can be used both for alpha and beta
  * potentials by permuting the spin parameter.
  */
-FunctionTree<3> *XCFunctional::calcGradientGGA(FunctionTree<3> &df_drhoa,
+FunctionTree<3> *XCFunctional::calcPotentialGGA(FunctionTree<3> &df_drhoa,
                                                FunctionTree<3> &df_dgaa,
                                                FunctionTree<3> &df_dgab,
                                                FunctionTreeVector<3> grad_rhoa,
@@ -868,7 +895,7 @@ FunctionTree<3> *XCFunctional::calcGradientGGA(FunctionTree<3> &df_drhoa,
  *
  * Computes the XC potential for explicit derivatives.
  */
-FunctionTree<3> *XCFunctional::calcGradientGGA(FunctionTree<3> &df_drho, FunctionTreeVector<3> &df_dgr) {
+FunctionTree<3> *XCFunctional::calcPotentialGGA(FunctionTree<3> &df_drho, FunctionTreeVector<3> &df_dgr) {
     FunctionTreeVector<3> funcs;
     funcs.push_back(std::make_tuple(1.0, &df_drho));
 
@@ -912,3 +939,105 @@ FunctionTree<3> *XCFunctional::calcGradDotPotDensVec(FunctionTree<3> &V, Functio
 }
 
 } // namespace mrdft
+
+int XCFunctional::getNodeLength() {
+    FunctionTree<3> &tree = mrcpp::get_func(xcInput, 0);
+    return tree.getTDim() * tree.getKp1_d();
+}
+
+int XCFunctional::getContractedLength() {
+    int length = -1;
+    if(isLDA()) length = 1; //only one function needed for LDA
+    if(isGGA()) length = 4; //four functions for LDA
+    if(isSpinSeparated()) length *= 2; //twice as many for spin-separated functionals;
+    return length;
+}
+
+int XCFunctional::getDensityLength() {
+    int length = -1;
+    if(this->order < 2) {
+        length = 0; // no contractions for order 0 or 1
+    } else if (order = 2) {
+        length = getContractedLength(); //same length as contracted fcns for order = 2
+    }
+    return length;
+}
+
+} //namespace mrdft
+
+MatrixXi build_output_mask(bool is_lda, bool is_spin_sep, int order) {
+    int size 1;
+    int start = 0;
+    MatrixXi mask(1,1) ;
+    switch (order) {
+    case 0:
+        break;
+    case 1:
+        start = 1;
+        if (is_lda and is_spin_sep) {
+            mask.resize(2,1);
+        } else if (is_gga and not is_spin_sep) {
+            mask.resize(4,1);
+        } else if (is_gga and is_spin_sep) {
+            mask.resize(8,1);
+        }
+        break;
+    case 2:
+        start = 2;
+        if (is_lda and is_spin_sep) {
+            start = 3;
+            mask.resize(2,2);
+        } else if (is_gga and not is_spin_sep) {
+            start = 5;
+            mask.resize(4,4);
+        } else if (is_gga and is_spin_sep) {
+            start = 9;
+            mask.resize(8,8);
+        }
+        break;
+    default:
+        MSG_FATAL("Not implemented");
+    }
+    fillMask(mask, start);
+    return mask;
+}
+
+VectorXi build_density_mask(bool is_lda, bool is_spin_sep, int order) {
+    int size 1;
+    int start = 0;
+    VectorXi mask(1) ;
+    switch (order) {
+    case 0:
+    case 1:
+        mask(0) = -1;
+        break;
+    case 2:
+        mask(0) = 1;
+        if (is_lda and is_spin_sep) {
+            mask.resize(2);
+            mask << 2, 3;
+        } else if (is_gga and not is_spin_sep) {
+            mask.resize(4);
+            mask << 4, 5, 6, 7;
+        } else if (is_gga and is_spin_sep) {
+            mask.resize(8);
+            mask << 8, 9, 10, 11, 12, 13, 14, 15;
+        }
+        break;
+    default:
+        MSG_FATAL("Not implemented");
+    }
+    return mask;
+}
+
+void XCFunctional::fill_output_mask(MatrixXi mask, int value) {
+    for (int i = 0, i < mask.rows(); i++) {
+        mask(i,i) = value;
+        value++;
+        for (int j = i+1, j < mask.cols(); j++) {
+            mask(i,j) = value;
+            mask(i,j) = value;
+            value++;
+        }
+    }
+    

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -98,16 +98,16 @@ VectorXi build_density_mask(bool is_lda, bool is_spin_sep, int order) {
         mask(0) = -1;
         break;
     case 2:
-        mask(0) = 1;
+        mask(0) = 0;
         if (is_lda and is_spin_sep) {
             mask.resize(2);
-            mask << 2, 3;
+            mask << 0, 1;
         } else if (is_gga and not is_spin_sep) {
             mask.resize(4);
-            mask << 4, 5, 6, 7;
+            mask << 0, 1, 2, 3;
         } else if (is_gga and is_spin_sep) {
             mask.resize(8);
-            mask << 8, 9, 10, 11, 12, 13, 14, 15;
+            mask << 0, 1, 2, 3, 4, 5, 6, 7;
         }
         break;
     default:
@@ -122,7 +122,7 @@ void fill_output_mask(MatrixXi &mask, int value) {
         value++;
         for (int j = i+1; j < mask.cols(); j++) {
             mask(i,j) = value;
-            mask(i,j) = value;
+            mask(j,i) = value;
             value++;
         }
     }   
@@ -260,7 +260,7 @@ bool XCFunctional::checkDensity(FunctionTreeVector<3> density, int n_dens) const
  * Returns a reference to the internal vector of density functions so that it can be
  * computed by the host program. This needs to be done before setup().
  */
-FunctionTreeVector<3> & XCFunctional::getDensityVector(DENSITY::DensityType type) {
+FunctionTreeVector<3> &XCFunctional::getDensityVector(DENSITY::DensityType type) {
     switch (type) {
         case DENSITY::DensityType::Total:
             return rho_t;
@@ -288,7 +288,7 @@ FunctionTree<3> &XCFunctional::getDensity(DENSITY::DensityType type, int index) 
 }
 
 void XCFunctional::setDensity(FunctionTree<3> &density, DENSITY::DensityType spin, int index) {
-    FunctionTreeVector<3> dens_vec = getDensityVector(spin);
+    FunctionTreeVector<3> &dens_vec = getDensityVector(spin);
     if (dens_vec.size() != index) {
         MSG_FATAL("Index mismatch");
     }
@@ -515,10 +515,7 @@ int XCFunctional::setupXCInputGradient() {
     int nUsed = 0;
     int nFetch = 3;
     if (useGamma()) {
- //in all cases except closed shell with gamma we need three functions.
-        if (not isSpinSeparated()) nFetch = 1;
-        xcInput.insert(xcInput.end(), gamma.begin(), gamma.begin() + nFetch);
-        nUsed += nFetch;
+        NOT_IMPLEMENTED_ABORT;
     } else {
         if (isSpinSeparated()) {
             xcInput.insert(xcInput.end(), grad_a.begin(), grad_a.begin() + nFetch);
@@ -611,7 +608,8 @@ void XCFunctional::contractNodeData(int node_index, int n_points, MatrixXd &out_
             int out_index = output_mask(i,j);
             int den_index = density_mask(j);
             if(den_index >= 0) {
-                FunctionNode<3> &dens_node = mrcpp::get_func(xcDensity, density_mask(i)).getEndFuncNode(node_index);
+                FunctionTree<3> &dens_func = mrcpp::get_func(xcDensity, den_index);
+                FunctionNode<3> &dens_node = dens_func.getEndFuncNode(node_index);
                 VectorXd dens_i;
                 dens_node.getValues(dens_i);
                 cont_ij = out_data.col(out_index).array() * dens_i.array();

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -51,23 +51,26 @@ void fill_output_mask(MatrixXi &mask, int start);
 
 
 MatrixXi build_output_mask(bool is_lda, bool is_spin_sep, int order) {
+    int start = 2;
     bool is_gga = not is_lda;
     MatrixXi mask(1,1) ;
-    int start = 1;
+    mask << 1;
     switch (order) {
     case 0:
         break;
     case 1:
         if (is_lda and is_spin_sep) {
             mask.resize(2,1);
+            mask << 1, 2;
         } else if (is_gga and not is_spin_sep) {
             mask.resize(4,1);
+            mask << 1, 2, 3, 4;
         } else if (is_gga and is_spin_sep) {
             mask.resize(8,1);
+            mask << 1, 2, 3, 4, 5, 6, 7, 8;
         }
         break;
     case 2:
-        start = 2;
         if (is_lda and is_spin_sep) {
             start = 3;
             mask.resize(2,2);
@@ -78,11 +81,11 @@ MatrixXi build_output_mask(bool is_lda, bool is_spin_sep, int order) {
             start = 9;
             mask.resize(8,8);
         }
+        fill_output_mask(mask, start);
         break;
     default:
         MSG_FATAL("Not implemented");
     }
-    fill_output_mask(mask, start);
     return mask;
 }
 
@@ -566,10 +569,7 @@ void XCFunctional::evaluate() {
     int nOut = getOutputLength();         // Output parameters from XCFun
     int nCon = getContractedLength();     // Contracted parameters to XCPotential 
     int nPts = getNodeLength();           // Number of gridpoints in a node
-        
-
-    
-    
+  
 #pragma omp parallel firstprivate(nInp, nOut)
     {
         int nNodes = mrcpp::get_func(xcInput, 0).getNEndNodes();
@@ -585,7 +585,7 @@ void XCFunctional::evaluate() {
             expandNodeData(n_idx, nCon, xcOutput, conData);
         }
     }
-    for (int i = 0; i < nOut; i++) {
+    for (int i = 0; i < nCon; i++) {
         mrcpp::get_func(xcOutput, i).mwTransform(mrcpp::BottomUp);
         mrcpp::get_func(xcOutput, i).calcSquareNorm();
     }
@@ -600,14 +600,14 @@ void XCFunctional::contractNodeData(int node_index, int n_points, MatrixXd &out_
 
     MatrixXi output_mask = build_output_mask(isLDA(), isSpinSeparated(), order);
     VectorXi density_mask = build_density_mask(isLDA(), isSpinSeparated(), order);
-    if(output_mask.rows() != density_mask.size()) MSG_FATAL("Inconsistent lengths");
+    if(output_mask.cols() != density_mask.size()) MSG_FATAL("Inconsistent lengths");
 
     VectorXd cont_i;
     VectorXd cont_ij;
-    for (int i = 0; i < output_mask.cols(); i++) {
+    for (int i = 0; i < output_mask.rows(); i++) {
         cont_i = VectorXd::Zero(n_points);
-        for (int j = 0; j < output_mask.rows(); j++) {
-            cont_i = VectorXd::Zero(n_points);
+        for (int j = 0; j < output_mask.cols(); j++) {
+            cont_ij = VectorXd::Zero(n_points);
             int out_index = output_mask(i,j);
             int den_index = density_mask(j);
             if(den_index >= 0) {
@@ -615,7 +615,7 @@ void XCFunctional::contractNodeData(int node_index, int n_points, MatrixXd &out_
                 VectorXd dens_i;
                 dens_node.getValues(dens_i);
                 cont_ij = out_data.col(out_index).array() * dens_i.array();
-            } else if (density_mask(i) == -1) {
+            } else {
                 cont_ij = out_data.col(out_index);
             }
             cont_i += cont_ij;

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -125,7 +125,7 @@ void fill_output_mask(MatrixXi &mask, int value) {
             mask(j,i) = value;
             value++;
         }
-    }   
+    }
 }
 }
 
@@ -474,7 +474,7 @@ void XCFunctional::setupXCDensityVariables() {
         }
         if (isGGA()) {
             if (isSpinSeparated()) {
-                xcDensity.insert(xcDensity.begin() + 1, grad_a.begin() + 3, grad_a.begin() + 6);
+                xcDensity.insert(xcDensity.begin() + 2, grad_a.begin() + 3, grad_a.begin() + 6);
                 xcDensity.insert(xcDensity.begin() + 5, grad_b.begin() + 3, grad_b.begin() + 6);
             } else {
                 xcDensity.insert(xcDensity.begin() + 1, grad_t.begin() + 3, grad_t.begin() + 6);
@@ -583,8 +583,15 @@ void XCFunctional::evaluate() {
         }
     }
     for (int i = 0; i < nFcs; i++) {
-        mrcpp::get_func(xcOutput, i).mwTransform(mrcpp::BottomUp);
-        mrcpp::get_func(xcOutput, i).calcSquareNorm();
+        FunctionTree<3> &func = mrcpp::get_func(xcOutput, i);
+        func.mwTransform(mrcpp::BottomUp);
+        func.calcSquareNorm();
+        std::cout << "Potential norm " << i << " " << func.getSquareNorm() << std::endl;
+    }
+
+    for (int i = 0; i < xcDensity.size(); i++) {
+        FunctionTree<3> &func = mrcpp::get_func(xcDensity, i);
+        std::cout << "Density norm " << i << " " << func.getSquareNorm() << std::endl;
     }
     timer.stop();
     Printer::printTree(0, "XC evaluate xcfun", mrcpp::sum_nodes(xcOutput), timer.getWallTime());

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -29,12 +29,14 @@
 #include "MRCPP/Printer"
 #include "MRCPP/Timer"
 #include "MRCPP/trees/FunctionNode.h"
+#include "MRCPP/utils/Plotter.h"
 
 #include "XCFunctional.h"
 
 using mrcpp::DerivativeOperator;
 using mrcpp::FunctionNode;
 using mrcpp::FunctionTree;
+using mrcpp::Plotter;
 using mrcpp::FunctionTreeVector;
 using mrcpp::Printer;
 using mrcpp::Timer;
@@ -43,6 +45,8 @@ using Eigen::MatrixXi;
 using Eigen::VectorXi;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
+
+static int xc_iteration = 0;
 
 namespace {
 MatrixXi build_output_mask(bool is_lda, bool is_spin_sep, int order);
@@ -283,7 +287,7 @@ FunctionTreeVector<3> &XCFunctional::getDensityVector(DENSITY::DensityType type)
  */
 FunctionTree<3> &XCFunctional::getDensity(DENSITY::DensityType type, int index) {
     FunctionTreeVector<3> dens_vec = getDensityVector(type);
-    if(index >= dens_vec.size()) MSG_FATAL("Vector out of boounds");
+    if(index >= dens_vec.size()) MSG_FATAL("Vector out of bounds");
     return mrcpp::get_func(dens_vec, index);
 }
 
@@ -302,6 +306,8 @@ int XCFunctional::getNNodes() const {
         const FunctionTree<3> &rho_gs_a = mrcpp::get_func(rho_a, 0);
         const FunctionTree<3> &rho_gs_b = mrcpp::get_func(rho_b, 0);
         nodes = rho_gs_a.getNNodes();
+        std::cout << "nnodes " << rho_gs_a.getNNodes()    << std::endl;
+        std::cout << "nnodes " << rho_gs_b.getNNodes()    << std::endl;        
         if (nodes != rho_gs_b.getNNodes()) MSG_ERROR("Alpha and beta grids not equal");
     } else {
         const FunctionTree<3> &rho_gs_t = mrcpp::get_func(rho_t, 0);
@@ -319,6 +325,8 @@ int XCFunctional::getNPoints() const {
         const FunctionTree<3> &rho_gs_b = mrcpp::get_func(rho_b, 0);
         nodes = rho_gs_a.getNEndNodes();
         points = rho_gs_a.getTDim()*rho_gs_a.getKp1_d();
+        std::cout << "enodes  " << rho_gs_a.getNEndNodes() << std::endl;
+        std::cout << "enodes  " << rho_gs_b.getNEndNodes() << std::endl;
         if (nodes != rho_gs_b.getNEndNodes()) MSG_ERROR("Alpha and beta grids not equal");
     } else {
         const FunctionTree<3> &rho_gs_t = mrcpp::get_func(rho_t, 0);
@@ -481,8 +489,30 @@ void XCFunctional::setupXCDensityVariables() {
             }
         }
     }
+    
+    plot_densities();
 
     if (n_dens != xcDensity.size()) MSG_FATAL("Mismatch between used vs requested " << n_dens << " : " << xcDensity.size());
+
+}
+
+void XCFunctional::plot_densities() {
+    
+    int nPts = 1000;                                // Number of points
+    double a[3] = { 0.0, 0.0, -2.0};                // Start point of plot
+    double b[3] = { 0.0, 0.0,  2.0};                // End point of plot
+    mrcpp::Plotter<3> plot;                         // Plotter of 3D functions
+    plot.setNPoints(nPts);                          // Set number of points
+    plot.setRange(a, b);                            // Set plot range
+
+    for (int i = 0; i < xcDensity.size(); i++) {
+        mrcpp::FunctionTree<3> &func = mrcpp::get_func(xcDensity, i);
+        std::string name="Dens_" + std::to_string(i) + "_iter_" + std::to_string(xc_iteration);
+        plot.linePlot(func, name);
+    }
+    
+    xc_iteration++;
+
 }
 
 /** @brief Sets xcInput pointers for the density
@@ -612,6 +642,9 @@ void XCFunctional::contractNodeData(int node_index, int n_points, MatrixXd &out_
             cont_ij = VectorXd::Zero(n_points);
             int out_index = output_mask(i,j);
             int den_index = density_mask(j);
+            //            if(den_index >= 2) {
+            //                continue;
+            //            } else if(den_index >= 0) {
             if(den_index >= 0) {
                 FunctionTree<3> &dens_func = mrcpp::get_func(xcDensity, den_index);
                 FunctionNode<3> &dens_node = dens_func.getEndFuncNode(node_index);

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -48,6 +48,82 @@ namespace {
 MatrixXi build_output_mask(bool is_lda, bool is_spin_sep, int order);
 VectorXi build_density_mask(bool is_lda, bool is_spin_sep, int order);
 void fill_output_mask(MatrixXi &mask, int start);
+
+
+MatrixXi build_output_mask(bool is_lda, bool is_spin_sep, int order) {
+    bool is_gga = not is_lda;
+    MatrixXi mask(1,1) ;
+    int start = 1;
+    switch (order) {
+    case 0:
+        break;
+    case 1:
+        if (is_lda and is_spin_sep) {
+            mask.resize(2,1);
+        } else if (is_gga and not is_spin_sep) {
+            mask.resize(4,1);
+        } else if (is_gga and is_spin_sep) {
+            mask.resize(8,1);
+        }
+        break;
+    case 2:
+        start = 2;
+        if (is_lda and is_spin_sep) {
+            start = 3;
+            mask.resize(2,2);
+        } else if (is_gga and not is_spin_sep) {
+            start = 5;
+            mask.resize(4,4);
+        } else if (is_gga and is_spin_sep) {
+            start = 9;
+            mask.resize(8,8);
+        }
+        break;
+    default:
+        MSG_FATAL("Not implemented");
+    }
+    fill_output_mask(mask, start);
+    return mask;
+}
+
+VectorXi build_density_mask(bool is_lda, bool is_spin_sep, int order) {
+    bool is_gga = not is_lda;
+    VectorXi mask(1) ;
+    switch (order) {
+    case 0:
+    case 1:
+        mask(0) = -1;
+        break;
+    case 2:
+        mask(0) = 1;
+        if (is_lda and is_spin_sep) {
+            mask.resize(2);
+            mask << 2, 3;
+        } else if (is_gga and not is_spin_sep) {
+            mask.resize(4);
+            mask << 4, 5, 6, 7;
+        } else if (is_gga and is_spin_sep) {
+            mask.resize(8);
+            mask << 8, 9, 10, 11, 12, 13, 14, 15;
+        }
+        break;
+    default:
+        MSG_FATAL("Not implemented");
+    }
+    return mask;
+}
+
+void fill_output_mask(MatrixXi &mask, int value) {
+    for (int i = 0; i < mask.rows(); i++) {
+        mask(i,i) = value;
+        value++;
+        for (int j = i+1; j < mask.cols(); j++) {
+            mask(i,j) = value;
+            mask(i,j) = value;
+            value++;
+        }
+    }   
+}
 }
 
 namespace mrdft {
@@ -139,7 +215,6 @@ bool XCFunctional::hasDensity(int n_dens) const {
  * ae then stored in the corresponding FunctionTreeVector
  */
 void XCFunctional::allocateDensities() {
-    bool out = true;
     for (int i = 0; i < nDensities; i++) {
         if (isSpinSeparated()) {
             FunctionTree<3> *temp_a = new FunctionTree<3>(MRA);
@@ -327,7 +402,6 @@ void XCFunctional::setup() {
 
 void XCFunctional::setupGradient() {
     if(isLDA()) return;
-    int n_grad;
     for (int i = 0; i < nDensities; i++) {
         if(isSpinSeparated()) {
             FunctionTreeVector<3> temp_a = mrcpp::gradient(*derivative, getDensity(DENSITY::DensityType::Alpha, i));
@@ -529,19 +603,22 @@ void XCFunctional::contractNodeData(int node_index, int n_points, MatrixXd &out_
     if(output_mask.rows() != density_mask.size()) MSG_FATAL("Inconsistent lengths");
 
     VectorXd cont_i;
+    VectorXd cont_ij;
     for (int i = 0; i < output_mask.cols(); i++) {
         cont_i = VectorXd::Zero(n_points);
         for (int j = 0; j < output_mask.rows(); j++) {
+            cont_i = VectorXd::Zero(n_points);
             int out_index = output_mask(i,j);
             int den_index = density_mask(j);
             if(den_index >= 0) {
                 FunctionNode<3> &dens_node = mrcpp::get_func(xcDensity, density_mask(i)).getEndFuncNode(node_index);
                 VectorXd dens_i;
                 dens_node.getValues(dens_i);
-                cont_i += out_data.col(out_index).array() * dens_i.array();
-            } else if (density_index(i) == -1) {
-                cont_i += out_data.col(output_index(i));
+                cont_ij = out_data.col(out_index).array() * dens_i.array();
+            } else if (density_mask(i) == -1) {
+                cont_ij = out_data.col(out_index);
             }
+            cont_i += cont_ij;
         }
         con_data.col(i) = cont_i;
     }
@@ -713,7 +790,7 @@ FunctionTreeVector<3> XCFunctional::calcPotential() {
  * deep copied into the corresponding potential functions.
  */
 void XCFunctional::calcPotentialLDA(FunctionTreeVector<3> &potentials) {
-    int nPotentials = isSpinSeparated()? 2 : 1
+    int nPotentials = isSpinSeparated()? 2 : 1;
     for (int i = 0; i < nPotentials; i++) {
         FunctionTree<3> &out_i = mrcpp::get_func(xcOutput, i);
         FunctionTree<3> *pot = new FunctionTree<3>(MRA);
@@ -748,66 +825,6 @@ void XCFunctional::calcPotentialGGA(FunctionTreeVector<3> &potentials) {
         potentials.push_back(std::make_tuple(1.0, pot));
     }
     pot = nullptr;
-}
-
-/** @brief XC potential calculation
- *
- * @param[in] df_drho Functional derivative wrt rho
- * @param[in] df_dgamma Functional_derivative wrt gamma
- * @param[in] grad_rho Gradient of rho
- *
- * Computes the XC potential for a non-spin separated functional and
- * gamma-type derivatives.
- */
-FunctionTree<3> *XCFunctional::calcPotentialGGA(FunctionTree<3> &df_drho,
-                                               FunctionTree<3> &df_dgamma,
-                                               FunctionTreeVector<3> grad_rho) {
-    FunctionTreeVector<3> funcs;
-    funcs.push_back(std::make_tuple(1.0, &df_drho));
-
-    FunctionTree<3> *tmp = calcGradDotPotDensVec(df_dgamma, grad_rho);
-    funcs.push_back(std::make_tuple(-2.0, tmp));
-
-    FunctionTree<3> *V = new FunctionTree<3>(MRA);
-    mrcpp::build_grid(*V, funcs);
-    mrcpp::add(-1.0, *V, funcs);
-    delete tmp;
-    return V;
-}
-
-/** @brief XC potential calculation
- *
- * @param[in] df_drhoa Functional derivative wrt rhoa
- * @param[in] df_dgaa  Functional_derivative wrt gamma_aa
- * @param[in] df_dgab  Functional_derivative wrt gamma_ab
- * @param[in] df_dgbb  Functional_derivative wrt gamma_bb
- * @param[in] grad_rhoa Gradient of rho_a
- * @param[in] grad_rhob Gradient of rho_b
- *
- * Computes the XC potential for a spin separated functional and
- * gamma-type derivatives. Can be used both for alpha and beta
- * potentials by permuting the spin parameter.
- */
-FunctionTree<3> *XCFunctional::calcPotentialGGA(FunctionTree<3> &df_drhoa,
-                                               FunctionTree<3> &df_dgaa,
-                                               FunctionTree<3> &df_dgab,
-                                               FunctionTreeVector<3> grad_rhoa,
-                                               FunctionTreeVector<3> grad_rhob) {
-    FunctionTreeVector<3> funcs;
-    funcs.push_back(std::make_tuple(1.0, &df_drhoa));
-
-    FunctionTree<3> *tmp1 = calcGradDotPotDensVec(df_dgaa, grad_rhoa);
-    funcs.push_back(std::make_tuple(-2.0, tmp1));
-
-    FunctionTree<3> *tmp2 = calcGradDotPotDensVec(df_dgab, grad_rhob);
-    funcs.push_back(std::make_tuple(-1.0, tmp2));
-
-    FunctionTree<3> *V = new FunctionTree<3>(MRA);
-    mrcpp::build_grid(*V, funcs);
-    mrcpp::add(-1.0, *V, funcs);
-    delete tmp1;
-    delete tmp2;
-    return V;
 }
 
 /** @brief XC potential calculation
@@ -860,14 +877,12 @@ FunctionTree<3> *XCFunctional::calcGradDotPotDensVec(FunctionTree<3> &V, Functio
     return result;
 }
 
-} // namespace mrdft
-
 int XCFunctional::getNodeLength() {
     FunctionTree<3> &tree = mrcpp::get_func(xcInput, 0);
     return tree.getTDim() * tree.getKp1_d();
 }
 
-int XCFunctional::getContractedLength() {
+int XCFunctional::getContractedLength() const {
     int length = -1;
     if(isLDA()) length = 1; //only one function needed for LDA
     if(isGGA()) length = 4; //four functions for LDA
@@ -875,91 +890,16 @@ int XCFunctional::getContractedLength() {
     return length;
 }
 
-int XCFunctional::getDensityLength() {
+int XCFunctional::getDensityLength() const {
     int length = -1;
     if(this->order < 2) {
         length = 0; // no contractions for order 0 or 1
-    } else if (order = 2) {
+    } else if (order == 2) {
         length = getContractedLength(); //same length as contracted fcns for order = 2
     }
     return length;
 }
 
-} //namespace mrdft
+} // namespace mrdft
 
-MatrixXi build_output_mask(bool is_lda, bool is_spin_sep, int order) {
-    int size 1;
-    int start = 0;
-    MatrixXi mask(1,1) ;
-    switch (order) {
-    case 0:
-        break;
-    case 1:
-        start = 1;
-        if (is_lda and is_spin_sep) {
-            mask.resize(2,1);
-        } else if (is_gga and not is_spin_sep) {
-            mask.resize(4,1);
-        } else if (is_gga and is_spin_sep) {
-            mask.resize(8,1);
-        }
-        break;
-    case 2:
-        start = 2;
-        if (is_lda and is_spin_sep) {
-            start = 3;
-            mask.resize(2,2);
-        } else if (is_gga and not is_spin_sep) {
-            start = 5;
-            mask.resize(4,4);
-        } else if (is_gga and is_spin_sep) {
-            start = 9;
-            mask.resize(8,8);
-        }
-        break;
-    default:
-        MSG_FATAL("Not implemented");
-    }
-    fillMask(mask, start);
-    return mask;
-}
 
-VectorXi build_density_mask(bool is_lda, bool is_spin_sep, int order) {
-    int size 1;
-    int start = 0;
-    VectorXi mask(1) ;
-    switch (order) {
-    case 0:
-    case 1:
-        mask(0) = -1;
-        break;
-    case 2:
-        mask(0) = 1;
-        if (is_lda and is_spin_sep) {
-            mask.resize(2);
-            mask << 2, 3;
-        } else if (is_gga and not is_spin_sep) {
-            mask.resize(4);
-            mask << 4, 5, 6, 7;
-        } else if (is_gga and is_spin_sep) {
-            mask.resize(8);
-            mask << 8, 9, 10, 11, 12, 13, 14, 15;
-        }
-        break;
-    default:
-        MSG_FATAL("Not implemented");
-    }
-    return mask;
-}
-
-void fill_output_mask(MatrixXi &mask, int value) {
-    for (int i = 0, i < mask.rows(); i++) {
-        mask(i,i) = value;
-        value++;
-        for (int j = i+1, j < mask.cols(); j++) {
-            mask(i,j) = value;
-            mask(i,j) = value;
-            value++;
-        }
-    }   
-}

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -39,6 +39,8 @@ using mrcpp::FunctionTreeVector;
 using mrcpp::Printer;
 using mrcpp::Timer;
 
+using Eigen::MatrixXi;
+using Eigen::VectorXi;
 using Eigen::MatrixXd;
 using Eigen::VectorXd;
 
@@ -87,11 +89,8 @@ XCFunctional::~XCFunctional() {
  *
  * Prepare the XCFun object for evaluation based on the chosen parameters.
  */
-void XCFunctional::evalSetup(int ord, int mod) {
-    if (mod != 1 and mod != 3) {
-        MSG_FATAL("Only contracted or partial derivative modes are available")
-    }
-    mode = ModeType::Partial; //! HACK HACK HACK
+void XCFunctional::evalSetup(int ord) {
+    unsigned int mode = 1; //!< only partial derivative mode implemented
     order = ord; //!< update the order parameter in the object
     unsigned int func_type = isGGA(); //!< only LDA and GGA supported for now
     unsigned int dens_type = 1 + isSpinSeparated();  //!< only n (dens_type = 1) or alpha & beta (denst_type = 2) supported now.
@@ -183,13 +182,13 @@ bool XCFunctional::checkDensity(FunctionTreeVector<3> density, int n_dens) const
  * Returns a reference to the internal vector of density functions so that it can be
  * computed by the host program. This needs to be done before setup().
  */
-FunctionTreeVector<3> & XCFunctional::getDensityVector(DensityType type) {
+FunctionTreeVector<3> & XCFunctional::getDensityVector(DENSITY::DensityType type) {
     switch (type) {
-        case DensityType::Total:
+        case DENSITY::DensityType::Total:
             return rho_t;
-        case DensityType::Alpha:
+        case DENSITY::DensityType::Alpha:
             return rho_a;
-        case DensityType::Beta:
+        case DENSITY::DensityType::Beta:
             return rho_b;
         default:
             MSG_FATAL("Invalid density type");
@@ -204,25 +203,18 @@ FunctionTreeVector<3> & XCFunctional::getDensityVector(DensityType type) {
  * Returns a reference to the internal vector of density functions so that it can be
  * computed by the host program. This needs to be done before setup().
  */
-FunctionTree<3> &XCFunctional::getDensity(DensityType type, int index) {
+FunctionTree<3> &XCFunctional::getDensity(DENSITY::DensityType type, int index) {
     FunctionTreeVector<3> dens_vec = getDensityVector(type);
-    return getDensity(dens_vec, index);
+    if(index >= dens_vec.size()) MSG_FATAL("Vector out of boounds");
+    return mrcpp::get_func(dens_vec, index);
 }
 
-FunctionTree<3> &XCFunctional::getDensity(FunctionTreeVector<3> &density, int index) {
-    try { density.at(index); } 
-    catch (const std::out_of_range& oor) {
-        MSG_FATAL("Out of Range error: " << oor.what());
-    }
-    return mrcpp::get_func(density, index);
-}
-
-void XCFunctional::setDensity(FunctionTree<3> *density, DensityType spin, int index) {
+void XCFunctional::setDensity(FunctionTree<3> &density, DENSITY::DensityType spin, int index) {
     FunctionTreeVector<3> dens_vec = getDensityVector(spin);
     if (dens_vec.size() != index) {
         MSG_FATAL("Index mismatch");
     }
-    dens_vec.push_back(std::make_tuple(1.0, density));
+    dens_vec.push_back(std::make_tuple(1.0, &density));
 }
 
 /** @brief Return the number of nodes in the density grid (including branch nodes)*/
@@ -325,12 +317,12 @@ void XCFunctional::clearGrid(FunctionTreeVector<3> densities) {
 
 void XCFunctional::setup() {
     if (not hasDensity(order)) {
-        MSG_ABORT("Not enough density functions initialized");
+        MSG_FATAL("Not enough density functions initialized");
     }
-    setupGradient(order);
+    setupGradient();
     setupXCInput();
     setupXCOutput();
-    setupXCDensityVariable();
+    setupXCDensityVariables();
 }
 
 void XCFunctional::setupGradient() {
@@ -338,12 +330,12 @@ void XCFunctional::setupGradient() {
     int n_grad;
     for (int i = 0; i < nDensities; i++) {
         if(isSpinSeparated()) {
-            FunctionTreeVector<3> temp_a = mrcpp::gradient(*derivative, getDensity(DensityType::Alpha, i));
-            FunctionTreeVector<3> temp_b = mrcpp::gradient(*derivative, getDensity(DensityType::Beta, i));
+            FunctionTreeVector<3> temp_a = mrcpp::gradient(*derivative, getDensity(DENSITY::DensityType::Alpha, i));
+            FunctionTreeVector<3> temp_b = mrcpp::gradient(*derivative, getDensity(DENSITY::DensityType::Beta, i));
             grad_a.insert(grad_a.end(), temp_a.begin(), temp_a.end());
             grad_b.insert(grad_b.end(), temp_b.begin(), temp_b.end());
         } else {
-            FunctionTreeVector<3> temp_t = mrcpp::gradient(*derivative, getDensity(DensityType::Total, i));
+            FunctionTreeVector<3> temp_t = mrcpp::gradient(*derivative, getDensity(DENSITY::DensityType::Total, i));
             grad_t.insert(grad_t.end(), temp_t.begin(), temp_t.end());
         }
     }
@@ -359,7 +351,7 @@ void XCFunctional::setupGradient() {
  */
 void XCFunctional::clear() {
     mrcpp::clear(xcInput, false);
-    mrcpp::clear(xcDensityVariables, false);
+    mrcpp::clear(xcDensity, false);
     mrcpp::clear(xcOutput, true);
     mrcpp::clear(grad_a, true);
     mrcpp::clear(grad_b, true);
@@ -508,15 +500,15 @@ void XCFunctional::evaluate() {
     {
         int nNodes = mrcpp::get_func(xcInput, 0).getNEndNodes();
 #pragma omp for schedule(guided)
-        for (int n = 0; n < nNodes; n++) {
+        for (int n_idx = 0; n_idx < nNodes; n_idx++) {
             MatrixXd inpData, outData, conData, denData;
             inpData = MatrixXd::Zero(nPts, nInp);
             outData = MatrixXd::Zero(nPts, nOut);
             conData = MatrixXd::Zero(nPts, nCon);
-            compressNodeData(n, nInp, xcInput, inpData);
+            compressNodeData(n_idx, nInp, xcInput, inpData);
             evaluateBlock(inpData, outData);
-            contractNodeData(n, outData, conData);
-            expandNodeData(n, nCon, xcOutput, conData);
+            contractNodeData(n_idx, nPts, outData, conData);
+            expandNodeData(n_idx, nCon, xcOutput, conData);
         }
     }
     for (int i = 0; i < nOut; i++) {
@@ -530,20 +522,20 @@ void XCFunctional::evaluate() {
 
 
 
-void XCFunctional::contractNodeData(int n, int n_coefs, MatrixXd &out_data, MatrixXd &con_data) {
+void XCFunctional::contractNodeData(int node_index, int n_points, MatrixXd &out_data, MatrixXd &con_data) {
 
     MatrixXi output_mask = build_output_mask(isLDA(), isSpinSeparated(), order);
     VectorXi density_mask = build_density_mask(isLDA(), isSpinSeparated(), order);
     if(output_mask.rows() != density_mask.size()) MSG_FATAL("Inconsistent lengths");
 
     VectorXd cont_i;
-    for (int i = 0; i < output_mask.cols()) {
-        cont_i = VectorXd::Zero(n_coefs);
-        for (int j = 0; i < output_mask.rows()) {
+    for (int i = 0; i < output_mask.cols(); i++) {
+        cont_i = VectorXd::Zero(n_points);
+        for (int j = 0; j < output_mask.rows(); j++) {
             int out_index = output_mask(i,j);
             int den_index = density_mask(j);
             if(den_index >= 0) {
-                FunctionNode<3> &dens_node = mrcpp::get_func(xcDensity, density_index(i)).getEndFuncNode(n);
+                FunctionNode<3> &dens_node = mrcpp::get_func(xcDensity, density_mask(i)).getEndFuncNode(node_index);
                 VectorXd dens_i;
                 dens_node.getValues(dens_i);
                 cont_i += out_data.col(out_index).array() * dens_i.array();

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -489,8 +489,8 @@ void XCFunctional::setupXCDensityVariables() {
             }
         }
     }
-    std::cout << "Plotting densities" << std::endl;
-    plot_function_tree_vector(xcDensity, "Dens_");
+	//    std::cout << "Plotting densities" << std::endl;
+	//    plot_function_tree_vector(xcDensity, "Dens_");
 
     if (n_dens != xcDensity.size()) MSG_FATAL("Mismatch between used vs requested " << n_dens << " : " << xcDensity.size());
 
@@ -500,11 +500,11 @@ void XCFunctional::plot_function_tree_vector(FunctionTreeVector<3> &functions, s
     
     int nPts = 10000;                               // Number of points
     double a[3] = { 0.0,  0.0,  8.0};               // Start point of plot
-    double b[3] = { 0.0,  8.0,  0.0};               // End point of plot
+	double b[3] = { 0.0,  8.0,  0.0};               // End point of plot
     double o[3] = { 0.0, -4.0, -4.0};               // Origin of plot
     mrcpp::Plotter<3> plot;                         // Plotter of 3D functions
     plot.setNPoints(nPts);                          // Set number of points
-    plot.setRange(a, b, o);                         // Set plot range
+	//    plot.setRange(a, b, o);                         // Set plot range
 
     for (int i = 0; i < functions.size(); i++) {
         mrcpp::FunctionTree<3> &func = mrcpp::get_func(functions, i);
@@ -818,10 +818,10 @@ FunctionTreeVector<3> XCFunctional::calcPotential() {
     }
     timer.stop();
     int n = mrcpp::sum_nodes(xc_pot);
-    double t = timer.getWallTime();
+	double t = timer.getWallTime();
     Printer::printTree(0, "XC potential", n, t);
-    std::cout << "Plotting potentials" << std::endl;
-    plot_function_tree_vector(xc_pot, "Potential_");
+	//    std::cout << "Plotting potentials" << std::endl;
+	//    plot_function_tree_vector(xc_pot, "Potential_");
     return xc_pot;
 }
 

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -23,6 +23,8 @@
  * <https://mrchem.readthedocs.io/>
  */
 
+#include <stdexcept>
+
 #include "MRCPP/MWOperators"
 #include "MRCPP/Printer"
 #include "MRCPP/Timer"
@@ -123,10 +125,10 @@ void XCFunctional::setFunctional(const std::string &name, double coef) {
 bool XCFunctional::hasDensity(int n_dens) const {
     bool out = true;
     if (isSpinSeparated()) {
-        out = checkDensity(rho_a, nDens);
-        out = checkDensity(rho_b, nDens);
+        out = checkDensity(rho_a, n_dens);
+        out = checkDensity(rho_b, n_dens);
     } else {
-        out = checkDensity(rho_t, nDens);
+        out = checkDensity(rho_t, n_dens);
     }
     return out;
 }
@@ -202,18 +204,25 @@ FunctionTreeVector<3> & XCFunctional::getDensityVector(DensityType type) {
  * Returns a reference to the internal vector of density functions so that it can be
  * computed by the host program. This needs to be done before setup().
  */
-FunctionTree<3> & XCFunctional::getDensity(DensityType type, int index) {
-    switch (type) {
-        case DensityType::Total:
-            return mrcpp::get_func(rho_t, index);
-        case DensityType::Alpha:
-            return mrcpp::get_func(rho_a, index);
-        case DensityType::Beta:
-            return mrcpp::get_func(rho_b, index);
-        default:
-            MSG_FATAL("Invalid density type");
+FunctionTree<3> &XCFunctional::getDensity(DensityType type, int index) {
+    FunctionTreeVector<3> dens_vec = getDensityVector(type);
+    return getDensity(dens_vec, index);
+}
+
+FunctionTree<3> &XCFunctional::getDensity(FunctionTreeVector<3> &density, int index) {
+    try { density.at(index); } 
+    catch (const std::out_of_range& oor) {
+        MSG_FATAL("Out of Range error: " << oor.what());
     }
-    MSG_FATAL("Total density functions not properly initialized");
+    return mrcpp::get_func(density, index);
+}
+
+void XCFunctional::setDensity(FunctionTree<3> *density, DensityType type, int index) {
+    FunctionTreeVector<3> dens_vec = getDensityVector(type);
+    if (dens_vec.size() != index) {
+        MSG_FATAL("Index mismatch");
+    }
+    dens_vec.push_back(std::make_tuple(1.0, density));
 }
 
 /** @brief Return the number of nodes in the density grid (including branch nodes)*/
@@ -315,27 +324,13 @@ void XCFunctional::clearGrid(FunctionTreeVector<3> densities) {
 }
 
 void XCFunctional::setup() {
-    switch (mode) {
-    case 1:
-        setup_partial();
-        break;
-    case 3:
-        setup_contracted();
-        break;
-    default:
-        MSG_FATAL("Not implemented: abort");
-    }
-}
-
-
-void XCFunctional::setupContracted() {
     if (not hasDensity(order)) {
         MSG_ABORT("Not enough density functions initialized");
     }
     setupGradient(order);
-    setupGamma(order);
-    setupXCInputContracted();
-    setupXCOutputContracted();
+    setupXCInput();
+    setupXCOutput();
+    setupXCDensityVariable();
 }
 
 void XCFunctional::setupGradient() {
@@ -355,100 +350,6 @@ void XCFunctional::setupGradient() {
     
 }
 
-void XCFunuctional::setupGamma() {
-    if (isLDA() or not useGamma()) return;
-    for (int i = 0; i < 3*nDensities; i+=3) {
-        if(isSpinSeparated()) {
-            FunctionTreeVector<3> temp_a(grad_a.begin()+i, grad_a.begin()+i+3);
-            FunctionTreeVector<3> temp_b(grad_b.begin()+i, grad_b.begin()+i+3);
-            FunctionTreeVector<3> temp_g = buildGamma(temp_a, temp_b);
-            gamma.insert(gamma.end(), temp_g.begin(), temp_g.end());
-        } else {
-            FunctionTreeVector<3> temp_t(grad_t.begin()+i, grad_t.begin()+i+3);
-            gamma.push_back(std::make_tuple(1.0, buildGamma(temp_t)));
-        }
-    }
-    return;
-}
-
-FunctionTree<3>* XCFunctional::buildGamma(FunctionTreeVector<3> &grad) {
-    FunctionTree<3> *gamma = new FunctionTree<3>(MRA);
-    mrcpp::build_grid(*gamma, grad);
-    mrcpp::dot(-1.0, *gamma, grad, grad);
-    return gamma;
-}
-
-FunctionTreeVector<3> XCFunctional::buildGamma(FunctionTreeVector<3> &grad_a, FunctionTreeVector<3> &grad_b) {
-    FunctionTree<3> *gamma_aa = new FunctionTree<3>(MRA);
-    FunctionTree<3> *gamma_ab = new FunctionTree<3>(MRA);
-    FunctionTree<3> *gamma_bb = new FunctionTree<3>(MRA);
-    mrcpp::build_grid(*gamma_aa, grad_a);
-    mrcpp::build_grid(*gamma_ab, grad_a);
-    mrcpp::build_grid(*gamma_bb, grad_a);
-    mrcpp::dot(-1.0, *gamma_aa, grad_a, grad_a);
-    mrcpp::dot(-1.0, *gamma_ab, grad_a, grad_b);
-    mrcpp::dot(-1.0, *gamma_bb, grad_b, grad_b);
-    FunctionTreeVector<3> temp_gamma;
-    temp_gamma.push_back(std::make_tuple(1.0, gamma_aa));
-    temp_gamma.push_back(std::make_tuple(1.0, gamma_ab));
-    temp_gamma.push_back(std::make_tuple(1.0, gamma_bb));
-    return temp_gamma
-}
-
-/** @brief Prepare for xcfun evaluation
- *
- * This computes the necessary input functions (gradients and gamma) and
- * constructs empty grids to hold the output functions of xcfun, and
- * collects them in the xcInput and xcOutput vectors, respectively.
- * Assumes that the density functions rho_t or rho_a/rho_b have already
- * been computed.
- */
-void XCFunctional::setup_partial() {
-    if (isSpinSeparated()) {
-        FunctionTree<3> &rho_gs_a = mrcpp::get_func(rho_a, 0);
-        FunctionTree<3> &rho_gs_b = mrcpp::get_func(rho_b, 0);
-        setup_partial(rho_gs_a, rho_gs_b);
-    } else {
-        FunctionTree<3> &rho_gs_t = mrcpp::get_func(rho_t, 0);
-        setup_partial(rho_gs_t);
-    }
-    setupXCInput();
-    setupXCOutput();
-}
-
-void XCFunctional::setup_partial(FunctionTree<3> &rho_a, FunctionTree<3> &rho_b) {
-    if (isGGA()) {
-        grad_a = mrcpp::gradient(*derivative, rho_a);
-        grad_b = mrcpp::gradient(*derivative, rho_b);
-    }
-    if (useGamma()) {
-        FunctionTree<3> *gamma_aa = new FunctionTree<3>(MRA);
-        FunctionTree<3> *gamma_ab = new FunctionTree<3>(MRA);
-        FunctionTree<3> *gamma_bb = new FunctionTree<3>(MRA);
-        mrcpp::build_grid(*gamma_aa, rho_a);
-        mrcpp::build_grid(*gamma_ab, rho_a);
-        mrcpp::build_grid(*gamma_bb, rho_a);
-        mrcpp::dot(-1.0, *gamma_aa, grad_a, grad_a);
-        mrcpp::dot(-1.0, *gamma_ab, grad_a, grad_b);
-        mrcpp::dot(-1.0, *gamma_bb, grad_b, grad_b);
-        gamma.push_back(std::make_tuple(1.0, gamma_aa));
-        gamma.push_back(std::make_tuple(1.0, gamma_ab));
-        gamma.push_back(std::make_tuple(1.0, gamma_bb));
-    }
-}
-
-void XCFunctional::setup_partial(FunctionTree<3> &rho_t) {
-    if (isGGA()) {
-        grad_t = mrcpp::gradient(*derivative, rho_t);
-    }
-    if (useGamma()) {
-        FunctionTree<3> *gamma_tt = new FunctionTree<3>(MRA);
-        mrcpp::build_grid(*gamma_tt, rho_t);
-        mrcpp::dot(-1.0, *gamma_tt, grad_t, grad_t);
-        gamma.push_back(std::make_tuple(1.0, gamma_tt));
-    }
-}
-
 /** @brief Cleanup after xcfun evaluation
  *
  * This deallocates the memory used by both the input and output functions
@@ -458,17 +359,15 @@ void XCFunctional::setup_partial(FunctionTree<3> &rho_t) {
  */
 void XCFunctional::clear() {
     mrcpp::clear(xcInput, false);
+    mrcpp::clear(xcDensityVariables, false);
     mrcpp::clear(xcOutput, true);
     mrcpp::clear(grad_a, true);
     mrcpp::clear(grad_b, true);
     mrcpp::clear(grad_t, true);
     mrcpp::clear(gamma, true);
-    clearGrid();
-
-    // Clear MW coefs but keep the grid
-    // if (rho_a != nullptr) mrcpp::clear_grid(*rho_a);
-    // if (rho_b != nullptr) mrcpp::clear_grid(*rho_b);
-    // if (rho_t != nullptr) mrcpp::clear_grid(*rho_t);
+    mrcpp::clear(rho_a, true);
+    mrcpp::clear(rho_b, true);
+    mrcpp::clear(rho_t, true);
 }
 
 /** @brief Allocate input arrays for xcfun
@@ -486,6 +385,37 @@ void XCFunctional::setupXCInput() {
     if (isGGA()) nUsed += setupXCInputGradient();
 
     if (nInp != nUsed) MSG_ERROR("Mismatch between used vs requested " << nUsed << " : " << nInp);
+}
+
+/** @brief Allocate input arrays for xcfun
+ *
+ * Based on the xcfun setup, the requested array of FunctionTrees(s)
+ * is allocared and its pointers assigned to the required input
+ * functions.
+ */
+void XCFunctional::setupXCDensityVariables() {
+    if (xcDensity.size() != 0) MSG_ERROR("XC density vars not empty");
+
+    int n_dens = getDensityLength();
+    
+    if(getDensityLength() > 0) {
+        if (isSpinSeparated()) {
+            xcDensity.push_back(rho_a[1]);
+            xcDensity.push_back(rho_b[1]);
+        } else {
+            xcDensity.push_back(rho_t[1]);
+        }
+        if (isGGA()) {
+            if (isSpinSeparated()) {
+                xcDensity.insert(xcDensity.begin() + 1, grad_a.begin() + 3, grad_a.begin() + 6);
+                xcDensity.insert(xcDensity.begin() + 5, grad_b.begin() + 3, grad_b.begin() + 6);
+            } else {
+                xcDensity.insert(xcDensity.begin() + 1, grad_t.begin() + 3, grad_t.begin() + 6);
+            }
+        }
+    }
+
+    if (n_dens != xcDensity.size()) MSG_FATAL("Mismatch between used vs requested " << n_dens << " : " << xcDensity.size());
 }
 
 /** @brief Sets xcInput pointers for the density
@@ -1030,7 +960,7 @@ VectorXi build_density_mask(bool is_lda, bool is_spin_sep, int order) {
     return mask;
 }
 
-void XCFunctional::fill_output_mask(MatrixXi mask, int value) {
+void fill_output_mask(MatrixXi &mask, int value) {
     for (int i = 0, i < mask.rows(); i++) {
         mask(i,i) = value;
         value++;
@@ -1039,5 +969,5 @@ void XCFunctional::fill_output_mask(MatrixXi mask, int value) {
             mask(i,j) = value;
             value++;
         }
-    }
-    
+    }   
+}

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -62,12 +62,6 @@ XCFunctional::XCFunctional(mrcpp::MultiResolutionAnalysis<3> &mra, bool spin)
         , functional(xc_new_functional())
         , derivative(nullptr) {
     derivative = new mrcpp::ABGVOperator<3>(MRA, 0.0, 0.0);
-    if (isSpinSeparated()) {
-        rho_a = new FunctionTree<3>(MRA);
-        rho_b = new FunctionTree<3>(MRA);
-    } else {
-        rho_t = new FunctionTree<3>(MRA);
-    }
 }
 
 /** @brief Destructor */
@@ -85,7 +79,7 @@ XCFunctional::~XCFunctional() {
  *
  * Prepare the XCFun object for evaluation based on the chosen parameters.
  */
-void XCFunctional::evalSetup(int ord) {
+void XCFunctional::evalSetup(int ord, int mod) {
     if (mod != 1 and mod != 3) {
         MSG_FATAL("Only contracted or partial derivative modes are available")
     }
@@ -98,7 +92,7 @@ void XCFunctional::evalSetup(int ord) {
     unsigned int current = 0;   //!< no current density
     unsigned int exp_derivative = not useGamma(); //!< use gamma or explicit derivatives
     if (isLDA()) exp_derivative = 0; //!< fall back to gamma-type derivatives if LDA (bad hack: no der are actually needed here!)
-    xc_user_eval_setup(functional, order, func_type, dens_type, mode_type, laplacian, kinetic, current, exp_derivative);
+    xc_user_eval_setup(functional, order, func_type, dens_type, mode, laplacian, kinetic, current, exp_derivative);
 }
 
 /** @brief Set density functional
@@ -121,6 +115,7 @@ void XCFunctional::setFunctional(const std::string &name, double coef) {
  * and beta densities are tested, otherwise only the total density.
  */
 bool XCFunctional::hasDensity() const {
+    bool out = true;
     if (isSpinSeparated()) {
         out = checkDensity(rho_a);
         out = checkDensity(rho_b);
@@ -141,13 +136,13 @@ bool XCFunctional::hasDensity() const {
  * not be used in reality.
  *
  */
-bool checkDensity(FunctionTreeVector<3> density) const {
+bool XCFunctional::checkDensity(FunctionTreeVector<3> density) const {
     bool out = true;
     if (density.size() < nDensities) out = false;
-    std::cout << 'HACK Check only GS density for now...' << std::eendl;
+    std::cout << "HACK Check only GS density for now..." << std::endl;
     for (int i = 0; i < 1; i++) {
-        FunctionTree<3> dens = mrcpp::get_func(density, i);
-        if (temp->getSquareNorm() < 0.0) out = false;
+        FunctionTree<3> &dens = mrcpp::get_func(density, i);
+        if (dens.getSquareNorm() < 0.0) out = false;
     }
     return out;
 }
@@ -198,13 +193,13 @@ FunctionTree<3> & XCFunctional::getDensity(DensityType type, int index) {
 int XCFunctional::getNNodes() const {
     int nodes = 0;
     if (isSpinSeparated()) {
-        FunctionTree<3> &rho_gs_a = mrcpp::get_func(rho_a, 0);
-        FunctionTree<3> &rho_gs_b = mrcpp::get_func(rho_b, 0);
-        nodes = rho_gs_a->getNNodes();
-        if (nodes != rho_gs_b->getNNodes()) MSG_ERROR("Alpha and beta grids not equal");
+        const FunctionTree<3> &rho_gs_a = mrcpp::get_func(rho_a, 0);
+        const FunctionTree<3> &rho_gs_b = mrcpp::get_func(rho_b, 0);
+        nodes = rho_gs_a.getNNodes();
+        if (nodes != rho_gs_b.getNNodes()) MSG_ERROR("Alpha and beta grids not equal");
     } else {
-        FunctionTree<3> &rho_gs_t = mrcpp::get_func(rho_t, 0);
-        nodes = rho_gs_t->getNNodes();
+        const FunctionTree<3> &rho_gs_t = mrcpp::get_func(rho_t, 0);
+        nodes = rho_gs_t.getNNodes();
     }
     return nodes;
 }
@@ -214,15 +209,15 @@ int XCFunctional::getNPoints() const {
     int nodes = 0;
     int points = 0;
     if (isSpinSeparated()) {
-        FunctionTree<3> &rho_gs_a = mrcpp::get_func(rho_a, 0);
-        FunctionTree<3> &rho_gs_b = mrcpp::get_func(rho_b, 0);
-        nodes = rho_gs_a->getNEndNodes();
-        points = rho_gs_a->getTDim()*rho_a->getKp1_d();
-        if (nodes != rho_gs_b->getNEndNodes()) MSG_ERROR("Alpha and beta grids not equal");
+        const FunctionTree<3> &rho_gs_a = mrcpp::get_func(rho_a, 0);
+        const FunctionTree<3> &rho_gs_b = mrcpp::get_func(rho_b, 0);
+        nodes = rho_gs_a.getNEndNodes();
+        points = rho_gs_a.getTDim()*rho_gs_a.getKp1_d();
+        if (nodes != rho_gs_b.getNEndNodes()) MSG_ERROR("Alpha and beta grids not equal");
     } else {
-        FunctionTree<3> &rho_gs_t = mrcpp::get_func(rho_t, 0);
-        nodes = rho_t->getNEndNodes();
-        points = rho_t->getTDim() * rho_t->getKp1_d();
+        const FunctionTree<3> &rho_gs_t = mrcpp::get_func(rho_t, 0);
+        nodes = rho_gs_t.getNEndNodes();
+        points = rho_gs_t.getTDim() * rho_gs_t.getKp1_d();
     }
     return nodes * points;
 }
@@ -245,12 +240,12 @@ void XCFunctional::buildGrid(double Z, const mrcpp::Coord<3> &R) {
             FunctionTree<3> &rho_gs_b = mrcpp::get_func(rho_b, 0);
             mrcpp::build_grid(rho_gs_a, gauss);
             mrcpp::build_grid(rho_gs_b, gauss);
-            distributeGrid(rho_a)
-            distributeGrid(rho_b)
+            copyGrid(rho_a);
+            copyGrid(rho_b);
         } else {
             FunctionTree<3> &rho_gs_t = mrcpp::get_func(rho_t, 0);
             mrcpp::build_grid(rho_gs_t, gauss);
-            distributeGrid(rho_t)
+            copyGrid(rho_t);
         }
     }
 }
@@ -285,7 +280,7 @@ void XCFunctional::clearGrid() {
  * This will _remove_ all existing grid refinement and leave only root nodes
  * in the density grids.
  */
-void XCFunctional::clearGrid(densities) {
+void XCFunctional::clearGrid(FunctionTreeVector<3> densities) {
     for (int i = 0; i < densities.size(); i++) {
         FunctionTree<3> &rho = mrcpp::get_func(densities, i);
         rho_a.clear();
@@ -319,11 +314,11 @@ void XCFunctional::setup_contracted() {
  */
 void XCFunctional::setup_partial() {
     if (isSpinSeparated()) {
-        FunctionTreeVector &rho_gs_a = mrcpp::get_function(rho_a, 0);
-        FunctionTreeVector &rho_gs_b = mrcpp::get_function(rho_b, 0);
+        FunctionTree<3> &rho_gs_a = mrcpp::get_func(rho_a, 0);
+        FunctionTree<3> &rho_gs_b = mrcpp::get_func(rho_b, 0);
         setup_partial(rho_gs_a, rho_gs_b);
     } else {
-        FunctionTreeVector &rho_gs_t = mrcpp::get_function(rho_t, 0);
+        FunctionTree<3> &rho_gs_t = mrcpp::get_func(rho_t, 0);
         setup_partial(rho_gs_t);
     }
 }
@@ -411,13 +406,13 @@ void XCFunctional::setupXCInput() {
 int XCFunctional::setupXCInputDensity() {
     int nUsed = 0;
     if (isSpinSeparated()) {
-        if (rho_a == nullptr) MSG_FATAL("Invalid alpha density");
-        if (rho_b == nullptr) MSG_FATAL("Invalid beta density");
+        if (rho_a.size() <= 0) MSG_FATAL("Invalid alpha density");
+        if (rho_b.size() <= 0) MSG_FATAL("Invalid beta density");
         xcInput.push_back(rho_a[0]);
         xcInput.push_back(rho_b[0]);
         nUsed = 2;
     } else {
-        if (rho_t == nullptr) MSG_FATAL("Invalid total density");
+        if (rho_t.size() <= 0) MSG_FATAL("Invalid total density");
         xcInput.push_back(rho_t[0]);
         nUsed = 1;
     }

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -434,9 +434,7 @@ void XCFunctional::clear() {
     mrcpp::clear(grad_b, true);
     mrcpp::clear(grad_t, true);
     mrcpp::clear(gamma, true);
-    mrcpp::clear(rho_a, true);
-    mrcpp::clear(rho_b, true);
-    mrcpp::clear(rho_t, true);
+    clearGrid(); // We want to keep empty the density trees
 }
 
 /** @brief Allocate input arrays for xcfun
@@ -542,7 +540,7 @@ void XCFunctional::setupXCOutput() {
     // Fetch density grid to copy
     FunctionTree<3> &grid = mrcpp::get_func(xcInput, 0);
 
-    int nOut = getContractedLength();
+    int nOut = getContractedLength() + 1; //We always keep the functional as well
     for (int i = 0; i < nOut; i++) {
         FunctionTree<3> *tmp = new FunctionTree<3>(MRA);
         mrcpp::copy_grid(*tmp, grid);
@@ -575,14 +573,15 @@ void XCFunctional::evaluate() {
             MatrixXd inpData, outData, conData, denData;
             inpData = MatrixXd::Zero(nPts, nInp);
             outData = MatrixXd::Zero(nPts, nOut);
-            conData = MatrixXd::Zero(nPts, nCon);
+            conData = MatrixXd::Zero(nPts, nCon + 1);
             compressNodeData(n_idx, nInp, xcInput, inpData);
             evaluateBlock(inpData, outData);
+            conData.col(0) = outData.col(0); // we always keep the density functional
             contractNodeData(n_idx, nPts, outData, conData);
             expandNodeData(n_idx, nCon, xcOutput, conData);
         }
     }
-    for (int i = 0; i < nCon; i++) {
+    for (int i = 0; i < nCon + 1; i++) {
         mrcpp::get_func(xcOutput, i).mwTransform(mrcpp::BottomUp);
         mrcpp::get_func(xcOutput, i).calcSquareNorm();
     }
@@ -590,8 +589,6 @@ void XCFunctional::evaluate() {
     Printer::printTree(0, "XC evaluate xcfun", mrcpp::sum_nodes(xcOutput), timer.getWallTime());
     printout(2, std::endl);
 }
-
-
 
 void XCFunctional::contractNodeData(int node_index, int n_points, MatrixXd &out_data, MatrixXd &con_data) {
 
@@ -618,7 +615,7 @@ void XCFunctional::contractNodeData(int node_index, int n_points, MatrixXd &out_
             }
             cont_i += cont_ij;
         }
-        con_data.col(i) = cont_i;
+        con_data.col(i+1) = cont_i; //The first column contains the energy functional
     }
 }
 
@@ -789,8 +786,9 @@ FunctionTreeVector<3> XCFunctional::calcPotential() {
  */
 void XCFunctional::calcPotentialLDA(FunctionTreeVector<3> &potentials) {
     int nPotentials = isSpinSeparated()? 2 : 1;
+    int iStart = 1;
     for (int i = 0; i < nPotentials; i++) {
-        FunctionTree<3> &out_i = mrcpp::get_func(xcOutput, i);
+        FunctionTree<3> &out_i = mrcpp::get_func(xcOutput, i + iStart);
         FunctionTree<3> *pot = new FunctionTree<3>(MRA);
         mrcpp::copy_grid(*pot, out_i);
         mrcpp::copy_func(*pot, out_i);
@@ -808,17 +806,17 @@ void XCFunctional::calcPotentialGGA(FunctionTreeVector<3> &potentials) {
     if (useGamma()) NOT_IMPLEMENTED_ABORT;
     FunctionTree<3> *pot;
     if (isSpinSeparated()) {
-        FunctionTree<3> &df_da = mrcpp::get_func(xcOutput, 0);
-        FunctionTree<3> &df_db = mrcpp::get_func(xcOutput, 4);
-        FunctionTreeVector<3> df_dga(xcOutput.begin() + 1, xcOutput.begin() + 4);
-        FunctionTreeVector<3> df_dgb(xcOutput.begin() + 5, xcOutput.begin() + 8);
+        FunctionTree<3> &df_da = mrcpp::get_func(xcOutput, 1);
+        FunctionTree<3> &df_db = mrcpp::get_func(xcOutput, 2);
+        FunctionTreeVector<3> df_dga(xcOutput.begin() + 3, xcOutput.begin() + 6);
+        FunctionTreeVector<3> df_dgb(xcOutput.begin() + 6, xcOutput.begin() + 9);
         pot = calcPotentialGGA(df_da, df_dga);
         potentials.push_back(std::make_tuple(1.0, pot));
         pot = calcPotentialGGA(df_db, df_dgb);
         potentials.push_back(std::make_tuple(1.0, pot));
     } else {
-        FunctionTree<3> &df_dt = mrcpp::get_func(xcOutput, 0);
-        FunctionTreeVector<3> df_dgt(xcOutput.begin() + 1, xcOutput.begin() + 4);
+        FunctionTree<3> &df_dt = mrcpp::get_func(xcOutput, 1);
+        FunctionTreeVector<3> df_dgt(xcOutput.begin() + 2, xcOutput.begin() + 5);
         pot = calcPotentialGGA(df_dt, df_dgt);
         potentials.push_back(std::make_tuple(1.0, pot));
     }
@@ -845,34 +843,6 @@ FunctionTree<3> *XCFunctional::calcPotentialGGA(FunctionTree<3> &df_drho, Functi
     mrcpp::add(-1.0, *V, funcs);
     delete tmp;
     return V;
-}
-
-/** @brief Helper function to compute divergence of a vector field times a function
- *
- * @param[in] V Function (derivative of the functional wrt gamma)
- * @param[in] rho Vector field (density gradient)
- *
- */
-FunctionTree<3> *XCFunctional::calcGradDotPotDensVec(FunctionTree<3> &V, FunctionTreeVector<3> &rho) {
-    FunctionTreeVector<3> vec;
-    for (int d = 0; d < rho.size(); d++) {
-        Timer timer;
-        FunctionTree<3> &rho_d = mrcpp::get_func(rho, d);
-        FunctionTree<3> *Vrho = new FunctionTree<3>(MRA);
-        mrcpp::copy_grid(*Vrho, rho_d);
-        mrcpp::multiply(-1.0, *Vrho, 1.0, V, rho_d);
-        vec.push_back(std::make_tuple(1.0, Vrho));
-        timer.stop();
-        Printer::printTree(2, "Multiply", Vrho->getNNodes(), timer.getWallTime());
-    }
-
-    Timer timer;
-    FunctionTree<3> *result = new FunctionTree<3>(MRA);
-    mrcpp::divergence(*result, *derivative, vec);
-    mrcpp::clear(vec, true);
-    timer.stop();
-    Printer::printTree(2, "Gradient", result->getNNodes(), timer.getWallTime());
-    return result;
 }
 
 int XCFunctional::getNodeLength() {

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -489,7 +489,7 @@ void XCFunctional::setupXCDensityVariables() {
             }
         }
     }
-    
+    std::cout << "Plotting densities" << std::endl;
     plot_function_tree_vector(xcDensity, "Dens_");
 
     if (n_dens != xcDensity.size()) MSG_FATAL("Mismatch between used vs requested " << n_dens << " : " << xcDensity.size());
@@ -498,19 +498,20 @@ void XCFunctional::setupXCDensityVariables() {
 
 void XCFunctional::plot_function_tree_vector(FunctionTreeVector<3> &functions, std::string prefix) {
     
-    int nPts = 1000;                                // Number of points
-    double a[3] = { 0.0, 0.0, -2.0};                // Start point of plot
-    double b[3] = { 0.0, 0.0,  2.0};                // End point of plot
+    int nPts = 10000;                               // Number of points
+    double a[3] = { 0.0,  0.0,  8.0};               // Start point of plot
+    double b[3] = { 0.0,  8.0,  0.0};               // End point of plot
+    double o[3] = { 0.0, -4.0, -4.0};               // Origin of plot
     mrcpp::Plotter<3> plot;                         // Plotter of 3D functions
     plot.setNPoints(nPts);                          // Set number of points
-    plot.setRange(a, b);                            // Set plot range
+    plot.setRange(a, b, o);                         // Set plot range
 
     for (int i = 0; i < functions.size(); i++) {
         mrcpp::FunctionTree<3> &func = mrcpp::get_func(functions, i);
         std::string name= prefix + std::to_string(i) + "_iter_" + std::to_string(xc_iteration);
         std::cout << name << std::endl;
         std::cout << func << std::endl;
-        plot.linePlot(func, name);
+        plot.surfPlot(func, name);
     }
     
     xc_iteration++;
@@ -644,9 +645,9 @@ void XCFunctional::contractNodeData(int node_index, int n_points, MatrixXd &out_
             cont_ij = VectorXd::Zero(n_points);
             int out_index = output_mask(i,j);
             int den_index = density_mask(j);
-            //            if(den_index >= 2) {
-            //                continue;
-            //            } else if(den_index >= 0) {
+            //if(den_index >= 2) {  //WARNING: This HACK works for Open shell only
+            //        continue;
+            //} else if(den_index >= 0) {
             if(den_index >= 0) {
                 FunctionTree<3> &dens_func = mrcpp::get_func(xcDensity, den_index);
                 FunctionNode<3> &dens_node = dens_func.getEndFuncNode(node_index);
@@ -819,6 +820,8 @@ FunctionTreeVector<3> XCFunctional::calcPotential() {
     int n = mrcpp::sum_nodes(xc_pot);
     double t = timer.getWallTime();
     Printer::printTree(0, "XC potential", n, t);
+    std::cout << "Plotting potentials" << std::endl;
+    plot_function_tree_vector(xc_pot, "Potential_");
     return xc_pot;
 }
 

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -304,7 +304,7 @@ void XCFunctional::clearGrid() {
 void XCFunctional::clearGrid(FunctionTreeVector<3> densities) {
     for (int i = 0; i < densities.size(); i++) {
         FunctionTree<3> &rho = mrcpp::get_func(densities, i);
-        rho_a.clear();
+        rho.clear();
     }
 }
 

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -490,13 +490,13 @@ void XCFunctional::setupXCDensityVariables() {
         }
     }
     
-    plot_densities();
+    plot_function_tree_vector(xcDensity, "Dens_");
 
     if (n_dens != xcDensity.size()) MSG_FATAL("Mismatch between used vs requested " << n_dens << " : " << xcDensity.size());
 
 }
 
-void XCFunctional::plot_densities() {
+void XCFunctional::plot_function_tree_vector(FunctionTreeVector<3> &functions, std::string prefix) {
     
     int nPts = 1000;                                // Number of points
     double a[3] = { 0.0, 0.0, -2.0};                // Start point of plot
@@ -505,9 +505,11 @@ void XCFunctional::plot_densities() {
     plot.setNPoints(nPts);                          // Set number of points
     plot.setRange(a, b);                            // Set plot range
 
-    for (int i = 0; i < xcDensity.size(); i++) {
-        mrcpp::FunctionTree<3> &func = mrcpp::get_func(xcDensity, i);
-        std::string name="Dens_" + std::to_string(i) + "_iter_" + std::to_string(xc_iteration);
+    for (int i = 0; i < functions.size(); i++) {
+        mrcpp::FunctionTree<3> &func = mrcpp::get_func(functions, i);
+        std::string name= prefix + std::to_string(i) + "_iter_" + std::to_string(xc_iteration);
+        std::cout << name << std::endl;
+        std::cout << func << std::endl;
         plot.linePlot(func, name);
     }
     

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -562,7 +562,8 @@ void XCFunctional::evaluate() {
 
     int nInp = getInputLength();          // Input parameters to XCFun
     int nOut = getOutputLength();         // Output parameters from XCFun
-    int nCon = getContractedLength();     // Contracted parameters to XCPotential 
+    int nCon = getContractedLength();     // Contracted parameters to XCPotential
+    int nFcs = nCon + 1;                  // One extra function for the energy density
     int nPts = getNodeLength();           // Number of gridpoints in a node
   
 #pragma omp parallel firstprivate(nInp, nOut)
@@ -573,15 +574,15 @@ void XCFunctional::evaluate() {
             MatrixXd inpData, outData, conData, denData;
             inpData = MatrixXd::Zero(nPts, nInp);
             outData = MatrixXd::Zero(nPts, nOut);
-            conData = MatrixXd::Zero(nPts, nCon + 1);
+            conData = MatrixXd::Zero(nPts, nFcs);
             compressNodeData(n_idx, nInp, xcInput, inpData);
             evaluateBlock(inpData, outData);
-            conData.col(0) = outData.col(0); // we always keep the density functional
+            conData.col(0) = outData.col(0); // we always keep the energy functional
             contractNodeData(n_idx, nPts, outData, conData);
-            expandNodeData(n_idx, nCon, xcOutput, conData);
+            expandNodeData(n_idx, nFcs, xcOutput, conData);
         }
     }
-    for (int i = 0; i < nCon + 1; i++) {
+    for (int i = 0; i < nFcs; i++) {
         mrcpp::get_func(xcOutput, i).mwTransform(mrcpp::BottomUp);
         mrcpp::get_func(xcOutput, i).calcSquareNorm();
     }

--- a/src/mrdft/XCFunctional.h
+++ b/src/mrdft/XCFunctional.h
@@ -162,7 +162,7 @@ private:
 
     mrcpp::FunctionTree<3> *calcPotentialGGA(mrcpp::FunctionTree<3> &df_drho, mrcpp::FunctionTreeVector<3> &df_dgr);
 
-    void plot_densities();
+    void plot_function_tree_vector(mrcpp::FunctionTreeVector<3> &functions, std::string prefix);
 
 };
 

--- a/src/mrdft/XCFunctional.h
+++ b/src/mrdft/XCFunctional.h
@@ -70,16 +70,15 @@ public:
     ~XCFunctional();
 
     bool hasDensity() const;
-    bool checkDensity(FunctionTreeVector<3> density) const;
+    bool checkDensity(mrcpp::FunctionTreeVector<3> density) const;
     mrcpp::FunctionTreeVector<3> &getDensityVector(DensityType type);
-    mrcpp::FunctionTreeVector<3> &getDensity(DensityType type, int index = 0);
+    mrcpp::FunctionTree<3> &getDensity(DensityType type, int index = 0);
 
     int getNNodes() const;
     int getNPoints() const;
 
     void buildGrid(double Z, const mrcpp::Coord<3> &R);
-    void copyGrid(FunctionTreeVector<3> densities);
-    void clearGrid();
+    void copyGrid(mrcpp::FunctionTreeVector<3> densities);
 
     void setNDensities(int n) { this->nDensities = n; }
     int getNDensities() { return this->nDensities; }
@@ -102,7 +101,7 @@ public:
         return exx;
     }
 
-    void evalSetup(int order);
+    void evalSetup(int order, int mod = 1);
     void setup();
     void clear();
 
@@ -125,7 +124,7 @@ protected:
 
     mrcpp::FunctionTreeVector<3> rho_a;  ///< Alpha densities
     mrcpp::FunctionTreeVector<3> rho_b;  ///< Beta densities
-    mrcpp::FunctionTreeVecroe<3> rho_t;  ///< Total densities
+    mrcpp::FunctionTreeVector<3> rho_t;  ///< Total densities
     mrcpp::FunctionTreeVector<3> grad_a; ///< Gradient of the alpha densities
     mrcpp::FunctionTreeVector<3> grad_b; ///< Gradient of the beta  densities
     mrcpp::FunctionTreeVector<3> grad_t; ///< Gradient of the total densities
@@ -135,13 +134,13 @@ protected:
     mrcpp::FunctionTreeVector<3> xcOutput; ///< Bookkeeping array returned by XCFun
 
     void clearGrid();
-    void clearGrid(FunctionTreeVector<3> densities);
+    void clearGrid(mrcpp::FunctionTreeVector<3> densities);
     int getInputLength() const { return xc_input_length(this->functional); }
     int getOutputLength() const { return xc_output_length(this->functional); }
 
     void setup_partial();
-    void setup_partial(FunctionTree<3> &rho_a, FunctionTree<3> &rho_b);
-    void setup_partial(FunctionTree<3> &rho_t);
+    void setup_partial(mrcpp::FunctionTree<3> &rho_a, mrcpp::FunctionTree<3> &rho_b);
+    void setup_partial(mrcpp::FunctionTree<3> &rho_t);
     void setup_contracted();
     void setupXCInput();
     void setupXCOutput();

--- a/src/mrdft/XCFunctional.h
+++ b/src/mrdft/XCFunctional.h
@@ -71,7 +71,8 @@ public:
 
     bool hasDensity() const;
     bool checkDensity(FunctionTreeVector<3> density) const;
-    mrcpp::FunctionTreeVector<3> &getDensity(DensityType type);
+    mrcpp::FunctionTreeVector<3> &getDensityVector(DensityType type);
+    mrcpp::FunctionTreeVector<3> &getDensity(DensityType type, int index = 0);
 
     int getNNodes() const;
     int getNPoints() const;

--- a/src/mrdft/XCFunctional.h
+++ b/src/mrdft/XCFunctional.h
@@ -115,7 +115,6 @@ public:
 private:
     int order;
     int nDensities;
-    unsigned int mode;
     const bool spin_separated;                  ///< Spin polarization
     const mrcpp::MultiResolutionAnalysis<3> MRA;///< Computational domain
 
@@ -143,7 +142,7 @@ private:
     int getOutputLength() const { return xc_output_length(this->functional); }
     int getContractedLength() const; 
     int getDensityLength() const;
-    int getNodeLength() const;
+    int getNodeLength();
     
     void setupGradient();
         

--- a/src/mrdft/XCFunctional.h
+++ b/src/mrdft/XCFunctional.h
@@ -162,6 +162,8 @@ private:
 
     mrcpp::FunctionTree<3> *calcPotentialGGA(mrcpp::FunctionTree<3> &df_drho, mrcpp::FunctionTreeVector<3> &df_dgr);
 
+    void plot_densities();
+
 };
 
 } // namespace mrdft

--- a/src/mrdft/XCFunctional.h
+++ b/src/mrdft/XCFunctional.h
@@ -74,7 +74,7 @@ public:
     bool checkDensity(mrcpp::FunctionTreeVector<3> density, int n_dens = 1) const;
     mrcpp::FunctionTreeVector<3> &getDensityVector(DensityType type);
     mrcpp::FunctionTree<3> &getDensity(DensityType type, int index = 0);
-    void setDensity(mrcpp::FunctionTree<3> &Density, int index = 0);
+    void setDensity(mrcpp::FunctionTree<3> &Density, DensityType spin, int index = 0);
 
     int getNNodes() const;
     int getNPoints() const;

--- a/src/mrdft/XCFunctional.h
+++ b/src/mrdft/XCFunctional.h
@@ -60,8 +60,7 @@
 
 namespace mrdft {
 
-enum class DensityType { Total, Alpha, Beta };
-enum class ModeType { Partial = 1, Potential = 2, Contracted = 3 };
+enum class DensityType { Total, Spin, Alpha, Beta }; //This should be kept in sync with the DENSITY namespace of MRChem
 
 class XCFunctional final {
 public:
@@ -75,6 +74,7 @@ public:
     bool checkDensity(mrcpp::FunctionTreeVector<3> density, int n_dens = 1) const;
     mrcpp::FunctionTreeVector<3> &getDensityVector(DensityType type);
     mrcpp::FunctionTree<3> &getDensity(DensityType type, int index = 0);
+    void setDensity(mrcpp::FunctionTree<3> &Density, int index = 0);
 
     int getNNodes() const;
     int getNPoints() const;
@@ -133,8 +133,9 @@ private:
     mrcpp::FunctionTreeVector<3> grad_t; ///< Gradient of the total densities
     mrcpp::FunctionTreeVector<3> gamma;  ///< Gamma function(s)
 
-    mrcpp::FunctionTreeVector<3> xcInput;  ///< Bookkeeping array to feed XCFun
-    mrcpp::FunctionTreeVector<3> xcOutput; ///< Bookkeeping array returned by XCFun
+    mrcpp::FunctionTreeVector<3> xcInput;   ///< Bookkeeping array to feed XCFun
+    mrcpp::FunctionTreeVector<3> xcOutput;  ///< Bookkeeping array returned by XCFun
+    mrcpp::FunctionTreeVector<3> xcDensity; ///< Bookkeeping array with density variables
 
     void clearGrid();
     void clearGrid(mrcpp::FunctionTreeVector<3> densities);
@@ -157,20 +158,8 @@ private:
 
     void calcPotentialLDA(mrcpp::FunctionTreeVector<3> &potentials);
     void calcPotentialGGA(mrcpp::FunctionTreeVector<3> &potentials);
-    void calcGradientGGA(mrcpp::FunctionTreeVector<3> &potentials);
-    void calcHessianGGA(mrcpp::FunctionTreeVector<3> &potentials);
-    void calcHessianGGAgamma(mrcpp::FunctionTreeVector<3> &potentials);
-    void calcHessianGGAgrad(mrcpp::FunctionTreeVector<3> &potentials);
 
-    mrcpp::FunctionTree<3> *calcGradientGGA(mrcpp::FunctionTree<3> &df_drho, mrcpp::FunctionTreeVector<3> &df_dgr);
-    mrcpp::FunctionTree<3> *calcGradientGGA(mrcpp::FunctionTree<3> &df_drho,
-                                            mrcpp::FunctionTree<3> &df_dgamma,
-                                            mrcpp::FunctionTreeVector<3> grad_rho);
-    mrcpp::FunctionTree<3> *calcGradientGGA(mrcpp::FunctionTree<3> &df_drhoa,
-                                            mrcpp::FunctionTree<3> &df_dgaa,
-                                            mrcpp::FunctionTree<3> &df_dgab,
-                                            mrcpp::FunctionTreeVector<3> grad_rhoa,
-                                            mrcpp::FunctionTreeVector<3> grad_rhob);
+    mrcpp::FunctionTree<3> *calcPotentialGGA(mrcpp::FunctionTree<3> &df_drho, mrcpp::FunctionTreeVector<3> &df_dgr);
 
     mrcpp::FunctionTree<3> *calcGradDotPotDensVec(mrcpp::FunctionTree<3> &V, mrcpp::FunctionTreeVector<3> &rho);
 };

--- a/src/mrdft/XCFunctional.h
+++ b/src/mrdft/XCFunctional.h
@@ -29,6 +29,7 @@
 
 #include "MRCPP/MWFunctions"
 #include "XCFun/xcfun.h"
+#include "mrenum.h"
 
 /**
  *  @class XCFunctional
@@ -58,9 +59,8 @@
  *
  */
 
-namespace mrdft {
 
-enum class DensityType { Total, Spin, Alpha, Beta }; //This should be kept in sync with the DENSITY namespace of MRChem
+namespace mrdft {
 
 class XCFunctional final {
 public:
@@ -72,9 +72,9 @@ public:
     bool hasDensity(int n_dens_a = 1
                     ) const;
     bool checkDensity(mrcpp::FunctionTreeVector<3> density, int n_dens = 1) const;
-    mrcpp::FunctionTreeVector<3> &getDensityVector(DensityType type);
-    mrcpp::FunctionTree<3> &getDensity(DensityType type, int index = 0);
-    void setDensity(mrcpp::FunctionTree<3> &Density, DensityType spin, int index = 0);
+    mrcpp::FunctionTreeVector<3> &getDensityVector(DENSITY::DensityType spin);
+    mrcpp::FunctionTree<3> &getDensity(DENSITY::DensityType type, int index = 0);
+    void setDensity(mrcpp::FunctionTree<3> &density, DENSITY::DensityType spin, int index = 0);
 
     int getNNodes() const;
     int getNPoints() const;
@@ -104,7 +104,7 @@ public:
         return exx;
     }
 
-    void evalSetup(int order, int mod = 1);
+    void evalSetup(int order);
     void setup();
     void clear();
 
@@ -142,19 +142,21 @@ private:
     int getInputLength() const { return xc_input_length(this->functional); }
     int getOutputLength() const { return xc_output_length(this->functional); }
     int getContractedLength() const; 
+    int getDensityLength() const;
+    int getNodeLength() const;
     
-    void setup_partial();
-    void setup_partial(mrcpp::FunctionTree<3> &rho_a, mrcpp::FunctionTree<3> &rho_b);
-    void setup_partial(mrcpp::FunctionTree<3> &rho_t);
-    void setup_contracted();
+    void setupGradient();
+        
     void setupXCInput();
     void setupXCOutput();
     int setupXCInputDensity();
     int setupXCInputGradient();
+    void setupXCDensityVariables();
 
     void evaluateBlock(Eigen::MatrixXd &inp, Eigen::MatrixXd &out) const;
     void compressNodeData(int n, int nFuncs, mrcpp::FunctionTreeVector<3> trees, Eigen::MatrixXd &data);
     void expandNodeData(int n, int nFuncs, mrcpp::FunctionTreeVector<3> trees, Eigen::MatrixXd &data);
+    void contractNodeData(int n, int n_coefs, Eigen::MatrixXd &out_data, Eigen::MatrixXd &con_data);
 
     void calcPotentialLDA(mrcpp::FunctionTreeVector<3> &potentials);
     void calcPotentialGGA(mrcpp::FunctionTreeVector<3> &potentials);

--- a/src/mrdft/XCFunctional.h
+++ b/src/mrdft/XCFunctional.h
@@ -76,6 +76,7 @@ public:
 
     int getNNodes() const;
     int getNPoints() const;
+    void allocateDensities();
 
     void buildGrid(double Z, const mrcpp::Coord<3> &R);
     void copyGrid(mrcpp::FunctionTreeVector<3> densities);
@@ -109,7 +110,7 @@ public:
     double calcEnergy();
     mrcpp::FunctionTreeVector<3> calcPotential();
 
-protected:
+private:
     int order;
     int nDensities;
     unsigned int mode;

--- a/src/mrdft/XCFunctional.h
+++ b/src/mrdft/XCFunctional.h
@@ -162,7 +162,6 @@ private:
 
     mrcpp::FunctionTree<3> *calcPotentialGGA(mrcpp::FunctionTree<3> &df_drho, mrcpp::FunctionTreeVector<3> &df_dgr);
 
-    mrcpp::FunctionTree<3> *calcGradDotPotDensVec(mrcpp::FunctionTree<3> &V, mrcpp::FunctionTreeVector<3> &rho);
 };
 
 } // namespace mrdft

--- a/src/mrdft/XCFunctional.h
+++ b/src/mrdft/XCFunctional.h
@@ -61,6 +61,7 @@
 namespace mrdft {
 
 enum class DensityType { Total, Alpha, Beta };
+enum class ModeType { Partial = 1, Potential = 2, Contracted = 3 };
 
 class XCFunctional final {
 public:
@@ -69,8 +70,9 @@ public:
     XCFunctional &operator=(const XCFunctional &func) = delete;
     ~XCFunctional();
 
-    bool hasDensity() const;
-    bool checkDensity(mrcpp::FunctionTreeVector<3> density) const;
+    bool hasDensity(int n_dens_a = 1
+                    ) const;
+    bool checkDensity(mrcpp::FunctionTreeVector<3> density, int n_dens = 1) const;
     mrcpp::FunctionTreeVector<3> &getDensityVector(DensityType type);
     mrcpp::FunctionTree<3> &getDensity(DensityType type, int index = 0);
 
@@ -138,7 +140,8 @@ private:
     void clearGrid(mrcpp::FunctionTreeVector<3> densities);
     int getInputLength() const { return xc_input_length(this->functional); }
     int getOutputLength() const { return xc_output_length(this->functional); }
-
+    int getContractedLength() const; 
+    
     void setup_partial();
     void setup_partial(mrcpp::FunctionTree<3> &rho_a, mrcpp::FunctionTree<3> &rho_b);
     void setup_partial(mrcpp::FunctionTree<3> &rho_t);

--- a/src/mrenum.h
+++ b/src/mrenum.h
@@ -1,0 +1,13 @@
+/*
+ *  \date Feb 22, 2018
+ *  \author Luca Frediani <luca-frediani@uit.no> \n
+ *          Hylleraas Centre for Quantum Molecular Sciences \n
+ *          UiT - The Arctic University of Norway
+ *
+ *  \breif Global enumerator structures
+ */
+
+#pragma once
+
+namespace DENSITY { enum class DensityType { Total, Spin, Alpha, Beta }; }
+

--- a/src/mrenum.h
+++ b/src/mrenum.h
@@ -10,4 +10,3 @@
 #pragma once
 
 namespace DENSITY { enum class DensityType { Total, Spin, Alpha, Beta }; }
-

--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -120,6 +120,7 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVect
     double rel_prec = prec;        // prec for rho_i = |x_i><phi_i| + |phi_i><x_i|
     double abs_prec = prec / N_el; // prec for rho = sum_i rho_i
 
+    //LUCA: rho_loc should get the "general" grid in order to make sure all densities are available on the same grid.
     Density rho_loc(false);
     if (&X == &Y) {
         density::compute_local_X(rel_prec, rho_loc, Phi, X, spin);

--- a/src/qmfunctions/density_utils.h
+++ b/src/qmfunctions/density_utils.h
@@ -32,10 +32,10 @@ namespace density {
 
 void allreduce_density(double prec, Density &rho_tot, Density &rho_loc);
 void compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp);
-void compute(double prec, Density &rho, OrbitalVector &Phi, int spin);
-void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &X, OrbitalVector &Y, int spin);
-void compute_local(double prec, Density &rho, OrbitalVector &Phi, int spin);
-void compute_local(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &X, OrbitalVector &Y, int spin);
+void compute(double prec, Density &rho, OrbitalVector &Phi, DENSITY::DensityType spin);
+void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &X, OrbitalVector &Y, DENSITY::DensityType spin);
+void compute_local(double prec, Density &rho, OrbitalVector &Phi, DENSITY::DensityType spin);
+void compute_local(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &X, OrbitalVector &Y, DENSITY::DensityType spin);
 
 } // namespace density
 } // namespace mrchem

--- a/src/qmoperators/two_electron/CoulombPotentialD1.cpp
+++ b/src/qmoperators/two_electron/CoulombPotentialD1.cpp
@@ -26,7 +26,7 @@ void CoulombPotentialD1::setupGlobalDensity(double prec) {
     Density &rho = this->density;
 
     Timer timer;
-    density::compute(prec, rho, Phi, DENSITY::Total);
+    density::compute(prec, rho, Phi, DENSITY::DensityType::Total);
     timer.stop();
     double t = timer.getWallTime();
     int n = rho.getNNodes(NUMBER::Total);

--- a/src/qmoperators/two_electron/CoulombPotentialD1.cpp
+++ b/src/qmoperators/two_electron/CoulombPotentialD1.cpp
@@ -47,7 +47,7 @@ void CoulombPotentialD1::setupLocalDensity(double prec) {
     Density &rho = this->density;
 
     Timer timer;
-    density::compute_local(prec, rho, Phi, DENSITY::Total);
+    density::compute_local(prec, rho, Phi, DENSITY::DensityType::Total);
     timer.stop();
     double t = timer.getWallTime();
     int n = rho.getNNodes(NUMBER::Total);

--- a/src/qmoperators/two_electron/CoulombPotentialD2.cpp
+++ b/src/qmoperators/two_electron/CoulombPotentialD2.cpp
@@ -48,7 +48,7 @@ void CoulombPotentialD2::setupLocalDensity(double prec) {
     OrbitalVector &Y = *this->orbitals_y;
 
     Timer timer;
-    density::compute_local(prec, rho, Phi, X, Y, DENSITY::Total);
+    density::compute_local(prec, rho, Phi, X, Y, DENSITY::DensityType::Total);
     timer.stop();
     double t = timer.getWallTime();
     int n = rho.getNNodes(NUMBER::Total);

--- a/src/qmoperators/two_electron/CoulombPotentialD2.cpp
+++ b/src/qmoperators/two_electron/CoulombPotentialD2.cpp
@@ -29,7 +29,7 @@ void CoulombPotentialD2::setupGlobalDensity(double prec) {
     OrbitalVector &Y = *this->orbitals_y;
 
     Timer timer;
-    density::compute(prec, rho, Phi, X, Y, DENSITY::Total);
+    density::compute(prec, rho, Phi, X, Y, DENSITY::DensityType::Total);
     timer.stop();
     double t = timer.getWallTime();
     int n = rho.getNNodes(NUMBER::Total);

--- a/src/qmoperators/two_electron/XCOperator.h
+++ b/src/qmoperators/two_electron/XCOperator.h
@@ -35,7 +35,7 @@ public:
     int getOrder() { return this->potential->getOrder(); }
     void setupDensity(double prec = -1.0) { this->potential->setupDensity(prec); }
     void setupPotential(double prec = -1.0) { this->potential->setupPotential(prec); }
-    mrcpp::FunctionTree<3> &getDensity(int spin) { return this->potential->getDensity(spin); }
+    mrcpp::FunctionTree<3> &getDensity(DENSITY::DensityType spin) { return this->potential->getDensity(spin); }
 
 private:
     XCPotential *potential;

--- a/src/qmoperators/two_electron/XCPotential.cpp
+++ b/src/qmoperators/two_electron/XCPotential.cpp
@@ -28,8 +28,16 @@ void XCPotential::setupDensity(double prec) {
         buildDensity(Phi, DENSITY::DensityType::Beta, prec);
         FunctionTree<3> &func_a = this->getDensity(DENSITY::DensityType::Alpha);
         FunctionTree<3> &func_b = this->getDensity(DENSITY::DensityType::Beta);
+        std::cout << "nnodes before  " << func_a.getNNodes()    << std::endl;
+        std::cout << "nnodes before  " << func_b.getNNodes()    << std::endl;
+        std::cout << "enodes before  " << func_a.getNEndNodes() << std::endl;
+        std::cout << "enodes before  " << func_b.getNEndNodes() << std::endl;
         while (mrcpp::refine_grid(func_a, func_b)) {}
         while (mrcpp::refine_grid(func_b, func_a)) {}
+        std::cout << "nnodes after   " << func_a.getNNodes()    << std::endl;
+        std::cout << "nnodes after   " << func_b.getNNodes()    << std::endl;
+        std::cout << "enodes after   " << func_a.getNEndNodes() << std::endl;
+        std::cout << "enodes after   " << func_b.getNEndNodes() << std::endl;
     } else {
         buildDensity(Phi, DENSITY::DensityType::Total, prec);
     }

--- a/src/qmoperators/two_electron/XCPotential.cpp
+++ b/src/qmoperators/two_electron/XCPotential.cpp
@@ -96,7 +96,7 @@ FunctionTree<3> &XCPotential::getPotential(int spin) {
 Orbital XCPotential::apply(Orbital phi) {
     QMPotential &V = *this;
     if (V.hasImag()) MSG_ERROR("Imaginary part of XC potential non-zero");
-    
+
     FunctionTree<3> &tree = getPotential(phi.spin());
     V.setReal(&tree);
     Orbital Vphi = QMPotential::apply(phi);

--- a/src/qmoperators/two_electron/XCPotential.cpp
+++ b/src/qmoperators/two_electron/XCPotential.cpp
@@ -88,7 +88,7 @@ FunctionTree<3> &XCPotential::getPotential(int spin) {
 Orbital XCPotential::apply(Orbital phi) {
     QMPotential &V = *this;
     if (V.hasImag()) MSG_ERROR("Imaginary part of XC potential non-zero");
-
+    
     FunctionTree<3> &tree = getPotential(phi.spin());
     V.setReal(&tree);
     Orbital Vphi = QMPotential::apply(phi);
@@ -96,6 +96,8 @@ Orbital XCPotential::apply(Orbital phi) {
 
     return Vphi;
 }
+
+
 
 //NOTE AFTER DISCUSSION WITH STIG: Need to move stuff that is
 //iteration-independent out of the response loop, so that all required

--- a/src/qmoperators/two_electron/XCPotential.cpp
+++ b/src/qmoperators/two_electron/XCPotential.cpp
@@ -24,14 +24,14 @@ void XCPotential::setupDensity(double prec) {
     if (this->orbitals == nullptr) MSG_ERROR("Orbitals not initialized");
     OrbitalVector &Phi = *this->orbitals;
     if (this->functional->isSpinSeparated()) {
-        buildDensity(Phi, DENSITY::Alpha, prec);
-        buildDensity(Phi, DENSITY::Beta, prec);
-        FunctionTree<3> &func_a = this->getDensity(DENSITY::Alpha);
-        FunctionTree<3> &func_b = this->getDensity(DENSITY::Beta);
+        buildDensity(Phi, DENSITY::DensityType::Alpha, prec);
+        buildDensity(Phi, DENSITY::DensityType::Beta, prec);
+        FunctionTree<3> &func_a = this->getDensity(DENSITY::DensityType::Alpha);
+        FunctionTree<3> &func_b = this->getDensity(DENSITY::DensityType::Beta);
         while (mrcpp::refine_grid(func_a, func_b)) {}
         while (mrcpp::refine_grid(func_b, func_a)) {}
     } else {
-        buildDensity(Phi, DENSITY::Total, prec);
+        buildDensity(Phi, DENSITY::DensityType::Total, prec);
     }
 }
 
@@ -42,7 +42,7 @@ void XCPotential::clear() {
     clearApplyPrec();
 }
 
-void XCPotential::buildDensity(OrbitalVector &Phi, int spin, double prec) {
+void XCPotential::buildDensity(OrbitalVector &Phi, DENSITY::DensityType spin, double prec) {
     Timer time;
     time.start();
     FunctionTree<3> &func = this->getDensity(spin);
@@ -54,11 +54,8 @@ void XCPotential::buildDensity(OrbitalVector &Phi, int spin, double prec) {
     Printer::printTree(0, "XC GS density", func.getNNodes(), time.getWallTime());
 }
 
-mrcpp::FunctionTree<3> &XCPotential::getDensity(int spin) {
-    if (spin == DENSITY::Total) return this->functional->getDensity(mrdft::DensityType::Total);
-    if (spin == DENSITY::Alpha) return this->functional->getDensity(mrdft::DensityType::Alpha);
-    if (spin == DENSITY::Beta) return this->functional->getDensity(mrdft::DensityType::Beta);
-    MSG_FATAL("Invalid density type");
+mrcpp::FunctionTree<3> &XCPotential::getDensity(DENSITY::DensityType spin) {
+    return this->functional->getDensity(spin);
 }
 
 /** @brief Return FunctionTree for the XC spin potential

--- a/src/qmoperators/two_electron/XCPotential.cpp
+++ b/src/qmoperators/two_electron/XCPotential.cpp
@@ -54,8 +54,8 @@ void XCPotential::buildDensity(OrbitalVector &Phi, DENSITY::DensityType spin, do
     Printer::printTree(0, "XC GS density", func.getNNodes(), time.getWallTime());
 }
 
-mrcpp::FunctionTree<3> &XCPotential::getDensity(DENSITY::DensityType spin) {
-    return this->functional->getDensity(spin);
+mrcpp::FunctionTree<3> &XCPotential::getDensity(DENSITY::DensityType spin, int index) {
+    return this->functional->getDensity(spin, index);
 }
 
 /** @brief Return FunctionTree for the XC spin potential

--- a/src/qmoperators/two_electron/XCPotential.cpp
+++ b/src/qmoperators/two_electron/XCPotential.cpp
@@ -24,37 +24,26 @@ void XCPotential::setupDensity(double prec) {
     if (this->orbitals == nullptr) MSG_ERROR("Orbitals not initialized");
     OrbitalVector &Phi = *this->orbitals;
     if (this->functional->isSpinSeparated()) {
-        Timer time_a;
-        FunctionTree<3> &func_a = this->getDensity(DENSITY::Alpha);
-        Density rho_a(false);
-        rho_a.setReal(&func_a);
-        density::compute(prec, rho_a, Phi, DENSITY::Alpha);
-        rho_a.setReal(nullptr);
-        time_a.stop();
-        Printer::printTree(0, "XC alpha density", func_a.getNNodes(), time_a.getWallTime());
-
-        Timer time_b;
-        FunctionTree<3> &func_b = this->getDensity(DENSITY::Beta);
-        Density rho_b(false);
-        rho_b.setReal(&func_b);
-        density::compute(prec, rho_b, Phi, DENSITY::Beta);
-        rho_b.setReal(nullptr);
-        time_b.stop();
-        Printer::printTree(0, "XC beta density", func_b.getNNodes(), time_b.getWallTime());
-
-        // Extend to union grid
+        buildDensity(DENSITY::Alpha, prec);
+        buildDensity(DENSITY::Beta, prec);
+        FunctionTree<3> &func = this->getDensity(DENSITY::Alpha);
+        FunctionTree<3> &func = this->getDensity(DENSITY::Beta);
         while (mrcpp::refine_grid(func_a, func_b)) {}
         while (mrcpp::refine_grid(func_b, func_a)) {}
     } else {
-        Timer time_t;
-        FunctionTree<3> &func_t = this->getDensity(DENSITY::Total);
-        Density rho_t(false);
-        rho_t.setReal(&func_t);
-        density::compute(prec, rho_t, Phi, DENSITY::Total);
-        rho_t.setReal(nullptr);
-        time_t.stop();
-        Printer::printTree(0, "XC total density", func_t.getNNodes(), time_t.getWallTime());
+        buildDensity(DENSITY::Total, prec);
     }
+}
+
+void XCPotential::buildDensity(int spin, double prec) {
+    Timer time;
+    FunctionTree<3> &func = this->getDensity(spin);
+    Density rho(false);
+    rho.setReal(&func);
+    density::compute(prec, rho, Phi, spin);
+    rho.setReal(nullptr);
+    time_a.stop();
+    Printer::printTree(0, "XC GS density", func.getNNodes(), time.getWallTime());
 }
 
 mrcpp::FunctionTree<3> &XCPotential::getDensity(int spin) {
@@ -64,9 +53,49 @@ mrcpp::FunctionTree<3> &XCPotential::getDensity(int spin) {
     MSG_FATAL("Invalid density type");
 }
 
-// NOTE AFTER DISCUSSION WITH STIG: Need to move stuff that is
-// iteration-independent out of the response loop, so that all required
-// functions, which only depend on the GS density are computed
-// once. Comment: still the grid for rho_1 is borrowed from rho_0 and
-// rho_0 should still be available.
+/** @brief Return FunctionTree for the XC spin potential
+ *
+ * @param[in] type Which spin potential to return (alpha, beta or total)
+ */
+FunctionTree<3> &XCPotential::getPotential(int spin) {
+    bool spinFunctional = this->functional->isSpinSeparated();
+    int pot_idx = -1;
+    if (spinFunctional and spin == SPIN::Alpha) {
+        pot_idx = 0;
+    } else if (spinFunctional and spin == SPIN::Beta) {
+        pot_idx = 1;
+    } else if (not spinFunctional) {
+        pot_idx = 0;
+    } else {
+        NOT_IMPLEMENTED_ABORT;
+    }
+    return mrcpp::get_func(this->potentials, pot_idx);
+}
+
+/** @brief XCPotentialD1 application
+ *
+ * @param[in] phi Orbital to which the potential is applied
+ *
+ * The operator is applied by choosing the correct potential function
+ * which is then assigned to the real function part of the operator
+ * base-class before the base class function is called.
+ */
+Orbital XCPotential::apply(Orbital phi) {
+    QMPotential &V = *this;
+    if (V.hasImag()) MSG_ERROR("Imaginary part of XC potential non-zero");
+
+    FunctionTree<3> &tree = getPotential(phi.spin());
+    V.setReal(&tree);
+    Orbital Vphi = QMPotential::apply(phi);
+    V.setReal(nullptr);
+
+    return Vphi;
+}
+
+//NOTE AFTER DISCUSSION WITH STIG: Need to move stuff that is
+//iteration-independent out of the response loop, so that all required
+//functions, which only depend on the GS density are computed
+//once. Comment: still the grid for rho_1 is borrowed from rho_0 and
+//rho_0 should still be available.
+
 } // namespace mrchem

--- a/src/qmoperators/two_electron/XCPotential.cpp
+++ b/src/qmoperators/two_electron/XCPotential.cpp
@@ -24,25 +24,33 @@ void XCPotential::setupDensity(double prec) {
     if (this->orbitals == nullptr) MSG_ERROR("Orbitals not initialized");
     OrbitalVector &Phi = *this->orbitals;
     if (this->functional->isSpinSeparated()) {
-        buildDensity(DENSITY::Alpha, prec);
-        buildDensity(DENSITY::Beta, prec);
-        FunctionTree<3> &func = this->getDensity(DENSITY::Alpha);
-        FunctionTree<3> &func = this->getDensity(DENSITY::Beta);
+        buildDensity(Phi, DENSITY::Alpha, prec);
+        buildDensity(Phi, DENSITY::Beta, prec);
+        FunctionTree<3> &func_a = this->getDensity(DENSITY::Alpha);
+        FunctionTree<3> &func_b = this->getDensity(DENSITY::Beta);
         while (mrcpp::refine_grid(func_a, func_b)) {}
         while (mrcpp::refine_grid(func_b, func_a)) {}
     } else {
-        buildDensity(DENSITY::Total, prec);
+        buildDensity(Phi, DENSITY::Total, prec);
     }
 }
 
-void XCPotential::buildDensity(int spin, double prec) {
+/** @brief Clears all data in the XCPotential object */
+void XCPotential::clear() {
+    this->energy = 0.0;
+    mrcpp::clear(this->potentials, true);
+    clearApplyPrec();
+}
+
+void XCPotential::buildDensity(OrbitalVector &Phi, int spin, double prec) {
     Timer time;
+    time.start();
     FunctionTree<3> &func = this->getDensity(spin);
     Density rho(false);
     rho.setReal(&func);
     density::compute(prec, rho, Phi, spin);
     rho.setReal(nullptr);
-    time_a.stop();
+    time.stop();
     Printer::printTree(0, "XC GS density", func.getNNodes(), time.getWallTime());
 }
 

--- a/src/qmoperators/two_electron/XCPotential.h
+++ b/src/qmoperators/two_electron/XCPotential.h
@@ -48,7 +48,7 @@ protected:
     double getEnergy() const { return this->energy; }
     int getOrder() const { return this->functional->getOrder(); }
 
-    mrcpp::FunctionTree<3> &getDensity(DENSITY::DensityType spin);
+    mrcpp::FunctionTree<3> &getDensity(DENSITY::DensityType spin, int index = 0);
     virtual void setupPotential(double prec) {}
     mrcpp::FunctionTree<3> &getPotential(int spin);
     Orbital apply(Orbital phi);

--- a/src/qmoperators/two_electron/XCPotential.h
+++ b/src/qmoperators/two_electron/XCPotential.h
@@ -4,8 +4,8 @@
 #include "parallel.h"
 #include "qmoperators/one_electron/QMPotential.h"
 
-/** @class XCPotential
- *
+/** 
+ * @class XCPotential
  * @brief Exchange-Correlation potential defined by a particular (spin) density
  *
  * The XC potential is computed by mapping of the density through a XC functional,
@@ -23,6 +23,7 @@
  *
  * LDA and GGA functionals are supported as well as two different ways to compute
  * the XC potentials: either with explicit derivatives or gamma-type derivatives.
+ *
  */
 
 namespace mrchem {

--- a/src/qmoperators/two_electron/XCPotential.h
+++ b/src/qmoperators/two_electron/XCPotential.h
@@ -48,8 +48,9 @@ protected:
 
     mrcpp::FunctionTree<3> &getDensity(int spin);
     virtual void setupPotential(double prec) {}
-    virtual Orbital apply(Orbital phi) = 0;
-
+    FunctionTree<3> getPotential(int spin);
+    Orbital apply(Orbital phi);
+    void buildDensity(int spin, double prec = -1.0);
     void setupDensity(double prec = -1.0);
 };
 

--- a/src/qmoperators/two_electron/XCPotential.h
+++ b/src/qmoperators/two_electron/XCPotential.h
@@ -47,12 +47,12 @@ protected:
     double getEnergy() const { return this->energy; }
     int getOrder() const { return this->functional->getOrder(); }
 
-    mrcpp::FunctionTree<3> &getDensity(int spin);
+    mrcpp::FunctionTree<3> &getDensity(DENSITY::DensityType spin);
     virtual void setupPotential(double prec) {}
     mrcpp::FunctionTree<3> &getPotential(int spin);
     Orbital apply(Orbital phi);
     void clear();
-    void buildDensity(OrbitalVector &Phi, int spin, double prec = -1.0);
+    void buildDensity(OrbitalVector &Phi, DENSITY::DensityType spin, double prec = -1.0);
     void setupDensity(double prec = -1.0);
 };
 

--- a/src/qmoperators/two_electron/XCPotential.h
+++ b/src/qmoperators/two_electron/XCPotential.h
@@ -39,18 +39,20 @@ public:
     friend class XCOperator;
 
 protected:
-    double energy;                   ///< XC energy
-    OrbitalVector *orbitals;         ///< External set of orbitals used to build the density
-    mrdft::XCFunctional *functional; ///< External XC functional to be used
+    double energy;                           ///< XC energy
+    OrbitalVector *orbitals;                 ///< External set of orbitals used to build the density
+    mrdft::XCFunctional *functional;         ///< External XC functional to be used
+    mrcpp::FunctionTreeVector<3> potentials; ///< XC Potential functions collected in a vector
 
     double getEnergy() const { return this->energy; }
     int getOrder() const { return this->functional->getOrder(); }
 
     mrcpp::FunctionTree<3> &getDensity(int spin);
     virtual void setupPotential(double prec) {}
-    FunctionTree<3> getPotential(int spin);
+    mrcpp::FunctionTree<3> &getPotential(int spin);
     Orbital apply(Orbital phi);
-    void buildDensity(int spin, double prec = -1.0);
+    void clear();
+    void buildDensity(OrbitalVector &Phi, int spin, double prec = -1.0);
     void setupDensity(double prec = -1.0);
 };
 

--- a/src/qmoperators/two_electron/XCPotentialD1.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD1.cpp
@@ -82,43 +82,4 @@ void XCPotentialD1::setupPotential(double prec) {
     this->functional->clear();
 }
 
-/** @brief Return FunctionTree for the XC spin potential
- *
- * @param[in] type Which spin potential to return (alpha, beta or total)
- */
-FunctionTree<3> &XCPotentialD1::getPotential(int spin) {
-    bool spinFunctional = this->functional->isSpinSeparated();
-    int pot_idx = -1;
-    if (spinFunctional and spin == SPIN::Alpha) {
-        pot_idx = 0;
-    } else if (spinFunctional and spin == SPIN::Beta) {
-        pot_idx = 1;
-    } else if (not spinFunctional) {
-        pot_idx = 0;
-    } else {
-        NOT_IMPLEMENTED_ABORT;
-    }
-    return mrcpp::get_func(this->potentials, pot_idx);
-}
-
-/** @brief XCPotentialD1 application
- *
- * @param[in] phi Orbital to which the potential is applied
- *
- * The operator is applied by choosing the correct potential function
- * which is then assigned to the real function part of the operator
- * base-class before the base class function is called.
- */
-Orbital XCPotentialD1::apply(Orbital phi) {
-    QMPotential &V = *this;
-    if (V.hasImag()) MSG_ERROR("Imaginary part of XC potential non-zero");
-
-    FunctionTree<3> &tree = getPotential(phi.spin());
-    V.setReal(&tree);
-    Orbital Vphi = QMPotential::apply(phi);
-    V.setReal(nullptr);
-
-    return Vphi;
-}
-
-} // namespace mrchem
+} //namespace mrchem

--- a/src/qmoperators/two_electron/XCPotentialD1.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD1.cpp
@@ -46,13 +46,6 @@ void XCPotentialD1::setup(double prec) {
     setupPotential(prec);
 }
 
-/** @brief Clears all data in the XCPotentialD1 object */
-void XCPotentialD1::clear() {
-    this->energy = 0.0;
-    mrcpp::clear(this->potentials, true);
-    clearApplyPrec();
-}
-
 /** @brief Compute XC potential(s)
  *
  * @param prec Precision used in refinement of density grid

--- a/src/qmoperators/two_electron/XCPotentialD1.h
+++ b/src/qmoperators/two_electron/XCPotentialD1.h
@@ -36,9 +36,6 @@ private:
     void clear();
 
     void setupPotential(double prec);
-    mrcpp::FunctionTree<3> &getPotential(int spin);
-
-    Orbital apply(Orbital phi);
 };
 
 } // namespace mrchem

--- a/src/qmoperators/two_electron/XCPotentialD1.h
+++ b/src/qmoperators/two_electron/XCPotentialD1.h
@@ -30,11 +30,7 @@ public:
     XCPotentialD1(mrdft::XCFunctional *F, OrbitalVector *Phi = nullptr);
 
 private:
-    mrcpp::FunctionTreeVector<3> potentials; ///< XC Potential functions collected in a vector
-
     void setup(double prec);
-    void clear();
-
     void setupPotential(double prec);
 };
 

--- a/src/qmoperators/two_electron/XCPotentialD2.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD2.cpp
@@ -65,25 +65,25 @@ void XCPotentialD2::setupPerturbedDensity(double prec) {
     OrbitalVector &Y = *this->orbitals_y;
 
     if (this->functional->isSpinSeparated()) {
-        buildPerturbedDensity(Phi, X, Y, DENSITY::Alpha);
-        buildPerturbedDensity(Phi, X, Y, DENSITY::Beta);
+        buildPerturbedDensity(Phi, X, Y, DENSITY::DensityType::Alpha);
+        buildPerturbedDensity(Phi, X, Y, DENSITY::DensityType::Beta);
     } else {
-        buildPerturbedDensity(Phi, X, Y, DENSITY::Total);
+        buildPerturbedDensity(Phi, X, Y, DENSITY::DensityType::Total);
     }
 }
 
 void XCPotentialD2::buildPerturbedDensity(OrbitalVector &Phi,
                                           OrbitalVector &X,
                                           OrbitalVector &Y,
-                                          int density_spin) {
+                                          DENSITY::DensityType density_spin) {
     Timer time;
     FunctionTree<3> &rho = this->getDensity(density_spin);
     Density *pert_dens = new Density(false);
-    mrcpp::build_grid(*pert_dens.real(), rho);
+    mrcpp::build_grid(pert_dens->real(), rho);
     density::compute(-1.0, *pert_dens, Phi, X, Y, density_spin);
     time.stop();
-    Printer::printTree(0, "XC perturbed density", *pert_dens.getNNodes(NUMBER::Total), time.getWallTime());
-    this->functional->setDensity(*pert_dens.real(), density_spin, 1);
+    Printer::printTree(0, "XC perturbed density", pert_dens->getNNodes(NUMBER::Total), time.getWallTime());
+    this->functional->setDensity(pert_dens->real(), density_spin, 1);
 }
 
 /** @brief Compute XC potential(s)

--- a/src/qmoperators/two_electron/XCPotentialD2.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD2.cpp
@@ -84,7 +84,7 @@ void XCPotentialD2::buildPerturbedDensity(double prec,
     pert_dens.setReal(&rho_pert);
     density::compute(prec, pert_dens, Phi, X, Y, density_spin); //LUCA: precision and grid refinenemt problem to be discussed
     while (mrcpp::refine_grid(rho_pert, rho)) {}
-    //    while (mrcpp::refine_grid(rho, rho_pert)) {}
+    while (mrcpp::refine_grid(rho, rho_pert)) {}  //LUCA: this does not work with open shell
     time.stop();
     Printer::printTree(0, "XC perturbed density", pert_dens.getNNodes(NUMBER::Total), time.getWallTime());
     pert_dens.setReal(nullptr); //Otherwise the FunctionTree object is deleted

--- a/src/qmoperators/two_electron/XCPotentialD2.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD2.cpp
@@ -82,7 +82,7 @@ void XCPotentialD2::buildPerturbedDensity(double prec,
     FunctionTree<3> &rho_pert = this->getDensity(density_spin, 1);
     Density pert_dens(false);
     pert_dens.setReal(&rho_pert);
-    density::compute(-1.0, pert_dens, Phi, X, Y, density_spin); //LUCA: precision and grid refinenemt problem to be discussed
+    density::compute(prec, pert_dens, Phi, X, Y, density_spin); //LUCA: precision and grid refinenemt problem to be discussed
     while (mrcpp::refine_grid(rho_pert, rho)) {}
     //    while (mrcpp::refine_grid(rho, rho_pert)) {}
     time.stop();

--- a/src/qmoperators/two_electron/XCPotentialD2.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD2.cpp
@@ -77,13 +77,15 @@ void XCPotentialD2::buildPerturbedDensity(OrbitalVector &Phi,
                                           OrbitalVector &Y,
                                           DENSITY::DensityType density_spin) {
     Timer time;
-    FunctionTree<3> &rho = this->getDensity(density_spin);
-    Density *pert_dens = new Density(false);
-    mrcpp::build_grid(pert_dens->real(), rho);
-    density::compute(-1.0, *pert_dens, Phi, X, Y, density_spin);
+    FunctionTree<3> &rho = this->getDensity(density_spin, 0);
+    FunctionTree<3> &rho_pert = this->getDensity(density_spin, 1);
+    Density pert_dens(false);
+    pert_dens.setReal(&rho_pert);
+    density::compute(-1.0, pert_dens, Phi, X, Y, density_spin); //LUCA: precision and grid refinenemt problem to be discussed
+    while (mrcpp::refine_grid(rho_pert, rho)) {}
+    pert_dens.setReal(nullptr); //Otherwise the FunctionTree object is deleted
     time.stop();
-    Printer::printTree(0, "XC perturbed density", pert_dens->getNNodes(NUMBER::Total), time.getWallTime());
-    this->functional->setDensity(pert_dens->real(), density_spin, 1);
+    Printer::printTree(0, "XC perturbed density", pert_dens.getNNodes(NUMBER::Total), time.getWallTime());
 }
 
 /** @brief Compute XC potential(s)

--- a/src/qmoperators/two_electron/XCPotentialD2.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD2.cpp
@@ -52,6 +52,7 @@ void XCPotentialD2::setup(double prec) {
     setApplyPrec(prec);
     setupDensity(prec);
     setupPerturbedDensity(prec);
+    syncGrids();
     setupPotential(prec);
 }
 
@@ -83,8 +84,8 @@ void XCPotentialD2::buildPerturbedDensity(double prec,
     Density pert_dens(false);
     pert_dens.setReal(&rho_pert);
     density::compute(prec, pert_dens, Phi, X, Y, density_spin); //LUCA: precision and grid refinenemt problem to be discussed
-    while (mrcpp::refine_grid(rho_pert, rho)) {}
-    while (mrcpp::refine_grid(rho, rho_pert)) {}  //LUCA: this does not work with open shell
+    //    while (mrcpp::refine_grid(rho_pert, rho)) {}
+    //    while (mrcpp::refine_grid(rho, rho_pert)) {}  //LUCA: this does not work with open shell
     time.stop();
     Printer::printTree(0, "XC perturbed density", pert_dens.getNNodes(NUMBER::Total), time.getWallTime());
     pert_dens.setReal(nullptr); //Otherwise the FunctionTree object is deleted
@@ -127,4 +128,21 @@ void XCPotentialD2::setupPotential(double prec) {
     println(0, " XC grid change " << std::setw(26) << newNodes << std::setw(17) << newPoints);
 }
 
+void XCPotentialD2::syncGrids() {
+    if (this->functional->isSpinSeparated()) {
+        FunctionTree<3> &rho1 = this->getDensity(DENSITY::DensityType::Alpha, 0);
+        FunctionTree<3> &rho2 = this->getDensity(DENSITY::DensityType::Alpha, 1);
+        FunctionTree<3> &rho3 = this->getDensity(DENSITY::DensityType::Beta, 0);
+        FunctionTree<3> &rho4 = this->getDensity(DENSITY::DensityType::Beta, 1);
+        while (mrcpp::refine_grid(rho1, rho2)) {};
+        while (mrcpp::refine_grid(rho2, rho3)) {};
+        while (mrcpp::refine_grid(rho3, rho4)) {};
+        while (mrcpp::refine_grid(rho4, rho1)) {};
+    } else {
+        FunctionTree<3> &rho1 = this->getDensity(DENSITY::DensityType::Total, 0);
+        FunctionTree<3> &rho2 = this->getDensity(DENSITY::DensityType::Total, 1);
+        while (mrcpp::refine_grid(rho1, rho2)) {};
+        while (mrcpp::refine_grid(rho2, rho1)) {};
+    }
+}
 } // namespace mrchem

--- a/src/qmoperators/two_electron/XCPotentialD2.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD2.cpp
@@ -84,10 +84,10 @@ void XCPotentialD2::buildPerturbedDensity(double prec,
     pert_dens.setReal(&rho_pert);
     density::compute(-1.0, pert_dens, Phi, X, Y, density_spin); //LUCA: precision and grid refinenemt problem to be discussed
     while (mrcpp::refine_grid(rho_pert, rho)) {}
-    while (mrcpp::refine_grid(rho, rho_pert)) {}
+    //    while (mrcpp::refine_grid(rho, rho_pert)) {}
+    time.stop();
     Printer::printTree(0, "XC perturbed density", pert_dens.getNNodes(NUMBER::Total), time.getWallTime());
     pert_dens.setReal(nullptr); //Otherwise the FunctionTree object is deleted
-    time.stop();
 }
 
 /** @brief Compute XC potential(s)

--- a/src/qmoperators/two_electron/XCPotentialD2.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD2.cpp
@@ -65,14 +65,15 @@ void XCPotentialD2::setupPerturbedDensity(double prec) {
     OrbitalVector &Y = *this->orbitals_y;
 
     if (this->functional->isSpinSeparated()) {
-        buildPerturbedDensity(Phi, X, Y, DENSITY::DensityType::Alpha);
-        buildPerturbedDensity(Phi, X, Y, DENSITY::DensityType::Beta);
+        buildPerturbedDensity(prec, Phi, X, Y, DENSITY::DensityType::Alpha);
+        buildPerturbedDensity(prec, Phi, X, Y, DENSITY::DensityType::Beta);
     } else {
-        buildPerturbedDensity(Phi, X, Y, DENSITY::DensityType::Total);
+        buildPerturbedDensity(prec, Phi, X, Y, DENSITY::DensityType::Total);
     }
 }
 
-void XCPotentialD2::buildPerturbedDensity(OrbitalVector &Phi,
+void XCPotentialD2::buildPerturbedDensity(double prec,
+                                          OrbitalVector &Phi,
                                           OrbitalVector &X,
                                           OrbitalVector &Y,
                                           DENSITY::DensityType density_spin) {
@@ -83,9 +84,10 @@ void XCPotentialD2::buildPerturbedDensity(OrbitalVector &Phi,
     pert_dens.setReal(&rho_pert);
     density::compute(-1.0, pert_dens, Phi, X, Y, density_spin); //LUCA: precision and grid refinenemt problem to be discussed
     while (mrcpp::refine_grid(rho_pert, rho)) {}
+    while (mrcpp::refine_grid(rho, rho_pert)) {}
+    Printer::printTree(0, "XC perturbed density", pert_dens.getNNodes(NUMBER::Total), time.getWallTime());
     pert_dens.setReal(nullptr); //Otherwise the FunctionTree object is deleted
     time.stop();
-    Printer::printTree(0, "XC perturbed density", pert_dens.getNNodes(NUMBER::Total), time.getWallTime());
 }
 
 /** @brief Compute XC potential(s)

--- a/src/qmoperators/two_electron/XCPotentialD2.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD2.cpp
@@ -83,17 +83,17 @@ void XCPotentialD2::setupPerturbedDensity(double prec) {
     OrbitalVector &Y = *this->orbitals_y;
 
     if (this->functional->isSpinSeparated()) {
-        this->pertDensity_a = buildPerturbedDensity(Phi, X, Y, DENSITY::Alpha);
-        this->pertDensity_b = buildPerturbedDensity(Phi, X, Y, DENSITY::Beta);
+        buildPerturbedDensity(Phi, X, Y, DENSITY::Alpha);
+        buildPerturbedDensity(Phi, X, Y, DENSITY::Beta);
     } else {
-        this->pertDensity_t = buildPerturbedDensity(Phi, X, Y, DENSITY::Total);
+        buildPerturbedDensity(Phi, X, Y, DENSITY::Total);
     }
 }
 
-Density *XCPotentialD2::buildPerturbedDensity(OrbitalVector &Phi,
-                                              OrbitalVector &X,
-                                              OrbitalVector &Y,
-                                              int density_spin) {
+void XCPotentialD2::buildPerturbedDensity(OrbitalVector &Phi,
+                                          OrbitalVector &X,
+                                          OrbitalVector &Y,
+                                          int density_spin) {
     Timer time;
     FunctionTree<3> &rho = this->getDensity(density_spin);
     pert_dens = new Density(false);
@@ -102,8 +102,7 @@ Density *XCPotentialD2::buildPerturbedDensity(OrbitalVector &Phi,
     density::compute(-1.0, dRho, Phi, X, Y, density_spin);
     time.stop();
     Printer::printTree(0, "XC perturbed density", dRho_b.getNNodes(NUMBER::Total), time_b.getWallTime());
-    FunctionTreeVector<3> & dv = this->functional->getDensityVector(density_spin);
-    dv.push_back(std::make_tuple(1.0, dRho.real()));
+    this->functional->setDensity;
 }
 
 /** @brief Compute XC potential(s)

--- a/src/qmoperators/two_electron/XCPotentialD2.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD2.cpp
@@ -56,9 +56,9 @@ XCPotentialD2::~XCPotentialD2() {
 void XCPotentialD2::setup(double prec) {
     if (isSetup(prec)) return;
     setApplyPrec(prec);
-    // setupDensity(prec);
+    setupDensity(prec);
     setupPerturbedDensity(prec);
-    // setupPotential(prec);
+    setupPotential(prec);
 }
 
 /** @brief Clears all data in the XCPotentialD2 object */
@@ -75,38 +75,35 @@ void XCPotentialD2::clear() {
 
 // LUCA This does not work in the case of a non spin separated functional used for an open-shell system!!
 void XCPotentialD2::setupPerturbedDensity(double prec) {
-    if (this->orbitals_x == nullptr) MSG_ERROR("Orbitals not initialized");
-    if (this->orbitals_y == nullptr) MSG_ERROR("Orbitals not initialized");
+    if (this->orbitals == nullptr) MSG_ERROR("Orbitals not initialized");
+    if (this->orbitals_x == nullptr) MSG_ERROR("X-Orbitals not initialized");
+    if (this->orbitals_y == nullptr) MSG_ERROR("Y-Orbitals not initialized");
     OrbitalVector &Phi = *this->orbitals;
     OrbitalVector &X = *this->orbitals_x;
     OrbitalVector &Y = *this->orbitals_y;
 
     if (this->functional->isSpinSeparated()) {
-        this->pertDensity_a = new Density(false);
-        this->pertDensity_b = new Density(false);
-        Density &dRho_a = *this->pertDensity_a;
-        Density &dRho_b = *this->pertDensity_b;
-        Timer time_a;
-        density::compute(prec, dRho_a, Phi, X, Y, DENSITY::Alpha);
-        time_a.stop();
-        Printer::printTree(0, "XC perturbed alpha density", dRho_a.getNNodes(NUMBER::Total), time_a.getWallTime());
-
-        Timer time_b;
-        density::compute(prec, dRho_b, Phi, X, Y, DENSITY::Beta);
-        time_b.stop();
-        Printer::printTree(0, "XC perturbed beta density", dRho_b.getNNodes(NUMBER::Total), time_b.getWallTime());
-
-        // Extend to union grid
-        while (mrcpp::refine_grid(dRho_a.real(), dRho_b.real())) {}
-        while (mrcpp::refine_grid(dRho_b.real(), dRho_a.real())) {}
+        this->pertDensity_a = buildPerturbedDensity(Phi, X, Y, DENSITY::Alpha);
+        this->pertDensity_b = buildPerturbedDensity(Phi, X, Y, DENSITY::Beta);
     } else {
-        this->pertDensity_t = new Density(false);
-        Density &dRho_t = *this->pertDensity_t;
-        Timer time_t;
-        density::compute(prec, dRho_t, Phi, X, Y, DENSITY::Total);
-        time_t.stop();
-        Printer::printTree(0, "XC perturbed total density", dRho_t.getNNodes(NUMBER::Total), time_t.getWallTime());
+        this->pertDensity_t = buildPerturbedDensity(Phi, X, Y, DENSITY::Total);
     }
+}
+
+Density *XCPotentialD2::buildPerturbedDensity(OrbitalVector &Phi,
+                                              OrbitalVector &X,
+                                              OrbitalVector &Y,
+                                              int density_spin) {
+    Timer time;
+    FunctionTree<3> &rho = this->getDensity(density_spin);
+    pert_dens = new Density(false);
+    Density &dRho = *pert_dens;
+    mrcpp::build_grid(dRho.real(), rho);
+    density::compute(-1.0, dRho, Phi, X, Y, density_spin);
+    time.stop();
+    Printer::printTree(0, "XC perturbed density", dRho_b.getNNodes(NUMBER::Total), time_b.getWallTime());
+    FunctionTreeVector<3> & dv = this->functional->getDensityVector(density_spin);
+    dv.push_back(std::make_tuple(1.0, dRho.real()));
 }
 
 /** @brief Compute XC potential(s)
@@ -144,318 +141,6 @@ void XCPotentialD2::setupPotential(double prec) {
 
     println(0, " XC grid size   " << std::setw(26) << inpNodes << std::setw(17) << inpPoints);
     println(0, " XC grid change " << std::setw(26) << newNodes << std::setw(17) << newPoints);
-}
-
-/** @brief Return FunctionTree for the XC spin potential
- *
- * @param[in] type Which spin potential to return (alpha, beta or total)
- */
-FunctionTree<3> &XCPotentialD2::getPotential(int orbitalSpin, int densitySpin) {
-    int pot_idx = XCPotentialD2::getPotentialIndex(orbitalSpin, densitySpin);
-    return mrcpp::get_func(this->potentials, pot_idx);
-}
-
-int XCPotentialD2::getPotentialIndex(int orbitalSpin, int densitySpin) {
-
-    int spinFunctional = this->functional->isSpinSeparated() ? 1 : 0;
-
-    // Potential order (spin separated): v_aa, v_ab, v_bb
-    // Potential order (spin restricted, total density only): v_rr
-
-    int functional_case = spinFunctional; // 0  1
-    functional_case += orbitalSpin << 1;  // 0  2  4  6
-    functional_case += densitySpin << 3;  // 0  8 16 24
-
-    // OS Paired Alpha Beta
-    // DS Total  Spin  Alpha Beta
-
-    // SF    OS             DS          case   Index
-    switch (functional_case) {
-        //  0     0 (paired)     0 (total)     0
-        case (0):
-            return 0;
-        //  1     0 (paired)     0 (total)     1    not valid
-        //  0     1 (alpha )     0 (total)     2
-        case (2):
-            return 0;
-        //  1     1 (alpha )     0 (total)     3    not valid
-        //  0     2 (beta  )     0 (total)     4
-        case (4):
-            return 0;
-        //  1     2 (beta  )     0 (total)     5    not valid
-        //  0     3 (unused)     0 (total)     6    not valid
-        //  1     3 (unused)     0 (total)     7    not valid
-        //  0     0 (paired)     1 (spin )     8    not valid
-        //  1     0 (paired)     1 (spin )     9    not valid
-        //  0     1 (alpha )     1 (spin )    10    not valid
-        //  1     1 (alpha )     1 (spin )    11    not valid
-        //  0     2 (beta  )     1 (spin )    12    not valid
-        //  1     2 (beta  )     1 (spin )    13    not valid
-        //  0     3 (unused)     1 (spin )    14    not valid
-        //  1     3 (unused)     1 (spin )    15    not valid
-        //  0     0 (paired)     2 (alpha)    16    not implemented
-        //  1     0 (paired)     2 (alpha)    17    not implemented
-        //  0     1 (alpha )     2 (alpha)    18    not valid
-        //  1     1 (alpha )     2 (alpha)    19
-        case (19):
-            return 0;
-        //  0     2 (beta  )     2 (alpha)    20    not valid
-        //  1     2 (beta  )     2 (alpha)    21
-        case (21):
-            return 1;
-        //  0     3 (unused)     2 (alpha)    22    not valid
-        //  1     3 (unused)     2 (alpha)    23    not valid
-        //  0     0 (paired)     3 (beta )    24    not implemented
-        //  1     0 (paired)     3 (beta )    25    not implemented
-        //  0     1 (alpha )     3 (beta )    26    not valid
-        //  1     1 (alpha )     3 (beta )    27
-        case (27):
-            return 1;
-        //  0     2 (beta  )     3 (beta )    28    not valid
-        //  1     2 (beta  )     3 (beta )    29
-        case (29):
-            return 2;
-        //  0     3 (unused)     3 (beta )    30    not valid
-        //  1     3 (unused)     3 (beta )    31    not valid
-        default:
-            NOT_IMPLEMENTED_ABORT;
-    }
-
-    return -1;
-}
-
-/** @brief XCPotentialD2 application
- *
- * @param[in] phi Orbital to which the potential is applied
- *
- * The operator is applied by choosing the correct potential function
- * which is then assigned to the real function part of the operator
- * base-class before the base class function is called.
- */
-Orbital XCPotentialD2::apply(Orbital phi) {
-    bool spinSeparated = this->functional->isSpinSeparated();
-    bool totalDens = (pertDensity_t != nullptr);
-    bool alphaDens = (pertDensity_a != nullptr);
-    bool betaDens = (pertDensity_b != nullptr);
-
-    if (totalDens and (alphaDens or betaDens))
-        MSG_ERROR("Total density and spin separated densities are both available");
-
-    FunctionTree<3> *Vrho = new FunctionTree<3>(*MRA);
-    mrcpp::FunctionTreeVector<3> components;
-    if (not spinSeparated and totalDens) {
-        FunctionTree<3> *component = buildComponent(phi.spin(), DENSITY::Total, pertDensity_t->real());
-        components.push_back(std::make_tuple(1.0, component));
-    } else if (spinSeparated) {
-        if (totalDens) NOT_IMPLEMENTED_ABORT;
-        if (alphaDens) {
-            FunctionTree<3> *component = buildComponent(phi.spin(), DENSITY::Alpha, pertDensity_a->real());
-            components.push_back(std::make_tuple(1.0, component));
-        }
-        if (betaDens) {
-            FunctionTree<3> *component = buildComponent(phi.spin(), DENSITY::Beta, pertDensity_b->real());
-            components.push_back(std::make_tuple(1.0, component));
-        }
-    } else {
-        NOT_IMPLEMENTED_ABORT;
-    }
-
-    mrcpp::build_grid(*Vrho, components); // LUCA just using "add" results in loss of precision.
-    mrcpp::add(-1.0, *Vrho, components);
-    this->setReal(Vrho);
-    Orbital Vrhophi = QMPotential::apply(phi);
-    this->setReal(nullptr);
-    delete Vrho;
-    mrcpp::clear(components, true);
-    return Vrhophi;
-}
-
-FunctionTree<3> *XCPotentialD2::buildComponent(int orbital_spin, int density_spin, FunctionTree<3> &pert_dens) {
-    FunctionTree<3> *component = nullptr;
-    if (this->functional->isLDA()) {
-        component = buildComponentLDA(orbital_spin, density_spin, pert_dens);
-    } else if (this->functional->useGamma()) {
-        component = buildComponentGamma(orbital_spin, density_spin, pert_dens);
-    } else {
-        component = buildComponentGrad(orbital_spin, density_spin, pert_dens);
-    }
-    return component;
-}
-
-FunctionTree<3> *XCPotentialD2::buildComponentGrad(int orbital_spin, int density_spin, FunctionTree<3> &pert_dens) {
-    mrcpp::DerivativeOperator<3> *derivative = new mrcpp::ABGVOperator<3>(*MRA, 0.0, 0.0);
-    FunctionTree<3> &rho = this->getDensity(DENSITY::Total);
-    mrcpp::FunctionTreeVector<3> densities;
-    densities.push_back(std::make_tuple(1.0, &rho));
-    densities.push_back(std::make_tuple(1.0, &pert_dens));
-    mrcpp::FunctionTreeVector<3> grad_eta = mrcpp::gradient(*derivative, pert_dens);
-    mrcpp::FunctionTreeVector<3> d2fdrdg(potentials.begin() + 1, potentials.begin() + 4);
-    mrcpp::FunctionTreeVector<3> d2fdgdgx(potentials.begin() + 4, potentials.begin() + 7);
-    mrcpp::FunctionTreeVector<3> d2fdgdgy;
-    d2fdgdgy.push_back(potentials[5]); // yx --> xy
-    d2fdgdgy.push_back(potentials[7]); // yy
-    d2fdgdgy.push_back(potentials[8]); // yz
-    mrcpp::FunctionTreeVector<3> d2fdgdgz;
-    d2fdgdgz.push_back(potentials[6]); // zx --> xz
-    d2fdgdgz.push_back(potentials[8]); // zy --> yz
-    d2fdgdgz.push_back(potentials[9]); // zz
-
-    mrcpp::FunctionTree<3> *prod1 = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*prod1, densities);
-    mrcpp::multiply(-1.0, *prod1, 1.0, mrcpp::get_func(potentials, 0), pert_dens);
-
-    mrcpp::FunctionTree<3> *prod2 = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*prod2, densities);
-    mrcpp::dot(-1.0, *prod2, d2fdrdg, grad_eta);
-
-    mrcpp::FunctionTree<3> *prod3 = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*prod3, densities);
-    mrcpp::multiply(-1.0, *prod3, 1.0, mrcpp::get_func(potentials, 1), pert_dens);
-
-    mrcpp::FunctionTree<3> *prod4 = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*prod4, densities);
-    mrcpp::multiply(-1.0, *prod4, 1.0, mrcpp::get_func(potentials, 2), pert_dens);
-
-    mrcpp::FunctionTree<3> *prod5 = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*prod5, densities);
-    mrcpp::multiply(-1.0, *prod5, 1.0, mrcpp::get_func(potentials, 3), pert_dens);
-
-    mrcpp::FunctionTree<3> *prod6 = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*prod6, densities);
-    mrcpp::dot(-1.0, *prod6, d2fdgdgx, grad_eta);
-
-    mrcpp::FunctionTree<3> *prod7 = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*prod7, densities);
-    mrcpp::dot(-1.0, *prod7, d2fdgdgy, grad_eta);
-
-    mrcpp::FunctionTree<3> *prod8 = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*prod8, densities);
-    mrcpp::dot(-1.0, *prod8, d2fdgdgz, grad_eta);
-    mrcpp::clear(grad_eta, true);
-
-    mrcpp::FunctionTree<3> *sum_36 = new FunctionTree<3>(*MRA);
-    mrcpp::FunctionTree<3> *sum_47 = new FunctionTree<3>(*MRA);
-    mrcpp::FunctionTree<3> *sum_58 = new FunctionTree<3>(*MRA);
-
-    mrcpp::FunctionTreeVector<3> temp_div1;
-    temp_div1.push_back(std::make_tuple(1.0, prod3));
-    temp_div1.push_back(std::make_tuple(1.0, prod4));
-    temp_div1.push_back(std::make_tuple(1.0, prod5));
-    mrcpp::FunctionTreeVector<3> temp_div2;
-    temp_div2.push_back(std::make_tuple(1.0, prod6));
-    temp_div2.push_back(std::make_tuple(1.0, prod7));
-    temp_div2.push_back(std::make_tuple(1.0, prod8));
-
-    mrcpp::FunctionTree<3> *div1 = new FunctionTree<3>(*MRA);
-    mrcpp::divergence(*div1, *derivative, temp_div1);
-    mrcpp::clear(temp_div1, true);
-    mrcpp::FunctionTree<3> *div2 = new FunctionTree<3>(*MRA);
-    mrcpp::divergence(*div2, *derivative, temp_div2);
-    mrcpp::clear(temp_div2, true);
-
-    mrcpp::FunctionTreeVector<3> temp_sum;
-    temp_sum.push_back(std::make_tuple(1.0, prod1));
-    temp_sum.push_back(std::make_tuple(1.0, prod2));
-    temp_sum.push_back(std::make_tuple(-1.0, div1));
-    temp_sum.push_back(std::make_tuple(-1.0, div2));
-
-    mrcpp::FunctionTree<3> *component = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*component, densities);
-    mrcpp::add(-1.0, *component, temp_sum);
-    mrcpp::clear(temp_sum, true);
-
-    mrcpp::clear(d2fdrdg, false);
-    mrcpp::clear(d2fdgdgx, false);
-    mrcpp::clear(d2fdgdgy, false);
-    mrcpp::clear(d2fdgdgz, false);
-    return component;
-}
-
-FunctionTree<3> *XCPotentialD2::buildComponentGamma(int orbital_spin, int density_spin, FunctionTree<3> &pert_dens) {
-    mrcpp::DerivativeOperator<3> *derivative = new mrcpp::ABGVOperator<3>(*MRA, 0.0, 0.0);
-    FunctionTree<3> &rho = this->getDensity(DENSITY::Total);
-    mrcpp::FunctionTreeVector<3> densities;
-    densities.push_back(std::make_tuple(1.0, &rho));
-    densities.push_back(std::make_tuple(1.0, &pert_dens));
-    mrcpp::FunctionTreeVector<3> grad_rho = mrcpp::gradient(*derivative, rho);
-    mrcpp::FunctionTreeVector<3> grad_eta = mrcpp::gradient(*derivative, pert_dens);
-    mrcpp::FunctionTree<3> *gr_dot_gpr = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*gr_dot_gpr, densities); // All functions shall use the same grid here...
-    mrcpp::dot(-1.0, *gr_dot_gpr, grad_rho, grad_eta);
-
-    mrcpp::FunctionTree<3> *prod1 = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*prod1, densities);
-    mrcpp::multiply(-1.0, *prod1, 1.0, mrcpp::get_func(potentials, 1), pert_dens);
-
-    mrcpp::FunctionTree<3> *prod2 = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*prod2, densities);
-    mrcpp::multiply(-1.0, *prod2, 1.0, mrcpp::get_func(potentials, 2), *gr_dot_gpr);
-
-    mrcpp::FunctionTree<3> *prod3 = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*prod3, densities);
-    mrcpp::multiply(-1.0, *prod3, 1.0, mrcpp::get_func(potentials, 2), pert_dens);
-
-    mrcpp::FunctionTree<3> *prod4 = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*prod4, densities);
-    mrcpp::multiply(-1.0, *prod4, 1.0, mrcpp::get_func(potentials, 3), *gr_dot_gpr);
-    delete gr_dot_gpr;
-
-    mrcpp::FunctionTree<3> *div3 = calcGradDotPotDensVec(*prod3, grad_rho);
-    delete prod3;
-    mrcpp::FunctionTree<3> *div4 = calcGradDotPotDensVec(*prod4, grad_rho);
-    delete prod4;
-    mrcpp::clear(grad_rho, true);
-
-    mrcpp::FunctionTree<3> *div2 = calcGradDotPotDensVec(mrcpp::get_func(potentials, 0), grad_eta);
-    mrcpp::clear(grad_eta, true);
-
-    mrcpp::FunctionTree<3> *sum_42 = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*sum_42, densities);
-    mrcpp::add(-1.0, *sum_42, 2.0, *div4, 1.0, *div2);
-    delete div2;
-    delete div4;
-
-    mrcpp::FunctionTreeVector<3> temp_fun;
-
-    temp_fun.push_back(std::make_tuple(1.0, prod1));
-    temp_fun.push_back(std::make_tuple(2.0, prod2));
-    temp_fun.push_back(std::make_tuple(-2.0, div3));
-    temp_fun.push_back(std::make_tuple(-2.0, sum_42));
-
-    mrcpp::FunctionTree<3> *component = new FunctionTree<3>(*MRA);
-    mrcpp::build_grid(*component, densities);
-    mrcpp::add(-1.0, *component, temp_fun);
-
-    mrcpp::clear(densities, false);
-    mrcpp::clear(temp_fun, true);
-    delete derivative;
-    return component;
-}
-
-// Copied from XCFunctional. Ideally it should end up in mrcpp
-FunctionTree<3> *XCPotentialD2::calcGradDotPotDensVec(mrcpp::FunctionTree<3> &V, mrcpp::FunctionTreeVector<3> &rho) {
-    mrcpp::DerivativeOperator<3> *derivative = new mrcpp::ABGVOperator<3>(*MRA, 0.0, 0.0);
-    mrcpp::FunctionTreeVector<3> vec;
-    for (int d = 0; d < rho.size(); d++) {
-        mrcpp::FunctionTree<3> &rho_d = mrcpp::get_func(rho, d);
-        mrcpp::FunctionTree<3> *Vrho = new FunctionTree<3>(*MRA);
-        mrcpp::copy_grid(*Vrho, rho_d);
-        mrcpp::multiply(-1.0, *Vrho, 1.0, V, rho_d);
-        vec.push_back(std::make_tuple(1.0, Vrho));
-    }
-    mrcpp::FunctionTree<3> *result = new FunctionTree<3>(*MRA);
-    mrcpp::divergence(*result, *derivative, vec);
-    mrcpp::clear(vec, true);
-    return result;
-}
-
-FunctionTree<3> *XCPotentialD2::buildComponentLDA(int orbital_spin, int density_spin, FunctionTree<3> &pert_dens) {
-    FunctionTree<3> *tmp = new FunctionTree<3>(*MRA);
-    FunctionTree<3> &V = getPotential(orbital_spin, density_spin);
-    mrcpp::build_grid(*tmp, V);
-    mrcpp::build_grid(*tmp, pert_dens);
-    mrcpp::multiply(-1.0, *tmp, 1.0, V, pert_dens);
-    return tmp;
 }
 
 } // namespace mrchem

--- a/src/qmoperators/two_electron/XCPotentialD2.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD2.cpp
@@ -29,16 +29,10 @@ namespace mrchem {
 XCPotentialD2::XCPotentialD2(mrdft::XCFunctional *F, OrbitalVector *Phi, OrbitalVector *X, OrbitalVector *Y)
         : XCPotential(F, Phi)
         , orbitals_x(X)
-        , orbitals_y(Y)
-        , pertDensity_t(nullptr)
-        , pertDensity_a(nullptr)
-        , pertDensity_b(nullptr) {}
+        , orbitals_y(Y) {}
 
 XCPotentialD2::~XCPotentialD2() {
     mrcpp::clear(this->potentials, true);
-    if (this->pertDensity_t != nullptr) MSG_FATAL("Operator not properly cleared");
-    if (this->pertDensity_a != nullptr) MSG_FATAL("Operator not properly cleared");
-    if (this->pertDensity_b != nullptr) MSG_FATAL("Operator not properly cleared");
 }
 
 /** @brief Prepare the operator for application
@@ -59,18 +53,6 @@ void XCPotentialD2::setup(double prec) {
     setupDensity(prec);
     setupPerturbedDensity(prec);
     setupPotential(prec);
-}
-
-/** @brief Clears all data in the XCPotentialD2 object */
-void XCPotentialD2::clear() {
-    this->energy = 0.0;
-    if (this->pertDensity_t != nullptr) delete this->pertDensity_t;
-    if (this->pertDensity_a != nullptr) delete this->pertDensity_a;
-    if (this->pertDensity_b != nullptr) delete this->pertDensity_b;
-    this->pertDensity_t = nullptr;
-    this->pertDensity_a = nullptr;
-    this->pertDensity_b = nullptr;
-    clearApplyPrec();
 }
 
 // LUCA This does not work in the case of a non spin separated functional used for an open-shell system!!
@@ -96,13 +78,12 @@ void XCPotentialD2::buildPerturbedDensity(OrbitalVector &Phi,
                                           int density_spin) {
     Timer time;
     FunctionTree<3> &rho = this->getDensity(density_spin);
-    pert_dens = new Density(false);
-    Density &dRho = *pert_dens;
-    mrcpp::build_grid(dRho.real(), rho);
-    density::compute(-1.0, dRho, Phi, X, Y, density_spin);
+    Density *pert_dens = new Density(false);
+    mrcpp::build_grid(*pert_dens.real(), rho);
+    density::compute(-1.0, *pert_dens, Phi, X, Y, density_spin);
     time.stop();
-    Printer::printTree(0, "XC perturbed density", dRho_b.getNNodes(NUMBER::Total), time_b.getWallTime());
-    this->functional->setDensity;
+    Printer::printTree(0, "XC perturbed density", *pert_dens.getNNodes(NUMBER::Total), time.getWallTime());
+    this->functional->setDensity(*pert_dens.real(), density_spin, 1);
 }
 
 /** @brief Compute XC potential(s)

--- a/src/qmoperators/two_electron/XCPotentialD2.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD2.cpp
@@ -134,10 +134,22 @@ void XCPotentialD2::syncGrids() {
         FunctionTree<3> &rho2 = this->getDensity(DENSITY::DensityType::Alpha, 1);
         FunctionTree<3> &rho3 = this->getDensity(DENSITY::DensityType::Beta, 0);
         FunctionTree<3> &rho4 = this->getDensity(DENSITY::DensityType::Beta, 1);
+        int n1b = rho1.getNNodes();
+        int n2b = rho2.getNNodes();
+        int n3b = rho3.getNNodes();
+        int n4b = rho4.getNNodes();
+        std::cout << "Before " << n1b << " "  << n2b << " "  << n3b << " "  << n4b << std::endl;
         while (mrcpp::refine_grid(rho1, rho2)) {};
-        while (mrcpp::refine_grid(rho2, rho3)) {};
-        while (mrcpp::refine_grid(rho3, rho4)) {};
+        while (mrcpp::refine_grid(rho1, rho3)) {};
+        while (mrcpp::refine_grid(rho1, rho4)) {};
+        while (mrcpp::refine_grid(rho2, rho1)) {};
+        while (mrcpp::refine_grid(rho3, rho1)) {};
         while (mrcpp::refine_grid(rho4, rho1)) {};
+        int n1a = rho1.getNNodes();
+        int n2a = rho2.getNNodes();
+        int n3a = rho3.getNNodes();
+        int n4a = rho4.getNNodes();
+        std::cout << "After  " << n1a << " "  << n2a << " "  << n3a << " "  << n4a << std::endl;
     } else {
         FunctionTree<3> &rho1 = this->getDensity(DENSITY::DensityType::Total, 0);
         FunctionTree<3> &rho2 = this->getDensity(DENSITY::DensityType::Total, 1);

--- a/src/qmoperators/two_electron/XCPotentialD2.h
+++ b/src/qmoperators/two_electron/XCPotentialD2.h
@@ -37,7 +37,8 @@ private:
 
     void setup(double prec);
     void setupPotential(double prec);
-    void buildPerturbedDensity(OrbitalVector &Phi,
+    void buildPerturbedDensity(double prec,
+                               OrbitalVector &Phi,
                                OrbitalVector &X,
                                OrbitalVector &Y,
                                DENSITY::DensityType spin);

--- a/src/qmoperators/two_electron/XCPotentialD2.h
+++ b/src/qmoperators/two_electron/XCPotentialD2.h
@@ -44,6 +44,7 @@ private:
                                DENSITY::DensityType spin);
 
     void setupPerturbedDensity(double prec = -1.0);
+    void syncGrids();
 };
 
 } // namespace mrchem

--- a/src/qmoperators/two_electron/XCPotentialD2.h
+++ b/src/qmoperators/two_electron/XCPotentialD2.h
@@ -34,26 +34,15 @@ public:
 private:
     OrbitalVector *orbitals_x;               ///< 1st external set of perturbed orbitals used to build the density
     OrbitalVector *orbitals_y;               ///< 2nd external set of perturbed orbitals used to build the density
-    mrcpp::FunctionTreeVector<3> potentials; ///< XC Potential functions collected in a vector
 
     void setup(double prec);
-    void clear();
-
     void setupPotential(double prec);
-    mrcpp::FunctionTree<3> &getPotential(int orbitalSpin, int densitySpin);
-    mrcpp::FunctionTree<3> *buildComponent(int orbital_spin, int density_spin, mrcpp::FunctionTree<3> &pert_dens);
-    mrcpp::FunctionTree<3> *buildComponentGamma(int orbital_spin, int density_spin, mrcpp::FunctionTree<3> &pert_dens);
-    mrcpp::FunctionTree<3> *buildComponentGrad(int orbital_spin, int density_spin, mrcpp::FunctionTree<3> &pert_dens);
-    mrcpp::FunctionTree<3> *buildComponentLDA(int orbital_spin, int density_spin, mrcpp::FunctionTree<3> &pert_dens);
+    void buildPerturbedDensity(OrbitalVector &Phi,
+                               OrbitalVector &X,
+                               OrbitalVector &Y,
+                               int density_spin);
 
-    Orbital apply(Orbital phi);
-
-    // LUCA I wanted to include the following declarations in the cpp
-    // file but i did not manage to get the syntax (copied from
-    // density_utils.copp) right.
-    int getPotentialIndex(int orbitalSpin, int densitySpin);
     void setupPerturbedDensity(double prec = -1.0);
-    mrcpp::FunctionTree<3> *calcGradDotPotDensVec(mrcpp::FunctionTree<3> &V, mrcpp::FunctionTreeVector<3> &rho);
 };
 
 } // namespace mrchem

--- a/src/qmoperators/two_electron/XCPotentialD2.h
+++ b/src/qmoperators/two_electron/XCPotentialD2.h
@@ -40,7 +40,7 @@ private:
     void buildPerturbedDensity(OrbitalVector &Phi,
                                OrbitalVector &X,
                                OrbitalVector &Y,
-                               int density_spin);
+                               DENSITY::DensityType spin);
 
     void setupPerturbedDensity(double prec = -1.0);
 };

--- a/src/qmoperators/two_electron/XCPotentialD2.h
+++ b/src/qmoperators/two_electron/XCPotentialD2.h
@@ -35,9 +35,6 @@ private:
     OrbitalVector *orbitals_x;               ///< 1st external set of perturbed orbitals used to build the density
     OrbitalVector *orbitals_y;               ///< 2nd external set of perturbed orbitals used to build the density
     mrcpp::FunctionTreeVector<3> potentials; ///< XC Potential functions collected in a vector
-    Density *pertDensity_t;                  ///< total first-order perturbed electronic density
-    Density *pertDensity_a;                  ///< alpha first-order perturbed electronic density
-    Density *pertDensity_b;                  ///< beta  first-order perturbed electronic density
 
     void setup(double prec);
     void clear();

--- a/tests/qmfunctions/density.cpp
+++ b/tests/qmfunctions/density.cpp
@@ -65,8 +65,8 @@ TEST_CASE("Density", "[density]") {
             Density rho_t(false);
             Density rho_s(false);
 
-            density::compute(prec, rho_t, Phi, DENSITY::Total);
-            density::compute(prec, rho_s, Phi, DENSITY::Spin);
+            density::compute(prec, rho_t, Phi, DENSITY::DensityType::Total);
+            density::compute(prec, rho_s, Phi, DENSITY::DensityType::Spin);
 
             REQUIRE(rho_t.integrate().real() == Approx(7.0));
             REQUIRE(rho_s.integrate().real() == Approx(3.0));
@@ -76,8 +76,8 @@ TEST_CASE("Density", "[density]") {
             Density rho_a(true);
             Density rho_b(true);
 
-            density::compute(prec, rho_a, Phi, DENSITY::Alpha);
-            density::compute(prec, rho_b, Phi, DENSITY::Beta);
+            density::compute(prec, rho_a, Phi, DENSITY::DensityType::Alpha);
+            density::compute(prec, rho_b, Phi, DENSITY::DensityType::Beta);
 
             REQUIRE(rho_a.integrate().real() == Approx(5.0));
             REQUIRE(rho_b.integrate().real() == Approx(2.0));

--- a/tests/qmoperators/xc_hessian.cpp
+++ b/tests/qmoperators/xc_hessian.cpp
@@ -102,6 +102,8 @@ TEST_CASE("XCHessian", "[xc_hessian]") {
     fun.setUseGamma(true);
     fun.setDensityCutoff(1.0e-10);
     fun.evalSetup(MRDFT::Hessian);
+    fun.setNDensities(1);
+    fun.allocateDensities();
     XCOperator V(&fun, &Phi, &Phi_x, &Phi_x);
 
     V.setup(prec);

--- a/tests/qmoperators/xc_hessian.cpp
+++ b/tests/qmoperators/xc_hessian.cpp
@@ -102,13 +102,11 @@ TEST_CASE("XCHessian", "[xc_hessian]") {
     fun.setUseGamma(true);
     fun.setDensityCutoff(1.0e-10);
     fun.evalSetup(MRDFT::Hessian);
-    fun.setNDensities(1);
+    fun.setNDensities(2);
     fun.allocateDensities();
-    XCOperator V(&fun, &Phi, &Phi_x, &Phi_x);
 
+    XCOperator V(&fun, &Phi, &Phi_x, &Phi_x);
     V.setup(prec);
-    V.setupDensity(prec);
-    V.setupPotential(prec);
 
     SECTION("apply") {
         Orbital Vphi_0 = V(Phi[0]);

--- a/tests/qmoperators/xc_hessian_pbe.cpp
+++ b/tests/qmoperators/xc_hessian_pbe.cpp
@@ -99,17 +99,15 @@ TEST_CASE("XCHessianPBE", "[xc_hessian_pbe]") {
 
     mrdft::XCFunctional fun(*MRA, false);
     fun.setFunctional("PBE", 1.0);
-    fun.setUseGamma(true);
+    fun.setUseGamma(false);
     fun.setDensityCutoff(1.0e-10);
     fun.evalSetup(MRDFT::Hessian);
-    fun.setNDensities(1);
+    fun.setNDensities(2);
     fun.allocateDensities();
-    XCOperator V(&fun, &Phi, &Phi_x, &Phi_x);
 
+    XCOperator V(&fun, &Phi, &Phi_x, &Phi_x);
     V.setup(prec);
-    V.setupDensity(prec);
-    V.setupPotential(prec);
-    V.setupDensity(prec);
+
     SECTION("apply") {
         Orbital Vphi_0 = V(Phi[0]);
         ComplexDouble V_00 = orbital::dot(Phi[0], Vphi_0);

--- a/tests/qmoperators/xc_hessian_pbe.cpp
+++ b/tests/qmoperators/xc_hessian_pbe.cpp
@@ -102,6 +102,8 @@ TEST_CASE("XCHessianPBE", "[xc_hessian_pbe]") {
     fun.setUseGamma(true);
     fun.setDensityCutoff(1.0e-10);
     fun.evalSetup(MRDFT::Hessian);
+    fun.setNDensities(1);
+    fun.allocateDensities();
     XCOperator V(&fun, &Phi, &Phi_x, &Phi_x);
 
     V.setup(prec);

--- a/tests/qmoperators/xc_operator.cpp
+++ b/tests/qmoperators/xc_operator.cpp
@@ -75,6 +75,8 @@ TEST_CASE("XCOperator", "[xc_operator]") {
     fun.setUseGamma(false);
     fun.setDensityCutoff(1.0e-10);
     fun.evalSetup(1);
+    fun.setNDensities(1);
+    fun.allocateDensities();
     XCOperator V(&fun, &Phi);
 
     // reference values obtained with a test run at order=9 in unit_test.cpp and prec=1.0e-5 here

--- a/tests/qmoperators/xc_operator_blyp.cpp
+++ b/tests/qmoperators/xc_operator_blyp.cpp
@@ -75,6 +75,8 @@ TEST_CASE("XCOperatorBLYP", "[xc_operator_blyp]") {
     fun.setUseGamma(false);
     fun.setDensityCutoff(1.0e-10);
     fun.evalSetup(1);
+    fun.setNDensities(1);
+    fun.allocateDensities();
     XCOperator V(&fun, &Phi);
 
     // reference values obtained with a test run at order=9 in unit_test.cpp and prec=1.0e-5 here


### PR DESCRIPTION
In order to handle the `CONTRACTED` mode of XCFun, we need to include perturbed densities in the `mrdft` interface. This is done by converting the original `FunctionTree` holding the density to a corresponding `FunctionTreeVector`.

Update: the `CONTRACTED` mode cannot be used (see [https://github.com/dftlibs/xcfun/issues/92]). I therefore need to fall back to the `PARTIAL_DERIVATIVE` mode, doing contractions on the fly for each node. The alternative would be to call XCFun four times at each response iteration, instead of one. I will call this mode `SEMI_CONTRACTED`.

- [x] Make the old `PARTIAL_DERIVATIVES` mode work with the new structure
- [x] `SEMI_CONTRACTED` mode for closed shell LDA SCF 
- [x] `SEMI_CONTRACTED` mode for closed shell LDA LR
- [x] `SEMI_CONTRACTED` mode for open shell LDA SCF 
- [x] `SEMI_CONTRACTED` mode for open shell LDA LR
- [x] `SEMI_CONTRACTED` mode for closed shell GGA SCF 
- [ ] `SEMI_CONTRACTED` mode for closed shell GGA LR
- [x] `SEMI_CONTRACTED` mode for open shell GGA SCF 
- [ ] `SEMI_CONTRACTED` mode for open shell GGA LR

The way densities are computed&stored is a total mess. I will restructure it as soon as I have a working code.
Todo wrt densities: 
1. store them in `XCFunctional` in a way that is easier to use/extend (conditional mess with LDA/GGA or CS/OS or GS/PERT and so on...)
2. Too many function vectors with nearly identical content.
3. The OS case with no beta density is currently not contemplated. This must be fixed. It is going to be easier when densities are restructured so that it is either one or two densities, where the one-density case is either alpha or total. 
4. `allocateDensities()` is conflicting with my "brilliant" (so to speak..) strategy to make sure I have the densities I need in the right place.
5. The calculation of the perturbed density and its gradient are too unstable, affecting the precision for GGA calculations. This MUST be fixed.