### PR TITLE
Update clang

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -74,7 +74,7 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Right
-ReflowComments:  false
+ReflowComments: true 
 SortIncludes:    true
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
@@ -89,3 +89,4 @@ SpacesInSquareBrackets: false
 Standard:        Cpp11
 TabWidth:        8
 UseTab:          Never
+FixNamespaceComments: true

--- a/src/SCFDriver.cpp
+++ b/src/SCFDriver.cpp
@@ -392,19 +392,19 @@ void SCFDriver::setup() {
         K = new ExchangeOperator(P, phi);
         fock->setExchangeOperator(K);
     }
-    //For DFT we need the XC operator
+    // For DFT we need the XC operator
     if (wf_method == "DFT") {
         xcfun = setupFunctional(MRDFT::Gradient);
         XC = new XCOperator(xcfun, phi);
         fock->setXCOperator(XC);
 
-        //For hybrid DFT we need a partial HF exchange
+        // For hybrid DFT we need a partial HF exchange
         if (xcfun->isHybrid()) {
             K = new ExchangeOperator(P, phi, xcfun->amountEXX());
             fock->setExchangeOperator(K);
         }
     }
-    //HACK we need a better way to decide whether to initialize the external potential operator
+    // HACK we need a better way to decide whether to initialize the external potential operator
     if (ext_electric) Vext = new ElectricFieldOperator(ext_electric_field, r_O);
     fock->setExtOperator(Vext);
     fock->build();
@@ -472,12 +472,12 @@ void SCFDriver::setup_np1() {
         K_np1 = new ExchangeOperator(P, phi);
         fock_np1->setExchangeOperator(K_np1);
     }
-    //For DFT we need the XC operator
+    // For DFT we need the XC operator
     if (wf_method == "DFT") {
         xcfun = setupFunctional(MRDFT::Gradient);
         XC_np1 = new XCOperator(xcfun, phi_np1);
         fock_np1->setXCOperator(XC_np1);
-        //For hybrid DFT we need a partial HF exchange
+        // For hybrid DFT we need a partial HF exchange
         if (xcfun->isHybrid()) {
             K_np1 = new ExchangeOperator(P, phi_np1, xcfun->amountEXX());
             fock_np1->setExchangeOperator(K_np1);
@@ -694,16 +694,16 @@ void SCFDriver::runLinearResponse(const ResponseCalculation &rsp_calc) {
     setupPerturbedOrbitals(rsp_calc);
     setupPerturbedOperators(rsp_calc);
 
-    d_fock->getXCOperator()->setupDensity(rel_prec); //Luca: maybe this is not the best place to do this....
+    d_fock->getXCOperator()->setupDensity(rel_prec); // Luca: maybe this is not the best place to do this....
     d_fock->getXCOperator()->setupPotential(rel_prec);
-    d_fock->getXCOperator()->setupDensity(rel_prec); //Luca: maybe this is not the best place to do this....
+    d_fock->getXCOperator()->setupDensity(rel_prec); // Luca: maybe this is not the best place to do this....
 
     bool converged = true;
     if (rsp_run) {
         LinearResponseSolver *solver = setupLinearResponseSolver(dynamic);
         solver->setupUnperturbed(rsp_orbital_prec[1], fock, phi, &F);
         solver->setup(d_fock, phi_x);
-        converged = solver->optimize(); //LUCA Here is a fock.setup()
+        converged = solver->optimize(); // LUCA Here is a fock.setup()
         solver->clear();
         solver->clearUnperturbed();
         delete solver;
@@ -1007,8 +1007,8 @@ mrdft::XCFunctional *SCFDriver::setupFunctional(int order) {
     fun->setUseGamma(dft_use_gamma);
     fun->setDensityCutoff(dft_cutoff);
     fun->evalSetup(order);
-    //setupInitialGrid(*fun, *molecule);
+    // setupInitialGrid(*fun, *molecule);
     return fun;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/SCFDriver.h
+++ b/src/SCFDriver.h
@@ -285,4 +285,4 @@ protected:
     mrcpp::DerivativeOperator<3> *useDerivative(std::string derivative_name);
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/analyticfunctions/HarmonicOscillatorFunction.h
+++ b/src/analyticfunctions/HarmonicOscillatorFunction.h
@@ -81,4 +81,4 @@ protected:
     const HarmonicOscillator1D fz;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/analyticfunctions/HydrogenFunction.cpp
+++ b/src/analyticfunctions/HydrogenFunction.cpp
@@ -174,4 +174,4 @@ double HydrogenFunction::evalf(const mrcpp::Coord<3> &p) const {
     return this->R.evalf(r) * this->Y.evalf(q);
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/analyticfunctions/HydrogenFunction.h
+++ b/src/analyticfunctions/HydrogenFunction.h
@@ -74,4 +74,4 @@ protected:
     AngularFunction Y;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/analyticfunctions/NuclearFunction.cpp
+++ b/src/analyticfunctions/NuclearFunction.cpp
@@ -79,4 +79,4 @@ bool NuclearFunction::isZeroOnInterval(const double *a, const double *b) const {
     }
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/analyticfunctions/NuclearFunction.h
+++ b/src/analyticfunctions/NuclearFunction.h
@@ -53,4 +53,4 @@ protected:
     std::vector<double> smooth;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/analyticfunctions/NuclearGradientFunction.cpp
+++ b/src/analyticfunctions/NuclearGradientFunction.cpp
@@ -86,4 +86,4 @@ double NuclearGradientFunction::du_dr(double r1) const {
 }
 // clang-format on
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/analyticfunctions/NuclearGradientFunction.h
+++ b/src/analyticfunctions/NuclearGradientFunction.h
@@ -55,4 +55,4 @@ protected:
     double du_dr(double r1) const;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/chemistry/Cavity.cpp
+++ b/src/chemistry/Cavity.cpp
@@ -51,4 +51,4 @@ double Cavity::evalf(const mrcpp::Coord<3> &r) const {
     return C;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/chemistry/Element.h
+++ b/src/chemistry/Element.h
@@ -69,4 +69,4 @@ protected:
     const double g_val;       /** g-value */
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/chemistry/Molecule.cpp
+++ b/src/chemistry/Molecule.cpp
@@ -384,4 +384,4 @@ void Molecule::printProperties() const {
     }
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/chemistry/Molecule.h
+++ b/src/chemistry/Molecule.h
@@ -132,4 +132,4 @@ protected:
     void readCoordinateString(const std::vector<std::string> &coord_str);
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/chemistry/Nucleus.h
+++ b/src/chemistry/Nucleus.h
@@ -85,4 +85,4 @@ public:
     }
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/chemistry/PeriodicTable.cpp
+++ b/src/chemistry/PeriodicTable.cpp
@@ -198,4 +198,4 @@ PeriodicTable::map_t PeriodicTable::_init_bysymbol() {
 PeriodicTable::map_t PeriodicTable::byName = _init_byname();
 PeriodicTable::map_t PeriodicTable::bySymbol = _init_bysymbol();
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/chemistry/PeriodicTable.h
+++ b/src/chemistry/PeriodicTable.h
@@ -23,7 +23,7 @@
  * <https://mrchem.readthedocs.io/>
  */
 
-/** 
+/**
  *
  * \date Jun 7, 2009
  * \author Jonas Juselius <jonas.juselius@uit.no> \n
@@ -59,4 +59,4 @@ private:
     static map_t _init_bysymbol();
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/chemistry/chemistry_fwd.h
+++ b/src/chemistry/chemistry_fwd.h
@@ -33,4 +33,4 @@ class Molecule;
 class Element;
 class PeriodicTable;
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/chemistry/chemistry_utils.cpp
+++ b/src/chemistry/chemistry_utils.cpp
@@ -30,7 +30,7 @@
 namespace mrchem {
 
 /** @brief computes the repulsion self energy of a set of nuclei
- * 
+ *
  * @param[in] nucs the set of nuclei
  *
  */
@@ -52,4 +52,4 @@ double compute_nuclear_repulsion(const Nuclei &nucs) {
     return E_nuc;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/chemistry/chemistry_utils.h
+++ b/src/chemistry/chemistry_utils.h
@@ -31,4 +31,4 @@ namespace mrchem {
 
 double compute_nuclear_repulsion(const Nuclei &nucs);
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/initial_guess/core.cpp
+++ b/src/initial_guess/core.cpp
@@ -72,8 +72,8 @@ int PT[29][2] = {
 };
 // clang-format on
 
-} //namespace core
-} //namespace initial_guess
+} // namespace core
+} // namespace initial_guess
 
 /** @brief Produce an initial guess of orbitals
  *
@@ -88,9 +88,9 @@ int PT[29][2] = {
  *
  */
 OrbitalVector initial_guess::core::setup(double prec, const Molecule &mol, bool restricted, int zeta) {
-    int mult = mol.getMultiplicity(); //multiplicity
-    int Ne = mol.getNElectrons();     //total electrons
-    int Nd = Ne - (mult - 1);         //doubly occupied
+    int mult = mol.getMultiplicity(); // multiplicity
+    int Ne = mol.getNElectrons();     // total electrons
+    int Nd = Ne - (mult - 1);         // doubly occupied
     if (Nd % 2 != 0) MSG_FATAL("Invalid multiplicity");
 
     // Make Fock operator contributions
@@ -135,7 +135,7 @@ OrbitalVector initial_guess::core::setup(double prec, const Molecule &mol, bool 
     if (restricted) {
         if (mult != 1) MSG_FATAL("Restricted open-shell not available");
 
-        int Np = Nd / 2; //paired orbitals
+        int Np = Nd / 2; // paired orbitals
         for (int i = 0; i < Np; i++) {
             ComplexVector v_i = U.row(i);
             Orbital psi_i(SPIN::Paired);
@@ -143,8 +143,8 @@ OrbitalVector initial_guess::core::setup(double prec, const Molecule &mol, bool 
             Psi.push_back(psi_i);
         }
     } else {
-        int Na = Nd / 2 + (mult - 1); //alpha orbitals
-        int Nb = Nd / 2;              //beta orbitals
+        int Na = Nd / 2 + (mult - 1); // alpha orbitals
+        int Nb = Nd / 2;              // beta orbitals
 
         OrbitalVector Psi_a;
         for (int i = 0; i < Na; i++) {
@@ -246,4 +246,4 @@ OrbitalVector initial_guess::core::project_ao(double prec, const Nuclei &nucs, i
     return Phi;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/initial_guess/core.h
+++ b/src/initial_guess/core.h
@@ -45,6 +45,6 @@ namespace core {
 OrbitalVector setup(double prec, const Molecule &mol, bool restricted, int zeta);
 OrbitalVector project_ao(double prec, const Nuclei &nucs, int spin, int zeta);
 
-} //namespace core
-} //namespace initial_guess
-} //namespace mrchem
+} // namespace core
+} // namespace initial_guess
+} // namespace mrchem

--- a/src/initial_guess/gto.cpp
+++ b/src/initial_guess/gto.cpp
@@ -67,11 +67,11 @@ OrbitalVector initial_guess::gto::setup(double prec,
                                         const std::string &bas_file,
                                         const std::string &mo_file) {
     // Figure out number of occupied orbitals
-    int mult = mol.getMultiplicity(); //multiplicity
-    int Ne = mol.getNElectrons();     //total electrons
-    int Nd = Ne - (mult - 1);         //doubly occupied electrons
+    int mult = mol.getMultiplicity(); // multiplicity
+    int Ne = mol.getNElectrons();     // total electrons
+    int Nd = Ne - (mult - 1);         // doubly occupied electrons
     if (Nd % 2 != 0) MSG_FATAL("Invalid multiplicity");
-    int Np = Nd / 2; //paired orbitals
+    int Np = Nd / 2; // paired orbitals
 
     // Project GTO expansion
     return initial_guess::gto::project_mo(prec, bas_file, mo_file, SPIN::Paired, Np);
@@ -100,12 +100,12 @@ OrbitalVector initial_guess::gto::setup(double prec,
                                         const std::string &moa_file,
                                         const std::string &mob_file) {
     // Figure out number of occupied orbitals
-    int mult = mol.getMultiplicity(); //multiplicity
-    int Ne = mol.getNElectrons();     //total electrons
-    int Nd = Ne - (mult - 1);         //paired electrons
+    int mult = mol.getMultiplicity(); // multiplicity
+    int Ne = mol.getNElectrons();     // total electrons
+    int Nd = Ne - (mult - 1);         // paired electrons
     if (Nd % 2 != 0) MSG_FATAL("Invalid multiplicity");
-    int Na = Nd / 2 + (mult - 1); //alpha orbitals
-    int Nb = Nd / 2;              //beta orbitals
+    int Na = Nd / 2 + (mult - 1); // alpha orbitals
+    int Nb = Nd / 2;              // beta orbitals
 
     // Project orbitals
     OrbitalVector Phi_a = initial_guess::gto::project_mo(prec, bas_file, moa_file, SPIN::Alpha, Na);
@@ -244,9 +244,9 @@ mrcpp::FunctionTree<3> *initial_guess::gto::project_density(double prec,
     return rho;
 }
 
-} //namespace mrchem
+} // namespace mrchem
 
-//void OrbitalVector::readVirtuals(const string &bf, const string &mo, int n_occ) {
+// void OrbitalVector::readVirtuals(const string &bf, const string &mo, int n_occ) {
 //    Timer timer;
 //    int oldPrec = Printer::setPrecision(15);
 //    printout(0, "\n\n=============== Setting up virtual orbitals ");

--- a/src/initial_guess/gto.h
+++ b/src/initial_guess/gto.h
@@ -62,6 +62,6 @@ mrcpp::FunctionTree<3> *project_density(double prec,
                                         const std::string &bas_file,
                                         const std::string &dens_file);
 
-} //namespace gto
-} //namespace initial_guess
-} //namespace mrchem
+} // namespace gto
+} // namespace initial_guess
+} // namespace mrchem

