### PR TITLE
broadcast_density only among share_masters, not among slaves

### DIFF
--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -132,8 +132,8 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, int spin) {
     if (rho.isShared()) {
         int tag = 3141;
         // MPI grand master distributes to shared masters
-        mpi::broadcast_density(rho_loc, mpi::comm_sh_group);
         if (mpi::share_master()) {
+            mpi::broadcast_density(rho_loc, mpi::comm_sh_group);
             // MPI shared masters copies the function into final memory
             mrcpp::copy_grid(rho.real(), rho_loc.real());
             mrcpp::copy_func(rho.real(), rho_loc.real());


### PR DESCRIPTION
The part densities where broadcasted among shared-slaves with same ranks. Only sharemasters should broadcast densities. (could, in some cases, give accounting errors when the trees were deleted, though did not give wrong results. (Also with the latest getNchunksUsed this can not happen))