### PR TITLE
orbitalvector size printout routine

### DIFF
--- a/.githooks/pre-commit-license-maintainer
+++ b/.githooks/pre-commit-license-maintainer
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 TEXT="MRChem, a numerical real-space code for molecular electronic structure"
-AUTHORS="Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors."
+AUTHORS="Stig Rune Jensen, Luca Frediani, Peter Wind and contributors."
 
 python .githooks/license_maintainer.py "$TEXT" "$AUTHORS"

--- a/config.h.in
+++ b/config.h.in
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/analyticfunctions/HarmonicOscillatorFunction.h
+++ b/src/analyticfunctions/HarmonicOscillatorFunction.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/analyticfunctions/HydrogenFunction.cpp
+++ b/src/analyticfunctions/HydrogenFunction.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/analyticfunctions/HydrogenFunction.h
+++ b/src/analyticfunctions/HydrogenFunction.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/analyticfunctions/NuclearFunction.cpp
+++ b/src/analyticfunctions/NuclearFunction.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/analyticfunctions/NuclearFunction.h
+++ b/src/analyticfunctions/NuclearFunction.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/analyticfunctions/NuclearGradientFunction.cpp
+++ b/src/analyticfunctions/NuclearGradientFunction.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/analyticfunctions/NuclearGradientFunction.h
+++ b/src/analyticfunctions/NuclearGradientFunction.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/Cavity.cpp
+++ b/src/chemistry/Cavity.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/Cavity.h
+++ b/src/chemistry/Cavity.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/Element.h
+++ b/src/chemistry/Element.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/Molecule.cpp
+++ b/src/chemistry/Molecule.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/Molecule.h
+++ b/src/chemistry/Molecule.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/Nucleus.h
+++ b/src/chemistry/Nucleus.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/PeriodicTable.cpp
+++ b/src/chemistry/PeriodicTable.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/PeriodicTable.h
+++ b/src/chemistry/PeriodicTable.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/chemistry_fwd.h
+++ b/src/chemistry/chemistry_fwd.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/chemistry_utils.cpp
+++ b/src/chemistry/chemistry_utils.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/chemistry_utils.h
+++ b/src/chemistry/chemistry_utils.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/core.cpp
+++ b/src/initial_guess/core.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/core.h
+++ b/src/initial_guess/core.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/core_guess.cpp
+++ b/src/initial_guess/core_guess.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/gto.cpp
+++ b/src/initial_guess/gto.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/gto.h
+++ b/src/initial_guess/gto.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/gto_guess.cpp
+++ b/src/initial_guess/gto_guess.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/sad.cpp
+++ b/src/initial_guess/sad.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/sad.h
+++ b/src/initial_guess/sad.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/sad_guess.cpp
+++ b/src/initial_guess/sad_guess.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrchem.in
+++ b/src/mrchem.in
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
 
+
 #
 # MRChem, a numerical real-space code for molecular electronic structure
 # calculations within the self-consistent field (SCF) approximations of quantum
 # chemistry (Hartree-Fock and Density Functional Theory).
-# Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+# Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
 #
 # This file is part of MRChem.
 #

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/XCFunctional.h
+++ b/src/mrdft/XCFunctional.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/DipoleMoment.h
+++ b/src/properties/DipoleMoment.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/GeometryDerivatives.h
+++ b/src/properties/GeometryDerivatives.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/HyperFineCoupling.h
+++ b/src/properties/HyperFineCoupling.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/Magnetizability.h
+++ b/src/properties/Magnetizability.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/NMRShielding.h
+++ b/src/properties/NMRShielding.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/Polarizability.h
+++ b/src/properties/Polarizability.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/SCFEnergy.h
+++ b/src/properties/SCFEnergy.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/SpinSpinCoupling.h
+++ b/src/properties/SpinSpinCoupling.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/properties_fwd.h
+++ b/src/properties/properties_fwd.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/ComplexFunction.cpp
+++ b/src/qmfunctions/ComplexFunction.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/ComplexFunction.h
+++ b/src/qmfunctions/ComplexFunction.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/Density.cpp
+++ b/src/qmfunctions/Density.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/Density.h
+++ b/src/qmfunctions/Density.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/Orbital.cpp
+++ b/src/qmfunctions/Orbital.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/Orbital.h
+++ b/src/qmfunctions/Orbital.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/OrbitalIterator.cpp
+++ b/src/qmfunctions/OrbitalIterator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/OrbitalIterator.h
+++ b/src/qmfunctions/OrbitalIterator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/QMFunction.cpp
+++ b/src/qmfunctions/QMFunction.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/QMFunction.cpp
+++ b/src/qmfunctions/QMFunction.cpp
@@ -107,14 +107,16 @@ int QMFunction::getNNodes(int type) const {
     return nNodes;
 }
 