--- a/src/initial_guess/sad.cpp
+++ b/src/initial_guess/sad.cpp
@@ -59,17 +59,17 @@ ComplexMatrix diagonalize_fock(KineticOperator &T, RankZeroTensorOperator &V, Or
 OrbitalVector rotate_orbitals(double prec, ComplexMatrix &U, OrbitalVector &Phi, int N, int spin);
 void project_atomic_densities(double prec, const Molecule &mol, mrcpp::FunctionTreeVector<3> &rho_atomic);
 
-} //namespace sad
-} //namespace initial_guess
+} // namespace sad
+} // namespace initial_guess
 
 OrbitalVector initial_guess::sad::setup(double prec, const Molecule &mol, bool restricted, int zeta) {
     // Figure out number of occupied orbitals
-    int mult = mol.getMultiplicity(); //multiplicity
-    int Ne = mol.getNElectrons();     //total electrons
-    int Nd = Ne - (mult - 1);         //doubly occupied electrons
+    int mult = mol.getMultiplicity(); // multiplicity
+    int Ne = mol.getNElectrons();     // total electrons
+    int Nd = Ne - (mult - 1);         // doubly occupied electrons
     if (Nd % 2 != 0) MSG_FATAL("Invalid multiplicity");
-    int Na = Nd / 2 + (mult - 1); //alpha orbitals
-    int Nb = Nd / 2;              //beta orbitals
+    int Na = Nd / 2 + (mult - 1); // alpha orbitals
+    int Nb = Nd / 2;              // beta orbitals
 
     // Make Fock operator contributions
     mrcpp::PoissonOperator P(*MRA, prec);
@@ -137,12 +137,12 @@ OrbitalVector initial_guess::sad::setup(double prec, const Molecule &mol, bool r
     OrbitalVector Psi;
     if (restricted) {
         if (mult != 1) MSG_FATAL("Restricted open-shell not available");
-        int Np = Nd / 2; //paired orbitals
+        int Np = Nd / 2; // paired orbitals
         ComplexMatrix U = initial_guess::sad::diagonalize_fock(T, V, Phi, SPIN::Paired);
         Psi = initial_guess::sad::rotate_orbitals(prec, U, Phi, Np, SPIN::Paired);
     } else {
-        int Na = Nd / 2 + (mult - 1); //alpha orbitals
-        int Nb = Nd / 2;              //beta orbitals
+        int Na = Nd / 2 + (mult - 1); // alpha orbitals
+        int Nb = Nd / 2;              // beta orbitals
 
         ComplexMatrix U_a = initial_guess::sad::diagonalize_fock(T, V, Phi, SPIN::Alpha);
         OrbitalVector Psi_a = initial_guess::sad::rotate_orbitals(prec, U_a, Phi, Na, SPIN::Alpha);
@@ -244,4 +244,4 @@ void initial_guess::sad::project_atomic_densities(double prec,
     Printer::printFooter(0, timer, 2);
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/initial_guess/sad.h
+++ b/src/initial_guess/sad.h
@@ -43,6 +43,6 @@ namespace sad {
 
 OrbitalVector setup(double prec, const Molecule &mol, bool restricted, int zeta);
 
-} //namespace sad
-} //namespace initial_guess
-} //namespace mrchem
+} // namespace sad
+} // namespace initial_guess
+} // namespace mrchem

