### PR TITLE
Fix FetchContent

### DIFF
--- a/external/upstream/fetch_getkw.cmake
+++ b/external/upstream/fetch_getkw.cmake
@@ -11,7 +11,7 @@ else()
     GIT_REPOSITORY
       https://github.com/dev-cafe/libgetkw.git
     GIT_TAG
-      986403e1f9b50210d6e45bb4fa336f08ddd31960 # Preferable to have a tag for a release
+      b0174c4c1b8df187fbabe34db47160eedf72faca # Preferable to have a tag for a release
     CMAKE_ARGS
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/external/upstream/fetch_getkw.cmake
+++ b/external/upstream/fetch_getkw.cmake
@@ -12,8 +12,6 @@ else()
       https://github.com/dev-cafe/libgetkw.git
     GIT_TAG
       986403e1f9b50210d6e45bb4fa336f08ddd31960 # Preferable to have a tag for a release
-    GIT_SHALLOW
-      1
     CMAKE_ARGS
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/external/upstream/fetch_mrcpp.cmake
+++ b/external/upstream/fetch_mrcpp.cmake
@@ -12,8 +12,6 @@ else()
       https://github.com/MRChemSoft/mrcpp.git
     GIT_TAG
       16da6e17742b3d6a2e0b1517f91ee086c0bd828a # Preferable to have a tag for a release
-    GIT_SHALLOW
-      1
     CMAKE_ARGS
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/external/upstream/fetch_xcfun.cmake
+++ b/external/upstream/fetch_xcfun.cmake
@@ -15,8 +15,6 @@ else()
       https://github.com/dftlibs/xcfun.git
     GIT_TAG
       a486a3f1483925c84590cf7ea012cf177f67ae9b # Preferable to have a tag for a release
-    GIT_SHALLOW
-      1
     CMAKE_ARGS
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}


### PR DESCRIPTION
* Remove `GIT_SHALLOW 1` in MRCPP, XCFun and Getkw so that we can point to older revisions.
* Update MRCPP and Getkw to latest and greatest.