### PR TITLE
Fix path to getkw Python packages

### DIFF
--- a/cmake/custom/main.cmake
+++ b/cmake/custom/main.cmake
@@ -7,13 +7,6 @@ set(PYTHON_SITE_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/python${PYTHON_VERSION_MAJOR
 
 # Fetch dependencies
 include(${PROJECT_SOURCE_DIR}/external/upstream/fetch_getkw.cmake)
-file(
-  COPY
-    ${getkw_sources_BINARY_DIR}/Python/${PYTHON_SITE_INSTALL_DIR}/getkw.py
-    ${getkw_sources_BINARY_DIR}/Python/${PYTHON_SITE_INSTALL_DIR}/pyparsing.py
-  DESTINATION
-    ${PROJECT_BINARY_DIR}/${PYTHON_SITE_INSTALL_DIR}
-  )
 include(${PROJECT_SOURCE_DIR}/external/upstream/fetch_xcfun.cmake)
 include(${PROJECT_SOURCE_DIR}/external/upstream/fetch_eigen3.cmake)
 include(${PROJECT_SOURCE_DIR}/external/upstream/fetch_mrcpp.cmake)

--- a/external/upstream/fetch_getkw.cmake
+++ b/external/upstream/fetch_getkw.cmake
@@ -9,9 +9,9 @@ else()
   FetchContent_Populate(getkw_sources
     QUIET
     GIT_REPOSITORY
-      https://github.com/dev-cafe/libgetkw.git
+      https://github.com/robertodr/libgetkw.git
     GIT_TAG
-      b0174c4c1b8df187fbabe34db47160eedf72faca # Preferable to have a tag for a release
+      config-modules # Preferable to have a tag for a release
     CMAKE_ARGS
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/external/upstream/fetch_getkw.cmake
+++ b/external/upstream/fetch_getkw.cmake
@@ -9,9 +9,9 @@ else()
   FetchContent_Populate(getkw_sources
     QUIET
     GIT_REPOSITORY
-      https://github.com/robertodr/libgetkw.git
+      https://github.com/dev-cafe/libgetkw.git
     GIT_TAG
-      config-modules # Preferable to have a tag for a release
+      bb3eb9726bc443d34f89629b025e90a4fc793c73 # Preferable to have a tag for a release
     CMAKE_ARGS
       -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
       -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}

--- a/src/mrchem.in
+++ b/src/mrchem.in
@@ -39,7 +39,7 @@ OFF = 0
 # FIXME This will pick up modules when installed
 sys.path.append("@CMAKE_INSTALL_PREFIX@/@PYTHON_SITE_INSTALL_DIR@")
 # FIXME For use from within the build tree
-sys.path.append("@PROJECT_BINARY_DIR@/@PYTHON_SITE_INSTALL_DIR@")
+sys.path.append("@getkw_PYMOD@")
 sys.path.append('@PROJECT_SOURCE_DIR@/src/chemistry')
 
 import getkw  # isort:skip


### PR DESCRIPTION
My take on #207 in tandem with dev-cafe/libgetkw#32. I have tested with a prebuilt and a fetched getkw. When dev-cafe/libgetkw#32 is in, I'll switch back to the right commit on the canonical repo.