--- a/src/mrdft/XCFunctional.cpp
+++ b/src/mrdft/XCFunctional.cpp
@@ -341,9 +341,9 @@ void XCFunctional::clear() {
     clearGrid();
 
     // Clear MW coefs but keep the grid
-    //if (rho_a != nullptr) mrcpp::clear_grid(*rho_a);
-    //if (rho_b != nullptr) mrcpp::clear_grid(*rho_b);
-    //if (rho_t != nullptr) mrcpp::clear_grid(*rho_t);
+    // if (rho_a != nullptr) mrcpp::clear_grid(*rho_a);
+    // if (rho_b != nullptr) mrcpp::clear_grid(*rho_b);
+    // if (rho_t != nullptr) mrcpp::clear_grid(*rho_t);
 }
 
 /** @brief Allocate input arrays for xcfun
@@ -515,7 +515,7 @@ void XCFunctional::evaluate() {
  * param[in] inp Input values
  * param[out] out Output values
  *
-*/
+ */
 void XCFunctional::evaluateBlock(MatrixXd &inp, MatrixXd &out) const {
     if (inp.cols() != getInputLength()) MSG_ERROR("Invalid input");
 
@@ -567,7 +567,8 @@ void XCFunctional::compressNodeData(int n, int nFuncs, FunctionTreeVector<3> tre
 
 /** @brief Converts data from a matrix to a FunctionNode
  *
- * The matrix containing the output from xcfun is converted back to the corresponding FunctionNode(s). The matrix dimensions are the overall number of grid points (nCoefs) and the number of functions (nFuncs).
+ * The matrix containing the output from xcfun is converted back to the corresponding FunctionNode(s). The matrix
+ * dimensions are the overall number of grid points (nCoefs) and the number of functions (nFuncs).
  *
  * parma[in] n the Index of the requested node
  * param[in] nFuncs The number of functions
@@ -627,7 +628,7 @@ FunctionTreeVector<3> XCFunctional::calcPotential() {
  */
 void XCFunctional::calcPotentialLDA(FunctionTreeVector<3> &potentials) {
     int nPotentials = 1;
-    int nStart = this->order; //PROBLEM: if I use a higher order than necessary this wil fail miserably!
+    int nStart = this->order; // PROBLEM: if I use a higher order than necessary this wil fail miserably!
     if (isSpinSeparated()) {
         nPotentials = this->order + 1;
         nStart = this->order * (this->order + 1) / 2;
@@ -827,15 +828,15 @@ FunctionTree<3> *XCFunctional::calcGradientGGA(FunctionTree<3> &df_drho, Functio
 
 FunctionTree<3> *XCFunctional::doubleDivergence(FunctionTreeVector<3> &df2dg2) {
     FunctionTreeVector<3> tmp;
-    tmp.push_back(df2dg2[0]); //xx
-    tmp.push_back(df2dg2[1]); //xy
-    tmp.push_back(df2dg2[2]); //xz
-    tmp.push_back(df2dg2[1]); //yx --> xy
-    tmp.push_back(df2dg2[3]); //yy
-    tmp.push_back(df2dg2[4]); //yz
-    tmp.push_back(df2dg2[2]); //zx --> xz
-    tmp.push_back(df2dg2[4]); //zy --> yz
-    tmp.push_back(df2dg2[5]); //zz
+    tmp.push_back(df2dg2[0]); // xx
+    tmp.push_back(df2dg2[1]); // xy
+    tmp.push_back(df2dg2[2]); // xz
+    tmp.push_back(df2dg2[1]); // yx --> xy
+    tmp.push_back(df2dg2[3]); // yy
+    tmp.push_back(df2dg2[4]); // yz
+    tmp.push_back(df2dg2[2]); // zx --> xz
+    tmp.push_back(df2dg2[4]); // zy --> yz
+    tmp.push_back(df2dg2[5]); // zz
     FunctionTreeVector<3> gradient;
     for (int i = 0; i < 3; i++) {
         FunctionTree<3> *component = new FunctionTree<3>(MRA);
@@ -880,4 +881,4 @@ FunctionTree<3> *XCFunctional::calcGradDotPotDensVec(FunctionTree<3> &V, Functio
     return result;
 }
 
-} //namespace mrdft
+} // namespace mrdft

--- a/src/mrdft/XCFunctional.h
+++ b/src/mrdft/XCFunctional.h
@@ -30,7 +30,7 @@
 #include "MRCPP/MWFunctions"
 #include "XCFun/xcfun.h"
 
-/** 
+/**
  *  @class XCFunctional
  *  @brief Compute XC functional with XCFun
  *
@@ -163,4 +163,4 @@ protected:
     mrcpp::FunctionTree<3> *doubleDivergence(mrcpp::FunctionTreeVector<3> &df2dg2);
 };
 
-} //namespace mrdft
+} // namespace mrdft

--- a/src/mrenv.cpp
+++ b/src/mrenv.cpp
@@ -128,4 +128,4 @@ void finalize(double wt) {
     println(0, endl);
 }
 
-} //namespace mrenv
+} // namespace mrenv

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -16,7 +16,7 @@ namespace omp {
 
 int n_threads = omp_get_max_threads();
 
-} //namespace omp
+} // namespace omp
 
 namespace mpi {
 
@@ -38,7 +38,7 @@ MPI_Comm comm_orb;
 MPI_Comm comm_share;
 MPI_Comm comm_sh_group;
 
-} //namespace mpi
+} // namespace mpi
 
 void mpi::initialize(int argc, char **argv) {
     omp_set_dynamic(0);
@@ -183,7 +183,7 @@ void mpi::allreduce_matrix(ComplexMatrix &mat, MPI_Comm comm) {
 #endif
 }
 
-//send an orbital with MPI, includes orbital meta data
+// send an orbital with MPI, includes orbital meta data
 void mpi::send_orbital(Orbital &orb, int dst, int tag) {
 #ifdef HAVE_MPI
     mpi::send_function(orb, dst, tag, mpi::comm_orb);
@@ -193,7 +193,7 @@ void mpi::send_orbital(Orbital &orb, int dst, int tag) {
 #endif
 }
 
-//receive an orbital with MPI, includes orbital meta data
+// receive an orbital with MPI, includes orbital meta data
 void mpi::recv_orbital(Orbital &orb, int src, int tag) {
 #ifdef HAVE_MPI
     mpi::recv_function(orb, src, tag, mpi::comm_orb);
@@ -204,7 +204,7 @@ void mpi::recv_orbital(Orbital &orb, int src, int tag) {
 #endif
 }
 
-//send a function with MPI
+// send a function with MPI
 void mpi::send_function(QMFunction &func, int dst, int tag, MPI_Comm comm) {
 #ifdef HAVE_MPI
     if (func.isShared()) MSG_WARN("Sending a shared function is not recommended");
@@ -216,7 +216,7 @@ void mpi::send_function(QMFunction &func, int dst, int tag, MPI_Comm comm) {
 #endif
 }
 
-//receive a function with MPI
+// receive a function with MPI
 void mpi::recv_function(QMFunction &func, int src, int tag, MPI_Comm comm) {
 #ifdef HAVE_MPI
     if (func.isShared()) MSG_WARN("Receiving a shared function is not recommended");
@@ -301,4 +301,4 @@ void mpi::broadcast_density(Density &rho, MPI_Comm comm) {
 #endif
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -13,7 +13,7 @@ namespace mrchem {
 
 namespace omp {
 extern int n_threads;
-} //namespace omp
+} // namespace omp
 
 namespace mpi {
 extern bool numerically_exact;
@@ -63,6 +63,6 @@ void allreduce_matrix(IntMatrix &vec, MPI_Comm comm);
 void allreduce_matrix(DoubleMatrix &mat, MPI_Comm comm);
 void allreduce_matrix(ComplexMatrix &mat, MPI_Comm comm);
 
-} //namespace mpi
+} // namespace mpi
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/properties/DipoleMoment.h
+++ b/src/properties/DipoleMoment.h
@@ -77,4 +77,4 @@ private:
 };
 // clang-format on
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/properties/GeometryDerivatives.h
+++ b/src/properties/GeometryDerivatives.h
@@ -79,4 +79,4 @@ private:
 };
 // clang-format on
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/properties/HyperFineCoupling.h
+++ b/src/properties/HyperFineCoupling.h
@@ -87,4 +87,4 @@ private:
 };
 // clang-format on
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/properties/Magnetizability.h
+++ b/src/properties/Magnetizability.h
@@ -92,4 +92,4 @@ private:
 };
 // clang-format on
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/properties/NMRShielding.h
+++ b/src/properties/NMRShielding.h
@@ -94,4 +94,4 @@ private:
 };
 // clang-format on
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/properties/Polarizability.h
+++ b/src/properties/Polarizability.h
@@ -74,4 +74,4 @@ private:
 };
 // clang-format on
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/properties/SCFEnergy.h
+++ b/src/properties/SCFEnergy.h
@@ -112,4 +112,4 @@ private:
 };
 // clang-format on
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/properties/SpinSpinCoupling.h
+++ b/src/properties/SpinSpinCoupling.h
@@ -101,4 +101,4 @@ private:
 };
 // clang-format on
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/properties/properties_fwd.h
+++ b/src/properties/properties_fwd.h
@@ -38,4 +38,4 @@ class Polarizability;
 class OpticalRotation;
 class GeometryDerivatives;
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmfunctions/Density.cpp
+++ b/src/qmfunctions/Density.cpp
@@ -52,11 +52,11 @@ Density &Density::operator=(const Density &dens) {
  * and imaginary ("phi_0_im.tree") parts.
  */
 void Density::saveDensity(const std::string &file) {
-    //writing meta data
+    // writing meta data
     std::stringstream metafile;
     metafile << file << ".meta";
 
-    //this flushes tree sizes
+    // this flushes tree sizes
     FunctionData &func_data = getFunctionData();
 
     std::fstream f;
@@ -65,14 +65,14 @@ void Density::saveDensity(const std::string &file) {
     f.write((char *)&func_data, sizeof(FunctionData));
     f.close();
 
-    //writing real part
+    // writing real part
     if (hasReal()) {
         std::stringstream fname;
         fname << file << "_re";
         real().saveTree(fname.str());
     }
 
-    //writing imaginary part
+    // writing imaginary part
     if (hasImag()) {
         std::stringstream fname;
         fname << file << "_im";
@@ -92,11 +92,11 @@ void Density::loadDensity(const std::string &file) {
     if (hasReal()) MSG_ERROR("Density not empty");
     if (hasImag()) MSG_ERROR("Density not empty");
 
-    //reading meta data
+    // reading meta data
     std::stringstream fmeta;
     fmeta << file << ".meta";
 
-    //this flushes tree sizes
+    // this flushes tree sizes
     FunctionData &func_data = getFunctionData();
 
     std::fstream f;
@@ -104,7 +104,7 @@ void Density::loadDensity(const std::string &file) {
     if (f.is_open()) f.read((char *)&func_data, sizeof(FunctionData));
     f.close();
 
-    //reading real part
+    // reading real part
     if (func_data.real_size > 0) {
         std::stringstream fname;
         fname << file << "_re";
@@ -112,7 +112,7 @@ void Density::loadDensity(const std::string &file) {
         real().loadTree(fname.str());
     }
 
-    //reading imaginary part
+    // reading imaginary part
     if (func_data.imag_size > 0) {
         std::stringstream fname;
         fname << file << "_im";
@@ -121,4 +121,4 @@ void Density::loadDensity(const std::string &file) {
     }
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmfunctions/Density.h
+++ b/src/qmfunctions/Density.h
@@ -58,4 +58,4 @@ public:
     void loadDensity(const std::string &file);
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmfunctions/Orbital.cpp
+++ b/src/qmfunctions/Orbital.cpp
@@ -116,11 +116,11 @@ Orbital Orbital::dagger() const {
  * and imaginary ("phi_0_im.tree") parts.
  */
 void Orbital::saveOrbital(const std::string &file) {
-    //writing meta data
+    // writing meta data
     std::stringstream metafile;
     metafile << file << ".meta";
 
-    //this flushes tree sizes
+    // this flushes tree sizes
     FunctionData &func_data = getFunctionData();
     OrbitalData &orb_data = getOrbitalData();
 
@@ -131,14 +131,14 @@ void Orbital::saveOrbital(const std::string &file) {
     f.write((char *)&orb_data, sizeof(OrbitalData));
     f.close();
 
-    //writing real part
+    // writing real part
     if (hasReal()) {
         std::stringstream fname;
         fname << file << "_re";
         real().saveTree(fname.str());
     }
 
-    //writing imaginary part
+    // writing imaginary part
     if (hasImag()) {
         std::stringstream fname;
         fname << file << "_im";
@@ -158,11 +158,11 @@ void Orbital::loadOrbital(const std::string &file) {
     if (hasReal()) MSG_ERROR("Orbital not empty");
     if (hasImag()) MSG_ERROR("Orbital not empty");
 
-    //reading meta data
+    // reading meta data
     std::stringstream fmeta;
     fmeta << file << ".meta";
 
-    //this flushes tree sizes
+    // this flushes tree sizes
     FunctionData &func_data = getFunctionData();
     OrbitalData &orb_data = getOrbitalData();
 
@@ -172,7 +172,7 @@ void Orbital::loadOrbital(const std::string &file) {
     if (f.is_open()) f.read((char *)&orb_data, sizeof(OrbitalData));
     f.close();
 
-    //reading real part
+    // reading real part
     if (func_data.real_size > 0) {
         std::stringstream fname;
         fname << file << "_re";
@@ -180,7 +180,7 @@ void Orbital::loadOrbital(const std::string &file) {
         real().loadTree(fname.str());
     }
 
-    //reading imaginary part
+    // reading imaginary part
     if (func_data.imag_size > 0) {
         std::stringstream fname;
         fname << file << "_im";
@@ -211,4 +211,4 @@ std::ostream &Orbital::print(std::ostream &o) const {
     return o;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmfunctions/Orbital.h
+++ b/src/qmfunctions/Orbital.h
@@ -88,4 +88,4 @@ private:
     std::ostream &print(std::ostream &o) const;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmfunctions/OrbitalIterator.cpp
+++ b/src/qmfunctions/OrbitalIterator.cpp
@@ -37,7 +37,7 @@ OrbitalIterator::OrbitalIterator(OrbitalVector &Phi, bool sym)
         , received_counter(0)
         , sent_counter(0)
         , orbitals(&Phi) {
-    //Find and save the orbitals each rank owns
+    // Find and save the orbitals each rank owns
     int my_mpi_rank = mpi::orb_rank;
     for (int impi = 0; impi < mpi::orb_size; impi++) {
         std::vector<int> orb_ix;
@@ -60,8 +60,8 @@ OrbitalIterator::OrbitalIterator(OrbitalVector &Phi, bool sym)
 //     there may be several calls to "next" for the same iter in case max_recv<0,
 //     or double iterations for symmetric treatment.
 bool OrbitalIterator::next(int max_recv) {
-    mpi::free_foreign(*this->orbitals); //delete foreign orbitals
-    //NB: for now we completely delete orbitals at each iteration. Could reuse the memory in next iteration.
+    mpi::free_foreign(*this->orbitals); // delete foreign orbitals
+    // NB: for now we completely delete orbitals at each iteration. Could reuse the memory in next iteration.
     this->received_orbital_index.clear();
     this->received_orbitals.clear();
     this->sent_orbital_index.clear();
@@ -83,30 +83,30 @@ bool OrbitalIterator::next(int max_recv) {
 
     int my_rank = mpi::orb_rank;
     int max_rank = mpi::orb_size;
-    int received = 0;                                //number of new received orbitals this call
-    int sent = 0;                                    //number of new sent orbitals this call
-    int maxget = max_recv;                           //max number of orbitals to receive
-    if (maxget < 0) maxget = this->orbitals->size(); //unlimited
+    int received = 0;                                // number of new received orbitals this call
+    int sent = 0;                                    // number of new sent orbitals this call
+    int maxget = max_recv;                           // max number of orbitals to receive
+    if (maxget < 0) maxget = this->orbitals->size(); // unlimited
 
     int nstep = 1;                  // send and receive in the same iteration
     if (this->symmetric) nstep = 2; // one iteration is receive, one iteration is send
 
     for (int step = 0; step < nstep; step++) {
-        if (this->iter >= mpi::orb_size) break; //last iteration is completed
+        if (this->iter >= mpi::orb_size) break; // last iteration is completed
 
-        bool IamReceiver = true; //default, both send and receive
-        bool IamSender = true;   //default, both send and receive
+        bool IamReceiver = true; // default, both send and receive
+        bool IamSender = true;   // default, both send and receive
 
         // Figure out which MPI to talk to
         int other_rank = (max_rank + this->iter - my_rank) % max_rank;
-        //note: my_rank= (max_rank + this->iter - other_rank)%max_rank
+        // note: my_rank= (max_rank + this->iter - other_rank)%max_rank
 
         int send_size = this->orb_ix_map[my_rank].size();
         int recv_size = this->orb_ix_map[other_rank].size();
 
         if (other_rank == my_rank) {
             // We receive from ourself
-            IamSender = false; //sending data is "for free"
+            IamSender = false; // sending data is "for free"
             for (int i = this->received_counter; i < send_size and received < maxget; i++) {
                 int orb_ix = this->orb_ix_map[my_rank][i];
                 Orbital &phi_i = (*this->orbitals)[orb_ix];
@@ -123,7 +123,8 @@ bool OrbitalIterator::next(int max_recv) {
                 //(my_rank + other_rank )%2 flips each time other_rank changes by one
                 //(my_rank < other_rank) ensures that my_rank and other_rank are opposite
                 // my_rank = other_rank must correspond to a receive (since it implicitely means extra work later on)
-                // NB: must take care that if at one step other_rank == my_rank, the other step must not be a receive!! not trivial
+                // NB: must take care that if at one step other_rank == my_rank, the other step must not be a receive!!
+                // not trivial
                 if ((my_rank + other_rank + (my_rank > other_rank)) % 2) {
                     IamReceiver = false;
                 } else {
@@ -133,7 +134,7 @@ bool OrbitalIterator::next(int max_recv) {
 
             // highest mpi rank send first receive after, the other does the opposite
             if (my_rank > other_rank) {
-                //send
+                // send
                 for (int i = this->sent_counter; i < send_size and IamSender and sent < maxget; i++) {
                     int tag = this->orbitals->size() * this->iter + i;
                     int orb_ix = this->orb_ix_map[my_rank][i];
@@ -141,10 +142,10 @@ bool OrbitalIterator::next(int max_recv) {
                     mpi::send_orbital(phi_i, other_rank, tag);
                     this->sent_orbital_index.push_back(orb_ix);
                     this->sent_orbital_mpirank.push_back(other_rank);
-                    this->sent_counter++; //total to other_rank
-                    sent++;               //this call
+                    this->sent_counter++; // total to other_rank
+                    sent++;               // this call
                 }
-                //receive
+                // receive
                 for (int i = this->received_counter; i < recv_size and IamReceiver and received < maxget; i++) {
                     int tag = this->orbitals->size() * this->iter + i;
                     int orb_ix = this->orb_ix_map[other_rank][i];
@@ -153,11 +154,11 @@ bool OrbitalIterator::next(int max_recv) {
                     this->received_orbital_index.push_back(orb_ix);
                     this->received_orbitals.push_back(phi_i);
                     this->rcv_step.push_back(step);
-                    this->received_counter++; //total from other_rank
-                    received++;               //this call
+                    this->received_counter++; // total from other_rank
+                    received++;               // this call
                 }
             } else {
-                //my_rank < other_rank -> receive first, send after receive
+                // my_rank < other_rank -> receive first, send after receive
                 for (int i = this->received_counter; i < recv_size and IamReceiver and received < maxget; i++) {
                     int tag = this->orbitals->size() * this->iter + i;
                     int orb_ix = this->orb_ix_map[other_rank][i];
@@ -166,10 +167,10 @@ bool OrbitalIterator::next(int max_recv) {
                     this->received_orbital_index.push_back(orb_ix);
                     this->received_orbitals.push_back(phi_i);
                     this->rcv_step.push_back(step);
-                    this->received_counter++; //total from other_rank
-                    received++;               //this call
+                    this->received_counter++; // total from other_rank
+                    received++;               // this call
                 }
-                //send
+                // send
                 for (int i = this->sent_counter; i < send_size and IamSender and sent < maxget; i++) {
                     int tag = this->orbitals->size() * this->iter + i;
                     int orb_ix = this->orb_ix_map[my_rank][i];
@@ -177,22 +178,22 @@ bool OrbitalIterator::next(int max_recv) {
                     mpi::send_orbital(phi_i, other_rank, tag);
                     this->sent_orbital_index.push_back(orb_ix);
                     this->sent_orbital_mpirank.push_back(other_rank);
-                    this->sent_counter++; //total to other_rank
-                    sent++;               //this call
+                    this->sent_counter++; // total to other_rank
+                    sent++;               // this call
                 }
             }
         }
 
         if ((this->sent_counter >= send_size or not IamSender) and
             (this->received_counter >= recv_size or not IamReceiver)) {
-            //all orbitals to be processed during this iteration are ready. Start next iteration
+            // all orbitals to be processed during this iteration are ready. Start next iteration
             this->sent_counter = 0;
             this->received_counter = 0;
             this->iter++;
-            if (this->iter % 2 == 0) break; //must always exit after odd iterations in order to finish duties outside
+            if (this->iter % 2 == 0) break; // must always exit after odd iterations in order to finish duties outside
         }
     }
     return true;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmfunctions/OrbitalIterator.h
+++ b/src/qmfunctions/OrbitalIterator.h
@@ -47,15 +47,15 @@ public:
 protected:
     const bool symmetric;
     int iter;
-    int received_counter; //number of orbitals fetched during this iteration
-    int sent_counter;     //number of orbitals sent during this iteration
+    int received_counter; // number of orbitals fetched during this iteration
+    int sent_counter;     // number of orbitals sent during this iteration
     OrbitalVector *orbitals;
     OrbitalVector received_orbitals;
-    std::vector<int> received_orbital_index;  //index of the orbitals received
-    std::vector<int> sent_orbital_index;      //indices of the orbitals sent out
-    std::vector<int> sent_orbital_mpirank;    //mpi rank (=rankID) of the orbitals sent out
-    std::vector<int> rcv_step;                //for symmetric treatment: if the send was at step=0 or 1
-    std::vector<std::vector<int>> orb_ix_map; //indices in the original orbital vector for each MPI
+    std::vector<int> received_orbital_index;  // index of the orbitals received
+    std::vector<int> sent_orbital_index;      // indices of the orbitals sent out
+    std::vector<int> sent_orbital_mpirank;    // mpi rank (=rankID) of the orbitals sent out
+    std::vector<int> rcv_step;                // for symmetric treatment: if the send was at step=0 or 1
+    std::vector<std::vector<int>> orb_ix_map; // indices in the original orbital vector for each MPI
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmfunctions/QMFunction.cpp
+++ b/src/qmfunctions/QMFunction.cpp
@@ -88,9 +88,9 @@ void QMFunction::free(int type) {
 }
 
 /** @brief Returns the orbital meta data
-     *
-     * Tree sizes (nChunks) are flushed before return.
-     */
+ *
+ * Tree sizes (nChunks) are flushed before return.
+ */
 FunctionData &QMFunction::getFunctionData() {
     this->func_ptr->flushFuncData();
     return this->func_ptr->func_data;
@@ -218,4 +218,4 @@ void QMFunction::rescale(ComplexDouble c) {
     out.add(c, tmp);
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -195,7 +195,7 @@ void density::compute_X(double prec, Density &rho, OrbitalVector &Phi, OrbitalVe
             if (not mpi::my_orb(X[i])) MSG_FATAL("Inconsistent MPI distribution");
 
             double occ = density::compute_occupation(Phi[i], spin);
-            if (std::abs(occ) < mrcpp::MachineZero) continue; //next orbital if this one is not occupied!
+            if (std::abs(occ) < mrcpp::MachineZero) continue; // next orbital if this one is not occupied!
 
             Density rho_i(false);
             qmfunction::multiply_real(rho_i, Phi[i], X[i], mult_prec);
@@ -251,7 +251,7 @@ void density::compute_XY(double prec, Density &rho, OrbitalVector &Phi, OrbitalV
             if (not mpi::my_orb(Y[i])) MSG_FATAL("Inconsistent MPI distribution");
 
             double occ = density::compute_occupation(Phi[i], spin);
-            if (std::abs(occ) < mrcpp::MachineZero) continue; //next orbital if this one is not occupied!
+            if (std::abs(occ) < mrcpp::MachineZero) continue; // next orbital if this one is not occupied!
 
             Density rho_x(false);
             Density rho_y(false);
@@ -307,4 +307,4 @@ double density::compute_occupation(Orbital &phi, int dens_spin) {
     return occ;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmfunctions/density_utils.h
+++ b/src/qmfunctions/density_utils.h
@@ -34,5 +34,5 @@ void compute(double prec, Density &rho, mrcpp::GaussExp<3> &dens_exp, int spin);
 void compute(double prec, Density &rho, OrbitalVector &Phi, int spin);
 void compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &X, OrbitalVector &Y, int spin);
 
-} //namespace density
-} //namespace mrchem
+} // namespace density
+} // namespace mrchem

--- a/src/qmfunctions/orbital_utils.cpp
+++ b/src/qmfunctions/orbital_utils.cpp
@@ -262,7 +262,7 @@ void orbital::save_orbitals(OrbitalVector &Phi, const std::string &file, const s
     if (n_orbs < 0) n_orbs = Phi.size();
     if (n_orbs > Phi.size()) MSG_ERROR("Index out of bounds");
     for (int i = 0; i < n_orbs; i++) {
-        if (not mpi::my_orb(Phi[i])) continue; //only save own orbitals
+        if (not mpi::my_orb(Phi[i])) continue; // only save own orbitals
         std::stringstream orbname;
         orbname << file << "_" << suffix << i;
         Phi[i].saveOrbital(orbname.str());
@@ -296,7 +296,7 @@ OrbitalVector orbital::load_orbitals(const std::string &file, const std::string 
             break;
         }
     }
-    //distribute errors
+    // distribute errors
     DoubleVector errors = DoubleVector::Zero(Phi.size());
     for (int i = 0; i < Phi.size(); i++) {
         if (mpi::my_orb(Phi[i])) errors(i) = Phi[i].error();
@@ -807,4 +807,4 @@ void orbital::print(const OrbitalVector &Phi) {
     printout(0, "============================================================\n\n\n");
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmfunctions/orbital_utils.h
+++ b/src/qmfunctions/orbital_utils.h
@@ -93,5 +93,5 @@ ComplexVector get_integrals(const OrbitalVector &Phi);
 
 void print(const OrbitalVector &Phi);
 
-} //namespace orbital
-} //namespace mrchem
+} // namespace orbital
+} // namespace mrchem

--- a/src/qmfunctions/qmfunction_fwd.h
+++ b/src/qmfunctions/qmfunction_fwd.h
@@ -56,4 +56,4 @@ using OrbitalVector = std::vector<Orbital>;
 
 class Density;
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmfunctions/qmfunction_utils.cpp
+++ b/src/qmfunctions/qmfunction_utils.cpp
@@ -331,4 +331,4 @@ void qmfunction::multiply_imag(QMFunction &out, QMFunction inp_a, QMFunction inp
     mpi::share_function(out, 0, 9292, mpi::comm_share);
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmfunctions/qmfunction_utils.h
+++ b/src/qmfunctions/qmfunction_utils.h
@@ -41,5 +41,5 @@ void multiply_real(QMFunction &out, QMFunction inp_a, QMFunction inp_b, double p
 void multiply_imag(QMFunction &out, QMFunction inp_a, QMFunction inp_b, double prec);
 void linear_combination(QMFunction &out, const ComplexVector &c, QMFunctionVector &inp, double prec);
 
-} //namespace qmfunction
-} //namespace mrchem
+} // namespace qmfunction
+} // namespace mrchem

--- a/src/qmoperators/QMOperator.h
+++ b/src/qmoperators/QMOperator.h
@@ -88,4 +88,4 @@ protected:
     virtual Orbital dagger(Orbital inp) = 0;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/RankOneTensorOperator.cpp
+++ b/src/qmoperators/RankOneTensorOperator.cpp
@@ -57,6 +57,6 @@ template <int I> ComplexVector RankOneTensorOperator<I>::trace(OrbitalVector &ph
     return out;
 }
 
-} //namespace mrchem
+} // namespace mrchem
 
 template class mrchem::RankOneTensorOperator<3>;

--- a/src/qmoperators/RankOneTensorOperator.h
+++ b/src/qmoperators/RankOneTensorOperator.h
@@ -49,4 +49,4 @@ public:
     ComplexVector trace(OrbitalVector &phi, OrbitalVector &x, OrbitalVector &y);
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/RankTwoTensorOperator.cpp
+++ b/src/qmoperators/RankTwoTensorOperator.cpp
@@ -51,6 +51,6 @@ ComplexMatrix RankTwoTensorOperator<I, J>::trace(OrbitalVector &phi, OrbitalVect
     return out;
 }
 
-} //namespace mrchem
+} // namespace mrchem
 
 template class mrchem::RankTwoTensorOperator<3, 3>;

--- a/src/qmoperators/RankTwoTensorOperator.h
+++ b/src/qmoperators/RankTwoTensorOperator.h
@@ -49,4 +49,4 @@ public:
     ComplexMatrix trace(OrbitalVector &phi, OrbitalVector &x, OrbitalVector &y);
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/RankZeroTensorOperator.cpp
+++ b/src/qmoperators/RankZeroTensorOperator.cpp
@@ -325,4 +325,4 @@ Orbital RankZeroTensorOperator::applyOperTerm(int n, Orbital inp) {
     return out;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/RankZeroTensorOperator.h
+++ b/src/qmoperators/RankZeroTensorOperator.h
@@ -170,4 +170,4 @@ inline RankZeroTensorOperator operator-(RankZeroTensorOperator A, RankZeroTensor
     return out;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/TensorOperator.h
+++ b/src/qmoperators/TensorOperator.h
@@ -67,4 +67,4 @@ protected:
     T oper[I];
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/AngularMomentumOperator.h
+++ b/src/qmoperators/one_electron/AngularMomentumOperator.h
@@ -21,4 +21,4 @@ protected:
     MomentumOperator p;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/DeltaOperator.cpp
+++ b/src/qmoperators/one_electron/DeltaOperator.cpp
@@ -37,4 +37,4 @@ void QMDelta::clear() {
     clearApplyPrec();
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/DeltaOperator.h
+++ b/src/qmoperators/one_electron/DeltaOperator.h
@@ -28,4 +28,4 @@ protected:
     QMDelta delta;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/DistanceOperator.cpp
+++ b/src/qmoperators/one_electron/DistanceOperator.cpp
@@ -49,4 +49,4 @@ void DistancePotential::clear() {
     clearApplyPrec();    // apply_prec = -1
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/DistanceOperator.h
+++ b/src/qmoperators/one_electron/DistanceOperator.h
@@ -30,4 +30,4 @@ protected:
     DistancePotential r_pow;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/ElectricFieldOperator.h
+++ b/src/qmoperators/one_electron/ElectricFieldOperator.h
@@ -36,11 +36,11 @@ public:
     }
 
     /** @brief returns the total nuclear contribution to the interaction
- * energy
- *
- * @param[in] the set of nuclei
- *
- */
+     * energy
+     *
+     * @param[in] the set of nuclei
+     *
+     */
     ComplexDouble trace(const Nuclei &nucs) {
         ComplexDouble result = 0.0;
         for (auto &nuc_k : nucs) result += trace(nuc_k);
@@ -48,11 +48,11 @@ public:
     }
 
     /** @brief returns contribution to the interaction energy from a
- * single nucleus
- *
- * @param[in] the nucleus
- *
- */
+     * single nucleus
+     *
+     * @param[in] the nucleus
+     *
+     */
     ComplexDouble trace(const Nucleus &nuc) { return -dipole.trace(nuc).dot(field); }
 
     using RankZeroTensorOperator::trace;
@@ -62,4 +62,4 @@ protected:
     H_E_dip dipole;        ///< the dipole moment operator
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/H_BB_dia.h
+++ b/src/qmoperators/one_electron/H_BB_dia.h
@@ -25,4 +25,4 @@ protected:
     PositionOperator r;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/H_BM_dia.h
+++ b/src/qmoperators/one_electron/H_BM_dia.h
@@ -38,4 +38,4 @@ protected:
     PositionOperator r_k;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/H_B_dip.h
+++ b/src/qmoperators/one_electron/H_B_dip.h
@@ -19,4 +19,4 @@ protected:
     AngularMomentumOperator l;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/H_B_spin.h
+++ b/src/qmoperators/one_electron/H_B_spin.h
@@ -20,4 +20,4 @@ protected:
     SpinOperator s;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/H_E_dip.h
+++ b/src/qmoperators/one_electron/H_E_dip.h
@@ -3,7 +3,7 @@
 #include "PositionOperator.h"
 #include "chemistry/Nucleus.h"
 
-/** Class H_E_dip 
+/** Class H_E_dip
  *
  * @brief Electric dipole operator
  *
@@ -31,10 +31,10 @@ public:
     }
 
     /** @brief returns the nuclear contribution to the dipole moment
- *
- * @param[in] the set of nuclei
- *
- */
+     *
+     * @param[in] the set of nuclei
+     *
+     */
     ComplexVector trace(const Nuclei &nucs) {
         ComplexVector result = ComplexVector::Zero(3);
         for (auto &nuc_k : nucs) result += trace(nuc_k);
@@ -42,10 +42,10 @@ public:
     }
 
     /** @brief returns the contribution to the dipole moment
- *
- * @param[in] the nucleus
- *
- */
+     *
+     * @param[in] the nucleus
+     *
+     */
     ComplexVector trace(const Nucleus &nuc) {
         ComplexVector result = ComplexVector::Zero(3);
         double Z = nuc.getCharge();
@@ -59,4 +59,4 @@ public:
     using RankOneTensorOperator<3>::trace;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/H_M_fc.h
+++ b/src/qmoperators/one_electron/H_M_fc.h
@@ -24,4 +24,4 @@ protected:
     DeltaOperator delta;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/H_M_pso.h
+++ b/src/qmoperators/one_electron/H_M_pso.h
@@ -23,4 +23,4 @@ protected:
     AngularMomentumOperator l;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/IdentityOperator.cpp
+++ b/src/qmoperators/one_electron/IdentityOperator.cpp
@@ -51,4 +51,4 @@ ComplexMatrix IdentityOperator::dagger(OrbitalVector &bra, OrbitalVector &ket) {
     return operator()(bra, ket);
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/IdentityOperator.h
+++ b/src/qmoperators/one_electron/IdentityOperator.h
@@ -39,4 +39,4 @@ protected:
     QMIdentity I;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/KineticOperator.cpp
+++ b/src/qmoperators/one_electron/KineticOperator.cpp
@@ -91,4 +91,4 @@ ComplexMatrix KineticOperator::dagger(OrbitalVector &bra, OrbitalVector &ket) {
     NOT_IMPLEMENTED_ABORT;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/KineticOperator.h
+++ b/src/qmoperators/one_electron/KineticOperator.h
@@ -38,4 +38,4 @@ protected:
     MomentumOperator p;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/MagneticFieldOperator.h
+++ b/src/qmoperators/one_electron/MagneticFieldOperator.h
@@ -36,4 +36,4 @@ protected:
     H_B_dip dipole;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/MomentumOperator.h
+++ b/src/qmoperators/one_electron/MomentumOperator.h
@@ -38,4 +38,4 @@ protected:
     QMMomentum p_z;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/NablaOperator.h
+++ b/src/qmoperators/one_electron/NablaOperator.h
@@ -38,4 +38,4 @@ protected:
     QMNabla d_z;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/NuclearGradientOperator.cpp
+++ b/src/qmoperators/one_electron/NuclearGradientOperator.cpp
@@ -32,4 +32,4 @@ void NuclearGradientPotential::clear() {
     clearApplyPrec();    // apply_prec = -1
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/NuclearGradientOperator.h
+++ b/src/qmoperators/one_electron/NuclearGradientOperator.h
@@ -37,4 +37,4 @@ protected:
     NuclearGradientPotential z_rm3;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/NuclearOperator.cpp
+++ b/src/qmoperators/one_electron/NuclearOperator.cpp
@@ -50,7 +50,7 @@ NuclearPotential::NuclearPotential(const Nuclei &nucs, double prec)
 }
 
 /** @brief computes the interaction energy of the nuclear potential with a second set of nuclei.
- * 
+ *
  * @param[in] nucs the set of nuclei
  *
  * Note: this function is not suited to compute the nuclear self-energy
@@ -69,4 +69,4 @@ double NuclearOperator::trace(const Nuclei &nucs) {
     return E_nuc;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/NuclearOperator.h
+++ b/src/qmoperators/one_electron/NuclearOperator.h
@@ -41,4 +41,4 @@ private:
     NuclearPotential r_m1;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/PositionOperator.cpp
+++ b/src/qmoperators/one_electron/PositionOperator.cpp
@@ -37,4 +37,4 @@ void PositionPotential::clear() {
     clearApplyPrec();    // apply_prec = -1
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/PositionOperator.h
+++ b/src/qmoperators/one_electron/PositionOperator.h
@@ -35,4 +35,4 @@ protected:
     PositionPotential r_z;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/QMPotential.cpp
+++ b/src/qmoperators/one_electron/QMPotential.cpp
@@ -154,4 +154,4 @@ void QMPotential::calcImagPart(Orbital &out, Orbital &inp, bool dagger) {
     }
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/SpinOperator.cpp
+++ b/src/qmoperators/one_electron/SpinOperator.cpp
@@ -52,4 +52,4 @@ Orbital QMSpin::dagger(Orbital inp) {
     NOT_IMPLEMENTED_ABORT;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/SpinOperator.h
+++ b/src/qmoperators/one_electron/SpinOperator.h
@@ -38,4 +38,4 @@ protected:
     QMSpin s_z;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/one_electron/X_rm3.h
+++ b/src/qmoperators/one_electron/X_rm3.h
@@ -23,4 +23,4 @@ protected:
     PositionOperator r;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/qmoperator_fwd.h
+++ b/src/qmoperators/qmoperator_fwd.h
@@ -44,7 +44,7 @@
  *                [Q_21,   Q_22,   \cdots, Q_2N  ]
  *                [\cdots, \cdots, \cdots, \cdots]
  *                [Q_M1,   Q_M2,   \cdots, Q_MN  ]
- * 
+ *
  * A particular component can be applied in the following way:
  *      \psi = Q[i][j](\phi)
  *
@@ -53,7 +53,7 @@
  * a single fundamental operator), but these can easily be reused by other
  * operators, e.g. the AngularMomentumOperator is constructed from
  * PositionOperator and MomentumOperator:
- * 
+ *
  *      l[0] = (r[1]p[2] - r[2]p[1])
  *      l[1] = (r[2]p[0] - r[0]p[2])
  *      l[2] = (r[0]p[1] - r[1]p[0])
@@ -70,4 +70,4 @@ class RankZeroTensorOperator;
 template <int I> class RankOneTensorOperator;
 template <int I, int J> class RankTwoTensorOperator;
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/CoulombOperator.h
+++ b/src/qmoperators/two_electron/CoulombOperator.h
@@ -47,4 +47,4 @@ private:
     CoulombPotential *potential;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/CoulombPotential.cpp
+++ b/src/qmoperators/two_electron/CoulombPotential.cpp
@@ -37,7 +37,7 @@ CoulombPotential::CoulombPotential(PoissonOperator *P)
  * operator to the density. If the density is not available it is computed
  * from the current orbitals (assuming that the orbitals are available).
  * For first-order perturbations the first order density and the Hessian will be
- * computed. In order to make the Hessian available to CoulombOperator, it is stored in the 
+ * computed. In order to make the Hessian available to CoulombOperator, it is stored in the
  * potential function instead of the zeroth-order potential.
  *
  */
@@ -91,4 +91,4 @@ void CoulombPotential::setupPotential(double prec) {
     Printer::printTree(0, "Coulomb potential", n, t);
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/CoulombPotential.h
+++ b/src/qmoperators/two_electron/CoulombPotential.h
@@ -44,4 +44,4 @@ protected:
     void setupPotential(double prec);
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/CoulombPotentialD1.cpp
+++ b/src/qmoperators/two_electron/CoulombPotentialD1.cpp
@@ -34,4 +34,4 @@ void CoulombPotentialD1::setupDensity(double prec) {
     Printer::printTree(0, "Coulomb density", n, t);
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/CoulombPotentialD1.h
+++ b/src/qmoperators/two_electron/CoulombPotentialD1.h
@@ -14,4 +14,4 @@ private:
     void setupDensity(double prec);
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/CoulombPotentialD2.cpp
+++ b/src/qmoperators/two_electron/CoulombPotentialD2.cpp
@@ -37,4 +37,4 @@ void CoulombPotentialD2::setupDensity(double prec) {
     Printer::printTree(0, "Perturbed Coulomb density", n, t);
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/CoulombPotentialD2.h
+++ b/src/qmoperators/two_electron/CoulombPotentialD2.h
@@ -16,4 +16,4 @@ private:
     void setupDensity(double prec);
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/ExchangeOperator.h
+++ b/src/qmoperators/two_electron/ExchangeOperator.h
@@ -36,4 +36,4 @@ protected:
     ExchangePotential *exchange;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/ExchangePotential.cpp
+++ b/src/qmoperators/two_electron/ExchangePotential.cpp
@@ -182,23 +182,23 @@ void ExchangePotential::setupInternal(double prec) {
     for (int i = 0; i < Phi.size(); i++) calcInternal(i);
 
     // Off-diagonal must come last because it IS in-place
-    OrbitalIterator iter(Phi, true); //symmetric iterator
+    OrbitalIterator iter(Phi, true); // symmetric iterator
     Orbital ex_rcv;
-    while (iter.next(1)) { //one orbital at the time
+    while (iter.next(1)) { // one orbital at the time
         if (iter.get_size() > 0) {
             Orbital &phi_i = iter.orbital(0);
             int idx = iter.idx(0);
             for (int j = 0; j < Phi.size(); j++) {
-                if (mpi::my_orb(phi_i) and j <= idx) continue; //compute only i<j for own block
+                if (mpi::my_orb(phi_i) and j <= idx) continue; // compute only i<j for own block
                 Orbital &phi_j = (*this->orbitals)[j];
                 if (mpi::my_orb(phi_j)) calcInternal(idx, j, phi_i, phi_j);
             }
-            //must send exchange_i to owner and receive exchange computed by other
+            // must send exchange_i to owner and receive exchange computed by other
             if (iter.get_step(0) and not mpi::my_orb(phi_i))
                 mpi::send_function(Ex[idx], phi_i.rankID(), idx, mpi::comm_orb);
 
             if (iter.get_sent_size()) {
-                //get exchange from where we sent orbital to
+                // get exchange from where we sent orbital to
                 int idx_sent = iter.get_idx_sent(0);
                 int sent_rank = iter.get_rank_sent(0);
                 mpi::recv_function(ex_rcv, sent_rank, idx_sent, mpi::comm_orb);
@@ -209,8 +209,8 @@ void ExchangePotential::setupInternal(double prec) {
                 mpi::send_function(Ex[idx], phi_i.rankID(), idx, mpi::comm_orb);
             if (not mpi::my_orb(Ex[idx])) Ex[idx].free(NUMBER::Total);
         } else {
-            if (iter.get_sent_size()) { //must receive exchange computed by other
-                //get exchange from where we sent orbital to
+            if (iter.get_sent_size()) { // must receive exchange computed by other
+                // get exchange from where we sent orbital to
                 int idx_sent = iter.get_idx_sent(0);
                 int sent_rank = iter.get_rank_sent(0);
                 mpi::recv_function(ex_rcv, sent_rank, idx_sent, mpi::comm_orb);
@@ -227,8 +227,8 @@ void ExchangePotential::setupInternal(double prec) {
         n += Ex[i].getNNodes(NUMBER::Total);
     }
 
-    mpi::allreduce_vector(this->tot_norms, mpi::comm_orb);  //to be checked
-    mpi::allreduce_matrix(this->part_norms, mpi::comm_orb); //to be checked
+    mpi::allreduce_vector(this->tot_norms, mpi::comm_orb);  // to be checked
+    mpi::allreduce_matrix(this->part_norms, mpi::comm_orb); // to be checked
 
     timer.stop();
     double t = timer.getWallTime();
@@ -271,7 +271,7 @@ void ExchangePotential::calcInternal(int i) {
         this->part_norms(i, i) = phi_iii.norm();
         this->exchange.push_back(phi_iii);
     } else {
-        //put empty orbital to fill the exchange vector
+        // put empty orbital to fill the exchange vector
         Orbital phi_iii = phi_i.paramCopy();
         this->exchange.push_back(phi_iii);
     }
@@ -387,31 +387,31 @@ double ExchangePotential::getScaledPrecision(int i, int j) const {
 }
 
 /** @brief determines the exchange factor to be used in the calculation of the exact exchange
-  *
-  * @param [in] orb input orbital to which K is applied
-  *
-  * The factor is computed in terms of the occupancy of the two orbitals and in terms of the spin
-  * 0.5 factors are used in order to preserve occupancy of the set of doubly occupied orbitals
-  * this-> is the orbital defining the operator whereas the input orbital (orb) is the one
-  * the operator is applied to
-  *
-  * Occupancy: Single/Double
-  * Spin: alpha/beta
-  *
-  * K (this->) | orb (input) | factor
-  * alpha      | alpha       | 1.0
-  * alpha      | beta        | 0.0
-  * alpha      | double      | 0.5
-  * -------------------------------
-  * beta       | alpha       | 0.0
-  * beta       | beta        | 1.0
-  * beta       | double      | 0.5
-  * -------------------------------
-  * double     | alpha       | 1.0
-  * double     | beta        | 1.0
-  * double     | double      | 1.0
-  *
-  */
+ *
+ * @param [in] orb input orbital to which K is applied
+ *
+ * The factor is computed in terms of the occupancy of the two orbitals and in terms of the spin
+ * 0.5 factors are used in order to preserve occupancy of the set of doubly occupied orbitals
+ * this-> is the orbital defining the operator whereas the input orbital (orb) is the one
+ * the operator is applied to
+ *
+ * Occupancy: Single/Double
+ * Spin: alpha/beta
+ *
+ * K (this->) | orb (input) | factor
+ * alpha      | alpha       | 1.0
+ * alpha      | beta        | 0.0
+ * alpha      | double      | 0.5
+ * -------------------------------
+ * beta       | alpha       | 0.0
+ * beta       | beta        | 1.0
+ * beta       | double      | 0.5
+ * -------------------------------
+ * double     | alpha       | 1.0
+ * double     | beta        | 1.0
+ * double     | double      | 1.0
+ *
+ */
 double ExchangePotential::getSpinFactor(Orbital phi_i, Orbital phi_j) const {
     double out = 0.0;
     if (phi_j.spin() == SPIN::Paired)
@@ -423,4 +423,4 @@ double ExchangePotential::getSpinFactor(Orbital phi_i, Orbital phi_j) const {
     return out;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/ExchangePotential.h
+++ b/src/qmoperators/two_electron/ExchangePotential.h
@@ -57,4 +57,4 @@ protected:
     void calcInternal(int i, int j, Orbital &phi_i, Orbital &phi_j);
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/FockOperator.cpp
+++ b/src/qmoperators/two_electron/FockOperator.cpp
@@ -46,7 +46,7 @@ FockOperator::FockOperator(KineticOperator *t,
         , ext(ext) {}
 
 /** @brief build the Fock operator once all contributions are in place
- * 
+ *
  */
 void FockOperator::build() {
     this->T = RankZeroTensorOperator();
@@ -188,4 +188,4 @@ ComplexMatrix FockOperator::dagger(OrbitalVector &bra, OrbitalVector &ket) {
     NOT_IMPLEMENTED_ABORT;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/FockOperator.h
+++ b/src/qmoperators/two_electron/FockOperator.h
@@ -76,4 +76,4 @@ protected:
     ElectricFieldOperator *ext; ///< Total external potential
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/XCOperator.h
+++ b/src/qmoperators/two_electron/XCOperator.h
@@ -41,4 +41,4 @@ private:
     XCPotential *potential;
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/XCPotential.cpp
+++ b/src/qmoperators/two_electron/XCPotential.cpp
@@ -64,9 +64,9 @@ mrcpp::FunctionTree<3> &XCPotential::getDensity(int spin) {
     MSG_FATAL("Invalid density type");
 }
 
-//NOTE AFTER DISCUSSION WITH STIG: Need to move stuff that is
-//iteration-independent out of the response loop, so that all required
-//functions, which only depend on the GS density are computed
-//once. Comment: still the grid for rho_1 is borrowed from rho_0 and
-//rho_0 should still be available.
+// NOTE AFTER DISCUSSION WITH STIG: Need to move stuff that is
+// iteration-independent out of the response loop, so that all required
+// functions, which only depend on the GS density are computed
+// once. Comment: still the grid for rho_1 is borrowed from rho_0 and
+// rho_0 should still be available.
 } // namespace mrchem

--- a/src/qmoperators/two_electron/XCPotential.h
+++ b/src/qmoperators/two_electron/XCPotential.h
@@ -53,4 +53,4 @@ protected:
     void setupDensity(double prec = -1.0);
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/XCPotentialD1.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD1.cpp
@@ -28,7 +28,7 @@ XCPotentialD1::XCPotentialD1(mrdft::XCFunctional *F, OrbitalVector *Phi)
         : XCPotential(F, Phi) {}
 
 /** @brief Prepare the operator for application
- * 
+ *
  * @param[in] prec Apply precision
  *
  * Sequence of steps required to compute the XC potentials:
@@ -121,4 +121,4 @@ Orbital XCPotentialD1::apply(Orbital phi) {
     return Vphi;
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/XCPotentialD1.h
+++ b/src/qmoperators/two_electron/XCPotentialD1.h
@@ -41,4 +41,4 @@ private:
     Orbital apply(Orbital phi);
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/qmoperators/two_electron/XCPotentialD2.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD2.cpp
@@ -42,7 +42,7 @@ XCPotentialD2::~XCPotentialD2() {
 }
 
 /** @brief Prepare the operator for application
- * 
+ *
  * @param[in] prec Apply precision
  *
  * Sequence of steps required to compute the XC potentials:
@@ -56,9 +56,9 @@ XCPotentialD2::~XCPotentialD2() {
 void XCPotentialD2::setup(double prec) {
     if (isSetup(prec)) return;
     setApplyPrec(prec);
-    //setupDensity(prec);
+    // setupDensity(prec);
     setupPerturbedDensity(prec);
-    //setupPotential(prec);
+    // setupPotential(prec);
 }
 
 /** @brief Clears all data in the XCPotentialD2 object */
@@ -73,7 +73,7 @@ void XCPotentialD2::clear() {
     clearApplyPrec();
 }
 
-//LUCA This does not work in the case of a non spin separated functional used for an open-shell system!!
+// LUCA This does not work in the case of a non spin separated functional used for an open-shell system!!
 void XCPotentialD2::setupPerturbedDensity(double prec) {
     if (this->orbitals_x == nullptr) MSG_ERROR("Orbitals not initialized");
     if (this->orbitals_y == nullptr) MSG_ERROR("Orbitals not initialized");
@@ -159,15 +159,15 @@ int XCPotentialD2::getPotentialIndex(int orbitalSpin, int densitySpin) {
 
     int spinFunctional = this->functional->isSpinSeparated() ? 1 : 0;
 
-    //Potential order (spin separated): v_aa, v_ab, v_bb
-    //Potential order (spin restricted, total density only): v_rr
+    // Potential order (spin separated): v_aa, v_ab, v_bb
+    // Potential order (spin restricted, total density only): v_rr
 
     int functional_case = spinFunctional; // 0  1
     functional_case += orbitalSpin << 1;  // 0  2  4  6
     functional_case += densitySpin << 3;  // 0  8 16 24
 
-    //OS Paired Alpha Beta
-    //DS Total  Spin  Alpha Beta
+    // OS Paired Alpha Beta
+    // DS Total  Spin  Alpha Beta
 
     // SF    OS             DS          case   Index
     switch (functional_case) {
@@ -260,7 +260,7 @@ Orbital XCPotentialD2::apply(Orbital phi) {
         NOT_IMPLEMENTED_ABORT;
     }
 
-    mrcpp::build_grid(*Vrho, components); //LUCA just using "add" results in loss of precision.
+    mrcpp::build_grid(*Vrho, components); // LUCA just using "add" results in loss of precision.
     mrcpp::add(-1.0, *Vrho, components);
     this->setReal(Vrho);
     Orbital Vrhophi = QMPotential::apply(phi);
@@ -292,13 +292,13 @@ FunctionTree<3> *XCPotentialD2::buildComponentGrad(int orbital_spin, int density
     mrcpp::FunctionTreeVector<3> d2fdrdg(potentials.begin() + 1, potentials.begin() + 4);
     mrcpp::FunctionTreeVector<3> d2fdgdgx(potentials.begin() + 4, potentials.begin() + 7);
     mrcpp::FunctionTreeVector<3> d2fdgdgy;
-    d2fdgdgy.push_back(potentials[5]); //yx --> xy
-    d2fdgdgy.push_back(potentials[7]); //yy
-    d2fdgdgy.push_back(potentials[8]); //yz
+    d2fdgdgy.push_back(potentials[5]); // yx --> xy
+    d2fdgdgy.push_back(potentials[7]); // yy
+    d2fdgdgy.push_back(potentials[8]); // yz
     mrcpp::FunctionTreeVector<3> d2fdgdgz;
-    d2fdgdgz.push_back(potentials[6]); //zx --> xz
-    d2fdgdgz.push_back(potentials[8]); //zy --> yz
-    d2fdgdgz.push_back(potentials[9]); //zz
+    d2fdgdgz.push_back(potentials[6]); // zx --> xz
+    d2fdgdgz.push_back(potentials[8]); // zy --> yz
+    d2fdgdgz.push_back(potentials[9]); // zz
 
     mrcpp::FunctionTree<3> *prod1 = new FunctionTree<3>(*MRA);
     mrcpp::build_grid(*prod1, densities);
@@ -432,7 +432,7 @@ FunctionTree<3> *XCPotentialD2::buildComponentGamma(int orbital_spin, int densit
     return component;
 }
 
-//Copied from XCFunctional. Ideally it should end up in mrcpp
+// Copied from XCFunctional. Ideally it should end up in mrcpp
 FunctionTree<3> *XCPotentialD2::calcGradDotPotDensVec(mrcpp::FunctionTree<3> &V, mrcpp::FunctionTreeVector<3> &rho) {
     mrcpp::DerivativeOperator<3> *derivative = new mrcpp::ABGVOperator<3>(*MRA, 0.0, 0.0);
     mrcpp::FunctionTreeVector<3> vec;

--- a/src/qmoperators/two_electron/XCPotentialD2.h
+++ b/src/qmoperators/two_electron/XCPotentialD2.h
@@ -51,12 +51,12 @@ private:
 
     Orbital apply(Orbital phi);
 
-    //LUCA I wanted to include the following declarations in the cpp
-    //file but i did not manage to get the syntax (copied from
-    //density_utils.copp) right.
+    // LUCA I wanted to include the following declarations in the cpp
+    // file but i did not manage to get the syntax (copied from
+    // density_utils.copp) right.
     int getPotentialIndex(int orbitalSpin, int densitySpin);
     void setupPerturbedDensity(double prec = -1.0);
     mrcpp::FunctionTree<3> *calcGradDotPotDensVec(mrcpp::FunctionTree<3> &V, mrcpp::FunctionTreeVector<3> &rho);
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/utils/MolPlot.h
+++ b/src/utils/MolPlot.h
@@ -75,7 +75,7 @@ protected:
         double min = 1.0e10;
         double isoval = 0.0;
         for (int n = 0; n < nRealPoints; n++) {
-            o << this->values[n] << " "; //12.5E
+            o << this->values[n] << " "; // 12.5E
             if (n % 6 == 5) o << std::endl;
             if (this->values[n] < min) min = this->values[n];
             if (this->values[n] > max) max = this->values[n];
@@ -96,4 +96,4 @@ protected:
     }
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/utils/NonlinearMaximizer.h
+++ b/src/utils/NonlinearMaximizer.h
@@ -47,7 +47,7 @@ public:
     int maximize();
 
 protected:
-    int N2h; //size (for orbital localization: N2h = N*(N-1)/2)
+    int N2h; // size (for orbital localization: N2h = N*(N-1)/2)
     DoubleMatrix hessian;
     DoubleVector gradient;
 
@@ -59,4 +59,4 @@ protected:
     virtual void do_step(const DoubleVector &step) {}
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/utils/RRMaximizer.cpp
+++ b/src/utils/RRMaximizer.cpp
@@ -48,7 +48,7 @@ RRMaximizer::RRMaximizer(double prec, OrbitalVector &Phi) {
     this->r_i_orig = DoubleMatrix::Zero(this->N, 3 * this->N);
     this->r_i = DoubleMatrix(this->N, 3 * this->N);
 
-    //Make R matrix
+    // Make R matrix
     PositionOperator r;
     r.setup(prec);
 
@@ -68,13 +68,13 @@ RRMaximizer::RRMaximizer(double prec, OrbitalVector &Phi) {
     OrbitalChunk yPhi = mpi::get_my_chunk(yPhi_Vec);
     OrbitalChunk zPhi = mpi::get_my_chunk(zPhi_Vec);
 
-    OrbitalIterator iter(Phi, true); //symmetric iterator;
+    OrbitalIterator iter(Phi, true); // symmetric iterator;
     while (iter.next(1)) {
         for (int i = 0; i < iter.get_size(); i++) {
             int idx_i = iter.idx(i);
             Orbital &bra_i = iter.orbital(i);
             for (int j = 0; j < xPhi.size(); j++) {
-                //note that idx_j are the same for x, y and z
+                // note that idx_j are the same for x, y and z
                 int idx_j = std::get<0>(xPhi[j]);
                 if (mpi::my_orb(bra_i) and idx_j > idx_i) continue;
                 Orbital &ket_j_x = std::get<1>(xPhi[j]);
@@ -113,7 +113,7 @@ RRMaximizer::RRMaximizer(double prec, OrbitalVector &Phi) {
     r_y.clear();
     r_z.clear();
 
-    //rotate R matrices into orthonormal basis
+    // rotate R matrices into orthonormal basis
     ComplexMatrix S_m12 = orbital::calc_lowdin_matrix(Phi);
     this->total_U = S_m12.real() * this->total_U;
 
@@ -122,14 +122,14 @@ RRMaximizer::RRMaximizer(double prec, OrbitalVector &Phi) {
         for (int j = 0; j < this->N; j++) {
             for (int i = 0; i <= j; i++) {
                 R(i, j) = this->r_i_orig(i, j + d * this->N);
-                R(j, i) = this->r_i_orig(i, j + d * this->N); //Enforce symmetry
+                R(j, i) = this->r_i_orig(i, j + d * this->N); // Enforce symmetry
             }
         }
         R = this->total_U.transpose() * R * this->total_U;
         for (int j = 0; j < this->N; j++) {
             for (int i = 0; i <= j; i++) {
                 this->r_i(i, j + d * this->N) = R(i, j);
-                this->r_i(j, i + d * this->N) = R(i, j); //Enforce symmetry
+                this->r_i(j, i + d * this->N) = R(i, j); // Enforce symmetry
             }
         }
     }
@@ -139,7 +139,7 @@ RRMaximizer::RRMaximizer(double prec, OrbitalVector &Phi) {
  * f$  \sum_{i=1,N}\langle i| {\bf R}| i \rangle^2\f$
  */
 double RRMaximizer::functional() const {
-    //s1 is what should be maximized (i.e. the sum of <i R i>^2)
+    // s1 is what should be maximized (i.e. the sum of <i R i>^2)
     double s1 = 0.0;
     for (int d = 0; d < 3; d++) {
         for (int j = 0; j < this->N; j++) {
@@ -389,7 +389,7 @@ double RRMaximizer::get_hessian(int ij, int kl) {
  */
 void RRMaximizer::do_step(const DoubleVector &step) {
     DoubleMatrix A(this->N, this->N);
-    //define rotation U=exp(-A), A real antisymmetric, from step
+    // define rotation U=exp(-A), A real antisymmetric, from step
     int ij = 0;
     for (int j = 0; j < this->N; j++) {
         for (int i = 0; i < j; i++) {
@@ -400,11 +400,11 @@ void RRMaximizer::do_step(const DoubleVector &step) {
         A(j, j) = 0.0;
     }
 
-    //calculate U=exp(-A) by diagonalization and U=Vexp(id)Vt with VdVt=iA
-    //could also sum the term in the expansion if A is small
+    // calculate U=exp(-A) by diagonalization and U=Vexp(id)Vt with VdVt=iA
+    // could also sum the term in the expansion if A is small
     this->total_U *= math_utils::skew_matrix_exp(A);
 
-    //rotate the original r matrix with total U
+    // rotate the original r matrix with total U
     DoubleMatrix r(this->N, this->N);
     for (int d = 0; d < 3; d++) {
         for (int j = 0; j < this->N; j++) {
@@ -417,4 +417,4 @@ void RRMaximizer::do_step(const DoubleVector &step) {
     }
 }
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/utils/RRMaximizer.h
+++ b/src/utils/RRMaximizer.h
@@ -57,4 +57,4 @@ protected:
     void do_step(const DoubleVector &step);
 };
 
-} //namespace mrchem
+} // namespace mrchem

--- a/src/utils/gto_utils/AOBasis.cpp
+++ b/src/utils/gto_utils/AOBasis.cpp
@@ -73,5 +73,5 @@ GaussExp<3> AOBasis::getNormBasis(const mrcpp::Coord<3> &center) const {
     return abas;
 }
 
-} //namespace gto_utils
-} //namespace mrchem
+} // namespace gto_utils
+} // namespace mrchem

--- a/src/utils/gto_utils/AOBasis.h
+++ b/src/utils/gto_utils/AOBasis.h
@@ -38,5 +38,5 @@ private:
     std::vector<AOContraction *> ctrs;
 };
 
-} //namespace gto_utils
-} //namespace mrchem
+} // namespace gto_utils
+} // namespace mrchem

--- a/src/utils/gto_utils/AOContraction.cpp
+++ b/src/utils/gto_utils/AOContraction.cpp
@@ -117,5 +117,5 @@ void AOContraction::append(double e, double c) {
     this->coefs.push_back(c);
 }
 
-} //namespace gto_utils
-} //namespace mrchem
+} // namespace gto_utils
+} // namespace mrchem

--- a/src/utils/gto_utils/AOContraction.h
+++ b/src/utils/gto_utils/AOContraction.h
@@ -43,5 +43,5 @@ protected:
     std::vector<double> coefs;
 };
 
-} //namespace gto_utils
-} //namespace mrchem
+} // namespace gto_utils
+} // namespace mrchem

--- a/src/utils/gto_utils/Intgrl.cpp
+++ b/src/utils/gto_utils/Intgrl.cpp
@@ -32,8 +32,8 @@ Intgrl::~Intgrl() {
 void Intgrl::readIntgrlFile(std::ifstream &ifs) {
     int nTypes;
     std::string line;
-    GETLINE(ifs, line); //First line is a comment
-    GETLINE(ifs, line); //Second line is number of atom types
+    GETLINE(ifs, line); // First line is a comment
+    GETLINE(ifs, line); // Second line is number of atom types
     std::istringstream iss(line);
     iss >> nTypes;
     for (int i = 0; i < nTypes; i++) { readAtomBlock(ifs); }
@@ -126,5 +126,5 @@ GaussExp<3> Intgrl::getMolBasis(bool norm) const {
     return molexp;
 }
 
-} //namespace gto_utils
-} //namespace mrchem
+} // namespace gto_utils
+} // namespace mrchem

--- a/src/utils/gto_utils/Intgrl.h
+++ b/src/utils/gto_utils/Intgrl.h
@@ -40,5 +40,5 @@ protected:
     void readAtomData(std::ifstream &ifs, int n_atoms, double z);
 };
 
-} //namespace gto_utils
-} //namespace mrchem
+} // namespace gto_utils
+} // namespace mrchem

--- a/src/utils/gto_utils/OrbitalExp.cpp
+++ b/src/utils/gto_utils/OrbitalExp.cpp
@@ -32,7 +32,7 @@ GaussExp<3> OrbitalExp::getMO(int i, const DoubleMatrix &M) const {
     int n = 0;
     for (int j = 0; j < size(); j++) {
         GaussExp<3> ao_j = getAO(j);
-        //ao_i.normalize();
+        // ao_i.normalize();
         if (std::abs(M(i, j)) > mrcpp::MachineZero) {
             ao_j *= M(i, j);
             mo_i.append(ao_j);
@@ -46,7 +46,7 @@ GaussExp<3> OrbitalExp::getMO(int i, const DoubleMatrix &M) const {
         zeroExp.append(zeroFunc);
         mo_i.append(zeroExp);
     }
-    //mo_i->normalize();
+    // mo_i->normalize();
     return mo_i;
 }
 
@@ -74,7 +74,7 @@ void OrbitalExp::rotate(const DoubleMatrix &U) {
         int n = 0;
         for (int j = 0; j < size(); j++) {
             GaussExp<3> ao_j = getAO(j);
-            //ao_j.normalize();
+            // ao_j.normalize();
             if (std::abs(U(i, j)) > mrcpp::MachineZero) {
                 ao_j *= U(i, j);
                 mo_i->append(ao_j);
@@ -88,7 +88,7 @@ void OrbitalExp::rotate(const DoubleMatrix &U) {
             ao_j.append(zeroFunc);
             mo_i->append(ao_j);
         }
-        //mo_i->normalize();
+        // mo_i->normalize();
         tmp.push_back(mo_i);
     }
     for (int i = 0; i < size(); i++) {
@@ -208,5 +208,5 @@ int OrbitalExp::getAngularMomentum(int n) const {
     return l;
 }
 
-} //namespace gto_utils
-} //namespace mrchem
+} // namespace gto_utils
+} // namespace mrchem

--- a/src/utils/gto_utils/OrbitalExp.h
+++ b/src/utils/gto_utils/OrbitalExp.h
@@ -33,5 +33,5 @@ protected:
     void transformToSpherical();
 };
 
-} //namespace gto_utils
-} //namespace mrchem
+} // namespace gto_utils
+} // namespace mrchem

--- a/src/utils/math_utils.cpp
+++ b/src/utils/math_utils.cpp
@@ -99,12 +99,12 @@ DoubleMatrix read_matrix_file(const std::string &file) {
  *      \f$iA\f$ (V unitary complex matrix)
  */
 DoubleMatrix skew_matrix_exp(const DoubleMatrix &A) {
-    //calculates U=exp(-A)=exp(i(iA)) iA=HermitianMatrix
-    //skew=antisymmetric real
+    // calculates U=exp(-A)=exp(i(iA)) iA=HermitianMatrix
+    // skew=antisymmetric real
     ComplexDouble im(0.0, 1.0);
     ComplexMatrix Aim = im * A;
 
-    //NB: eigenvalues are real, but eigenvectors are complex
+    // NB: eigenvalues are real, but eigenvectors are complex
     DoubleVector diag;
     ComplexMatrix U = diagonalize_hermitian_matrix(Aim, diag);
 
@@ -112,7 +112,7 @@ DoubleMatrix skew_matrix_exp(const DoubleMatrix &A) {
     for (int j = 0; j < A.cols(); j++) { diagim(j, j) = std::exp(im * diag(j)); }
 
     Aim = U * diagim * U.adjoint();
-    return Aim.real(); //imaginary part is zero
+    return Aim.real(); // imaginary part is zero
 }
 
 /** @brief Compute the power of a Hermitian matrix
@@ -150,8 +150,8 @@ ComplexMatrix hermitian_matrix_pow(const ComplexMatrix &A, double b) {
 ComplexMatrix diagonalize_hermitian_matrix(const ComplexMatrix &A, DoubleVector &diag) {
     Eigen::SelfAdjointEigenSolver<ComplexMatrix> es(A.cols());
     es.compute(A);
-    diag = es.eigenvalues();  //real
-    return es.eigenvectors(); //complex
+    diag = es.eigenvalues();  // real
+    return es.eigenvectors(); // complex
 }
 
 /** @brief Compute the eigenvalues and eigenvectors of a Hermitian matrix block
@@ -172,5 +172,5 @@ void diagonalize_block(ComplexMatrix &A, ComplexMatrix &U, int nstart, int nsize
     A.block(nstart, nstart, nsize, nsize) = ei_val.asDiagonal();
 }
 
-} //namespace math_utils
-} //namespace mrchem
+} // namespace math_utils
+} // namespace mrchem

--- a/src/utils/math_utils.h
+++ b/src/utils/math_utils.h
@@ -46,5 +46,5 @@ ComplexMatrix hermitian_matrix_pow(const ComplexMatrix &A, double b);
 ComplexMatrix diagonalize_hermitian_matrix(const ComplexMatrix &A, DoubleVector &diag);
 void diagonalize_block(ComplexMatrix &M, ComplexMatrix &U, int nstart, int nsize);
 
-} //namespace math_utils
-} //namespace mrchem
+} // namespace math_utils
+} // namespace mrchem

--- a/tests/qmfunctions/orbital.cpp
+++ b/tests/qmfunctions/orbital.cpp
@@ -156,4 +156,4 @@ TEST_CASE("Orbital", "[orbital]") {
     }
 }
 
-} //namespace orbital_tests
+} // namespace orbital_tests

--- a/tests/qmfunctions/orbital_vector.cpp
+++ b/tests/qmfunctions/orbital_vector.cpp
@@ -300,4 +300,4 @@ TEST_CASE("OrbitalVector", "[orbital_vector]") {
     }
 }
 
-} //namespace orbital_vector_tests
+} // namespace orbital_vector_tests

--- a/tests/qmfunctions/qmfunction.cpp
+++ b/tests/qmfunctions/qmfunction.cpp
@@ -283,4 +283,4 @@ TEST_CASE("QMFunction", "[qmfunction]") {
     }
 }
 
-} //namespace qmfunction_tests
+} // namespace qmfunction_tests

--- a/tests/qmoperators/electric_field_operator.cpp
+++ b/tests/qmoperators/electric_field_operator.cpp
@@ -72,10 +72,10 @@ TEST_CASE("ElectricFieldOperator", "[electric_field_operator]") {
     ElectricFieldOperator EF(field, {0.0, 0.0, 0.0});
     EF.setup(prec);
 
-    //origin
+    // origin
     mrcpp::Coord<3> o{0.4, 0.3, 0.2};
 
-    //setting up the orbitals
+    // setting up the orbitals
     for (int i = 0; i < nFuncs; i++) Phi.push_back(Orbital(SPIN::Paired));
     mpi::distribute(Phi);
 
@@ -85,7 +85,7 @@ TEST_CASE("ElectricFieldOperator", "[electric_field_operator]") {
     }
 
     SECTION("apply") {
-        //update ref based on MPI
+        // update ref based on MPI
         for (int i = 0; i < nFuncs; i++) {
             for (int j = 0; j < nFuncs; j++) {
                 if (not(mpi::my_orb(Phi[i])) or not(mpi::my_orb(Phi[j]))) ref(i, j) = 0.0;
@@ -106,7 +106,7 @@ TEST_CASE("ElectricFieldOperator", "[electric_field_operator]") {
     }
 
     SECTION("vector apply") {
-        //update ref based on MPI
+        // update ref based on MPI
         for (int i = 0; i < nFuncs; i++) {
             for (int j = 0; j < nFuncs; j++) {
                 if (not(mpi::my_orb(Phi[i])) or not(mpi::my_orb(Phi[j]))) ref(i, j) = 0.0;
@@ -177,4 +177,4 @@ TEST_CASE("ElectricFieldEnergy", "[electric_field_energy]") {
     EF.clear();
 }
 
-} //namespace electric_field_operator
+} // namespace electric_field_operator

--- a/tests/qmoperators/identity_operator.cpp
+++ b/tests/qmoperators/identity_operator.cpp
@@ -132,4 +132,4 @@ TEST_CASE("IdentityOperator", "[identity_operator]") {
     }
 }
 
-} //namespace identity_operator_tests
+} // namespace identity_operator_tests

--- a/tests/qmoperators/kinetic_operator.cpp
+++ b/tests/qmoperators/kinetic_operator.cpp
@@ -59,12 +59,12 @@ TEST_CASE("KineticOperator", "[kinetic_operator]") {
     // reference values for harmonic oscillator eigenfunctions
     DoubleVector E_K(nFuncs);
     for (int i = 0; i < nFuncs; i++) {
-        //energy = (nu + 1/2)
+        // energy = (nu + 1/2)
         double E_x = (i + 0.5);
         double E_y = (0 + 0.5);
         double E_z = (0 + 0.5);
 
-        //virial theorem: <E_K> = <E_P> = E/2
+        // virial theorem: <E_K> = <E_P> = E/2
         E_K(i) = 0.5 * (E_x + E_y + E_z);
     }
 
@@ -116,4 +116,4 @@ TEST_CASE("KineticOperator", "[kinetic_operator]") {
     T.clear();
 }
 
-} //namespace kinetic_operator
+} // namespace kinetic_operator

--- a/tests/qmoperators/nuclear_operator.cpp
+++ b/tests/qmoperators/nuclear_operator.cpp
@@ -76,11 +76,11 @@ TEST_CASE("NuclearOperator", "[nuclear_operator]") {
     DoubleVector E_P(Phi.size());
     for (int n = 1; n <= nShells; n++) {
         int L = n;
-        double E_n = 1.0 / (2.0 * n * n); //E_n = Z^2/(2*n^2)
+        double E_n = 1.0 / (2.0 * n * n); // E_n = Z^2/(2*n^2)
         for (int l = 0; l < L; l++) {
             int M = 2 * l + 1;
             for (int m = 0; m < M; m++) {
-                E_P(i++) = -2.0 * E_n; //virial theorem: 2<E_K> = -<E_P>
+                E_P(i++) = -2.0 * E_n; // virial theorem: 2<E_K> = -<E_P>
             }
         }
     }

--- a/tests/qmoperators/position_operator.cpp
+++ b/tests/qmoperators/position_operator.cpp
@@ -81,4 +81,4 @@ TEST_CASE("PositionOperator", "[position_operator]") {
     r.clear();
 }
 
-} //namespace position_operator
+} // namespace position_operator


### PR DESCRIPTION
clang-format is updated such that commenting styles will be consistent all over the project

Now the code has comments both starting and without blank spaces, i.e.,

`//comment`
`// comment`
This instances of `//comment` are now changed to `// comment`