-void QMFunction::crop(double prec) {
-    if (prec < 0.0) return;
+int QMFunction::crop(double prec) {
+    if (prec < 0.0) return 0;
     bool need_to_crop = not(isShared()) or mpi::share_master();
+    int nChunksremoved = 0;
     if (need_to_crop) {
-        if (hasReal()) real().crop(prec, 1.0, false);
-        if (hasImag()) imag().crop(prec, 1.0, false);
+        if (hasReal()) nChunksremoved = real().crop(prec, 1.0, false);
+        if (hasImag()) nChunksremoved += imag().crop(prec, 1.0, false);
     }
     mpi::share_function(*this, 0, 7744, mpi::comm_share);
+    return nChunksremoved;
 }
 
 ComplexDouble QMFunction::integrate() const {

--- a/src/qmfunctions/QMFunction.h
+++ b/src/qmfunctions/QMFunction.h
@@ -66,7 +66,7 @@ public:
     double squaredNorm() const;
     ComplexDouble integrate() const;
 
-    void crop(double prec);
+    int crop(double prec);
     void rescale(double c);
     void rescale(ComplexDouble c);
     void add(ComplexDouble c, QMFunction inp);

--- a/src/qmfunctions/QMFunction.h
+++ b/src/qmfunctions/QMFunction.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/density_utils.h
+++ b/src/qmfunctions/density_utils.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/orbital_utils.cpp
+++ b/src/qmfunctions/orbital_utils.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -25,7 +25,6 @@
 
 #include "MRCPP/Printer"
 #include "MRCPP/Timer"
-#include "MRCPP/trees/SerialTree.h"
 
 #include "parallel.h"
 #include "utils/RRMaximizer.h"

--- a/src/qmfunctions/orbital_utils.cpp
+++ b/src/qmfunctions/orbital_utils.cpp
@@ -23,9 +23,9 @@
  * <https://mrchem.readthedocs.io/>
  */
 
-#include "MRCPP/trees/SerialTree.h"
 #include "MRCPP/Printer"
 #include "MRCPP/Timer"
+#include "MRCPP/trees/SerialTree.h"
 
 #include "parallel.h"
 #include "utils/RRMaximizer.h"
@@ -689,11 +689,11 @@ DoubleVector orbital::get_errors(const OrbitalVector &Phi) {
 int orbital::get_size_nodes(const OrbitalVector &Phi, IntVector &sNodes) {
     int nOrbs = Phi.size();
     int totsize = 0;
-    for (int i = 0; i < nOrbs; i++){
-        if( Phi[i].hasReal()){
-            double fac = Phi[i].real().getKp1_d()*8;//number of coeff in one node
-            fac *= sizeof(double);// Number of Bytes in one node
-            sNodes[i] = (int)(fac/1024 * Phi[i].getNNodes(NUMBER::Total)); //kBytes in one orbital
+    for (int i = 0; i < nOrbs; i++) {
+        if (Phi[i].hasReal()) {
+            double fac = Phi[i].real().getKp1_d() * 8;                       //number of coeff in one node
+            fac *= sizeof(double);                                           // Number of Bytes in one node
+            sNodes[i] = (int)(fac / 1024 * Phi[i].getNNodes(NUMBER::Total)); //kBytes in one orbital
             totsize += sNodes[i];
         }
     }
@@ -703,9 +703,14 @@ int orbital::get_size_nodes(const OrbitalVector &Phi, IntVector &sNodes) {
 /** @brief Prints statistics about the size of orbitals in an OrbitalVector
 *
 * This is a collective function. Can be made non-collective by setting all = false.
+* outputs respectively:
+* Total size of orbital vector, average per MPI, Max per MPI, Max (largest)
+* orbital, smallest orbital, max total (not only the orbitalvector) memory
+* usage among all MP, minimum total (not only the orbitalvector) memory
+* usage among all MPI
 *
 */
-int orbital::print_size_nodes(const OrbitalVector &Phi, char* txt, bool all) {
+int orbital::print_size_nodes(const OrbitalVector &Phi, char *txt, bool all) {
     int nOrbs = Phi.size();
     IntVector sNodes = IntVector::Zero(nOrbs);
     int sVec = get_size_nodes(Phi, sNodes);
@@ -714,10 +719,10 @@ int orbital::print_size_nodes(const OrbitalVector &Phi, char* txt, bool all) {
     double nSum = 0.0, vSum = 0.0;
     double nOwnOrbs = 0.0, OwnSumMax = 0.0, OwnSumMin = 9.9e9;
     double totMax = 0.0, totMin = 9.9e9;
-    if (mpi::orb_rank==0) std::cout<< "OrbitalVector sizes statistics "<< txt << " (MB)" << std::endl;
+    if (mpi::orb_rank == 0) std::cout << "OrbitalVector sizes statistics " << txt << " (MB)" << std::endl;
     //stats for own orbitals
-    for (int i = 0; i < nOrbs; i++){
-        if(sNodes[i] > 0){
+    for (int i = 0; i < nOrbs; i++) {
+        if (sNodes[i] > 0) {
             nOwnOrbs++;
             if (sNodes[i] > nMax) nMax = sNodes[i];
             if (sNodes[i] < nMin) nMin = sNodes[i];
@@ -727,43 +732,44 @@ int orbital::print_size_nodes(const OrbitalVector &Phi, char* txt, bool all) {
     if (nSum == 0.0) nMin = 0.0;
 
     DoubleMatrix VecStats = DoubleMatrix::Zero(5, mpi::orb_size);
-    VecStats(0,mpi::orb_rank) = nMax;
-    VecStats(1,mpi::orb_rank) = nMin;
-    VecStats(2,mpi::orb_rank) = nSum;
-    VecStats(3,mpi::orb_rank) = nOwnOrbs;
-    VecStats(4,mpi::orb_rank) = Printer::printMem("",true);
+    VecStats(0, mpi::orb_rank) = nMax;
+    VecStats(1, mpi::orb_rank) = nMin;
+    VecStats(2, mpi::orb_rank) = nSum;
+    VecStats(3, mpi::orb_rank) = nOwnOrbs;
+    VecStats(4, mpi::orb_rank) = Printer::printMem("", true);
 
-    if(all){
+    if (all) {
         mpi::allreduce_matrix(VecStats, mpi::comm_orb);
         //overall stats
-        for (int i = 0; i < mpi::orb_size; i++){
-            if (VecStats(0,i) > vMax) vMax = VecStats(0,i);
-            if (VecStats(1,i) < vMin) vMin = VecStats(1,i);
-            if (VecStats(2,i) > OwnSumMax) OwnSumMax = VecStats(2,i);
-            if (VecStats(2,i) < OwnSumMin) OwnSumMin = VecStats(2,i);
-            if (VecStats(4,i) > totMax) totMax = VecStats(4,i);
-            if (VecStats(4,i) < totMin) totMin = VecStats(4,i);
-            vSum += VecStats(2,i);
+        for (int i = 0; i < mpi::orb_size; i++) {
+            if (VecStats(0, i) > vMax) vMax = VecStats(0, i);
+            if (VecStats(1, i) < vMin) vMin = VecStats(1, i);
+            if (VecStats(2, i) > OwnSumMax) OwnSumMax = VecStats(2, i);
+            if (VecStats(2, i) < OwnSumMin) OwnSumMin = VecStats(2, i);
+            if (VecStats(4, i) > totMax) totMax = VecStats(4, i);
+            if (VecStats(4, i) < totMin) totMin = VecStats(4, i);
+            vSum += VecStats(2, i);
         }
-    }else{
+    } else {
         int i = mpi::orb_rank;
-        if (VecStats(0,i) > vMax) vMax = VecStats(0,i);
-        if (VecStats(1,i) < vMin) vMin = VecStats(1,i);
-        if (VecStats(2,i) > OwnSumMax) OwnSumMax = VecStats(2,i);
-        if (VecStats(2,i) < OwnSumMin) OwnSumMin = VecStats(2,i);
-        if (VecStats(4,i) > totMax) totMax = VecStats(4,i);
-        if (VecStats(4,i) < totMin) totMin = VecStats(4,i);
-        vSum += VecStats(2,i);
+        if (VecStats(0, i) > vMax) vMax = VecStats(0, i);
+        if (VecStats(1, i) < vMin) vMin = VecStats(1, i);
+        if (VecStats(2, i) > OwnSumMax) OwnSumMax = VecStats(2, i);
+        if (VecStats(2, i) < OwnSumMin) OwnSumMin = VecStats(2, i);
+        if (VecStats(4, i) > totMax) totMax = VecStats(4, i);
+        if (VecStats(4, i) < totMin) totMin = VecStats(4, i);
+        vSum += VecStats(2, i);
     }
-    totMax *= 4.0/(1024.0);
-    totMin *= 4.0/(1024.0);
-    if (mpi::orb_rank == 0) std::cout<<"Total orbvec "<<(int)vSum/(1024)<<", ";
-    if (mpi::orb_rank == 0) std::cout<<"Av/MPI "<<(int)vSum/(1024)/mpi::orb_size<<", ";
-    if (mpi::orb_rank == 0) std::cout<<"Max/MPI "<<(int)OwnSumMax/(1024)<<", ";
-    if (mpi::orb_rank == 0) std::cout<<"Max/orb "<<(int)vMax/(1024)<<", ";
-    if (mpi::orb_rank == 0) std::cout<<"Min/orb "<<(int)vMin/(1024)<<", ";
-    if (mpi::orb_rank == 0 and all ) std::cout<<"Total max "<<(int)totMax<<", Total min "<<(int)totMin<<" MB"<<std::endl;
-    if (mpi::orb_rank == 0 and not all ) std::cout<<"Total master "<<(int)totMax<<" MB"<<std::endl;
+    totMax *= 4.0 / (1024.0);
+    totMin *= 4.0 / (1024.0);
+    if (mpi::orb_rank == 0) std::cout << "Total orbvec " << (int)vSum / (1024) << ", ";
+    if (mpi::orb_rank == 0) std::cout << "Av/MPI " << (int)vSum / (1024) / mpi::orb_size << ", ";
+    if (mpi::orb_rank == 0) std::cout << "Max/MPI " << (int)OwnSumMax / (1024) << ", ";
+    if (mpi::orb_rank == 0) std::cout << "Max/orb " << (int)vMax / (1024) << ", ";
+    if (mpi::orb_rank == 0) std::cout << "Min/orb " << (int)vMin / (1024) << ", ";
+    if (mpi::orb_rank == 0 and all)
+        std::cout << "Total max " << (int)totMax << ", Total min " << (int)totMin << " MB" << std::endl;
+    if (mpi::orb_rank == 0 and not all) std::cout << "Total master " << (int)totMax << " MB" << std::endl;
 
     return vSum;
 }

--- a/src/qmfunctions/orbital_utils.cpp
+++ b/src/qmfunctions/orbital_utils.cpp
@@ -692,7 +692,7 @@ int orbital::get_size_nodes(const OrbitalVector &Phi, IntVector &sNodes) {
         if (Phi[i].hasReal()) {
             double fac = Phi[i].real().getKp1_d() * 8;                       //number of coeff in one node
             fac *= sizeof(double);                                           // Number of Bytes in one node
-            sNodes[i] = (int)(fac / 1024 * Phi[i].getNNodes(NUMBER::Total)); //kBytes in one orbital
+            sNodes[i] = static_cast<int>(fac / 1024 * Phi[i].getNNodes(NUMBER::Total)); //kBytes in one orbital
             totsize += sNodes[i];
         }
     }

--- a/src/qmfunctions/orbital_utils.cpp
+++ b/src/qmfunctions/orbital_utils.cpp
@@ -709,7 +709,7 @@ int orbital::get_size_nodes(const OrbitalVector &Phi, IntVector &sNodes) {
 * usage among all MPI
 *
 */
-int orbital::print_size_nodes(const OrbitalVector &Phi, char *txt, bool all) {
+    int orbital::print_size_nodes(const OrbitalVector &Phi, const std::string txt, bool all, int printLevl) {
     int nOrbs = Phi.size();
     IntVector sNodes = IntVector::Zero(nOrbs);
     int sVec = get_size_nodes(Phi, sNodes);
@@ -718,7 +718,7 @@ int orbital::print_size_nodes(const OrbitalVector &Phi, char *txt, bool all) {
     double nSum = 0.0, vSum = 0.0;
     double nOwnOrbs = 0.0, OwnSumMax = 0.0, OwnSumMin = 9.9e9;
     double totMax = 0.0, totMin = 9.9e9;
-    if (mpi::orb_rank == 0) std::cout << "OrbitalVector sizes statistics " << txt << " (MB)" << std::endl;
+    println(0, "OrbitalVector sizes statistics " << txt << " (MB)");
     //stats for own orbitals
     for (int i = 0; i < nOrbs; i++) {
         if (sNodes[i] > 0) {
@@ -761,15 +761,13 @@ int orbital::print_size_nodes(const OrbitalVector &Phi, char *txt, bool all) {
     }
     totMax *= 4.0 / (1024.0);
     totMin *= 4.0 / (1024.0);
-    if (mpi::orb_rank == 0) std::cout << "Total orbvec " << (int)vSum / (1024) << ", ";
-    if (mpi::orb_rank == 0) std::cout << "Av/MPI " << (int)vSum / (1024) / mpi::orb_size << ", ";
-    if (mpi::orb_rank == 0) std::cout << "Max/MPI " << (int)OwnSumMax / (1024) << ", ";
-    if (mpi::orb_rank == 0) std::cout << "Max/orb " << (int)vMax / (1024) << ", ";
-    if (mpi::orb_rank == 0) std::cout << "Min/orb " << (int)vMin / (1024) << ", ";
-    if (mpi::orb_rank == 0 and all)
-        std::cout << "Total max " << (int)totMax << ", Total min " << (int)totMin << " MB" << std::endl;
-    if (mpi::orb_rank == 0 and not all) std::cout << "Total master " << (int)totMax << " MB" << std::endl;
-
+    printout(printLevl, "Total orbvec " << static_cast<int>(vSum / 1024));
+    printout(printLevl, ", Av/MPI " << static_cast<int>(vSum / 1024 / mpi::orb_size));
+    printout(printLevl, ", Max/MPI " << static_cast<int>(OwnSumMax / 1024));
+    printout(printLevl, ", Max/orb " << static_cast<int>(vMax / 1024));
+    printout(printLevl, ", Min/orb " << static_cast<int>(vMin / 1024));
+    if ( all ) println(printLevl, ", Total max " << static_cast<int>(totMax) << ", Total min " << static_cast<int>(totMin) << " MB");
+    if ( not all ) println(printLevl, ", Total master " << static_cast<int>(totMax) << " MB");
     return vSum;
 }
 

--- a/src/qmfunctions/orbital_utils.h
+++ b/src/qmfunctions/orbital_utils.h
@@ -79,7 +79,7 @@ int get_electron_number(const OrbitalVector &Phi, int spin = SPIN::Paired);
 int start_index(const OrbitalVector &Phi, int spin);
 int get_n_nodes(const OrbitalVector &Phi);
 int get_size_nodes(const OrbitalVector &Phi, IntVector &sNodes);
-int print_size_nodes(const OrbitalVector &Phi, char *txt = "", bool all = true);
+int print_size_nodes(const OrbitalVector &Phi, const std::string txt= "", bool all = true, int printLevl = 0);
 bool orbital_vector_is_sane(const OrbitalVector &Phi);
 
 void set_spins(OrbitalVector &Phi, const IntVector &spins);

--- a/src/qmfunctions/orbital_utils.h
+++ b/src/qmfunctions/orbital_utils.h
@@ -79,7 +79,7 @@ int get_electron_number(const OrbitalVector &Phi, int spin = SPIN::Paired);
 int start_index(const OrbitalVector &Phi, int spin);
 int get_n_nodes(const OrbitalVector &Phi);
 int get_size_nodes(const OrbitalVector &Phi, IntVector &sNodes);
-int print_size_nodes(const OrbitalVector &Phi, char* txt="", bool all = true);
+int print_size_nodes(const OrbitalVector &Phi, char *txt = "", bool all = true);
 bool orbital_vector_is_sane(const OrbitalVector &Phi);
 
 void set_spins(OrbitalVector &Phi, const IntVector &spins);

--- a/src/qmfunctions/orbital_utils.h
+++ b/src/qmfunctions/orbital_utils.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/orbital_utils.h
+++ b/src/qmfunctions/orbital_utils.h
@@ -78,6 +78,8 @@ int get_multiplicity(const OrbitalVector &Phi);
 int get_electron_number(const OrbitalVector &Phi, int spin = SPIN::Paired);
 int start_index(const OrbitalVector &Phi, int spin);
 int get_n_nodes(const OrbitalVector &Phi);
+int get_size_nodes(const OrbitalVector &Phi, IntVector &sNodes);
+int print_size_nodes(const OrbitalVector &Phi, char* txt="", bool all = true);
 bool orbital_vector_is_sane(const OrbitalVector &Phi);
 
 void set_spins(OrbitalVector &Phi, const IntVector &spins);

--- a/src/qmfunctions/qmfunction_fwd.h
+++ b/src/qmfunctions/qmfunction_fwd.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/qmfunction_utils.cpp
+++ b/src/qmfunctions/qmfunction_utils.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/qmfunction_utils.h
+++ b/src/qmfunctions/qmfunction_utils.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/QMOperator.h
+++ b/src/qmoperators/QMOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/RankOneTensorOperator.cpp
+++ b/src/qmoperators/RankOneTensorOperator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/RankOneTensorOperator.h
+++ b/src/qmoperators/RankOneTensorOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/RankTwoTensorOperator.cpp
+++ b/src/qmoperators/RankTwoTensorOperator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/RankTwoTensorOperator.h
+++ b/src/qmoperators/RankTwoTensorOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/RankZeroTensorOperator.cpp
+++ b/src/qmoperators/RankZeroTensorOperator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/RankZeroTensorOperator.h
+++ b/src/qmoperators/RankZeroTensorOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/TensorOperator.h
+++ b/src/qmoperators/TensorOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/qmoperator_fwd.h
+++ b/src/qmoperators/qmoperator_fwd.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/Accelerator.cpp
+++ b/src/scf_solver/Accelerator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/Accelerator.h
+++ b/src/scf_solver/Accelerator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/EnergyOptimizer.cpp
+++ b/src/scf_solver/EnergyOptimizer.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/EnergyOptimizer.h
+++ b/src/scf_solver/EnergyOptimizer.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/GroundStateSolver.cpp
+++ b/src/scf_solver/GroundStateSolver.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/GroundStateSolver.h
+++ b/src/scf_solver/GroundStateSolver.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/HelmholtzVector.cpp
+++ b/src/scf_solver/HelmholtzVector.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/HelmholtzVector.h
+++ b/src/scf_solver/HelmholtzVector.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/KAIN.cpp
+++ b/src/scf_solver/KAIN.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/KAIN.h
+++ b/src/scf_solver/KAIN.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/LinearResponseSolver.cpp
+++ b/src/scf_solver/LinearResponseSolver.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/LinearResponseSolver.h
+++ b/src/scf_solver/LinearResponseSolver.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/OrbitalOptimizer.cpp
+++ b/src/scf_solver/OrbitalOptimizer.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/OrbitalOptimizer.h
+++ b/src/scf_solver/OrbitalOptimizer.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/SCF.cpp
+++ b/src/scf_solver/SCF.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/SCF.h
+++ b/src/scf_solver/SCF.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/MolPlot.h
+++ b/src/utils/MolPlot.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/NonlinearMaximizer.cpp
+++ b/src/utils/NonlinearMaximizer.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/NonlinearMaximizer.h
+++ b/src/utils/NonlinearMaximizer.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/RRMaximizer.cpp
+++ b/src/utils/RRMaximizer.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/RRMaximizer.h
+++ b/src/utils/RRMaximizer.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/math_utils.cpp
+++ b/src/utils/math_utils.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/math_utils.h
+++ b/src/utils/math_utils.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmfunctions/density.cpp
+++ b/tests/qmfunctions/density.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmfunctions/orbital.cpp
+++ b/tests/qmfunctions/orbital.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmfunctions/orbital_vector.cpp
+++ b/tests/qmfunctions/orbital_vector.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmfunctions/qmfunction.cpp
+++ b/tests/qmfunctions/qmfunction.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/coulomb_hessian.cpp
+++ b/tests/qmoperators/coulomb_hessian.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/coulomb_operator.cpp
+++ b/tests/qmoperators/coulomb_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/electric_field_operator.cpp
+++ b/tests/qmoperators/electric_field_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/identity_operator.cpp
+++ b/tests/qmoperators/identity_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/kinetic_operator.cpp
+++ b/tests/qmoperators/kinetic_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/momentum_operator.cpp
+++ b/tests/qmoperators/momentum_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/nuclear_operator.cpp
+++ b/tests/qmoperators/nuclear_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/position_operator.cpp
+++ b/tests/qmoperators/position_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/xc_hessian.cpp
+++ b/tests/qmoperators/xc_hessian.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/xc_hessian_pbe.cpp
+++ b/tests/qmoperators/xc_hessian_pbe.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/xc_operator.cpp
+++ b/tests/qmoperators/xc_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/xc_operator_blyp.cpp
+++ b/tests/qmoperators/xc_operator_blyp.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2019 Stig Rune Jensen, Jonas Juselius, Luca Frediani, and contributors.
+ * Copyright (C) 2019 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *


### PR DESCRIPTION
Additional routine to be able to print out size information (in MBytes) for orbital vectors.
Is not called for now, but can easily be used during testing. call such as:
orbital::print_size_nodes(Phi_n,"after localization");

produces output such as:

OrbitalVector sizes statistics after localization (MB)
Total orbvec 124, Av/MPI 62, Max/MPI 75, Max/orb 27, Min/orb 23, Total max 1817, Total min 1666 MB

WIth respectively: total size of orbital vector, average per MPI, Max per MPI, Max (largest) orbital, smallest orbital, max total (not only the orbitalvector) memory usage among all MP, minimum total (not only the orbitalvector) memory usage among all MPI. 