### PR TITLE
Implement case-insensitive input reading

### DIFF
--- a/doc/mrchem_manual.rst
+++ b/doc/mrchem_manual.rst
@@ -7,7 +7,8 @@ The mrchem input file
 ---------------------
 
 The input file is organized in sections and keywords that can be of different
-type
+type.
+Input reading is **case-insensitive**.
 
 .. code-block:: bash
 
@@ -40,7 +41,7 @@ with ``abs_prec``. This will provide e.g. mHa precision in the total energy
 regardless of the molecular size (this might get `very` expensive for large
 systems). In this case the magnitude of the energy is estimated as
 
-.. math:: \tilde{E} = \sum_i^{nuc} Z_i^{5/2} 
+.. math:: \tilde{E} = \sum_i^{nuc} Z_i^{5/2}
 
 and the relative precision is set as
 
@@ -142,7 +143,7 @@ WaveFunction
 
 Here we give the wavefunction method and whether we run spin restricted (alpha
 and beta spins are forced to occupy the same spatial orbitals) or not (method
-must be specified, otherwise defaults are shown) 
+must be specified, otherwise defaults are shown)
 
 .. code-block:: bash
 
@@ -157,7 +158,7 @@ functional(s) must be specified in a separate DFT section (see below).
 
 DFT
 ---
- 
+
 This section specifies the exchange-correlation functional used in DFT
 (functional names must be specified, otherwise defaults are shown)
 
@@ -271,7 +272,7 @@ in the SCF iterations. To improve efficiency, the first iterations are done
 with reduced precision, starting at ``init`` and gradually increased
 to ``final``. The initial precision should not be set lower than
 ``init=1.0e-3``, and the final precision should not exceed the top level
-``rel_prec``. Negative values sets them equal to ``rel_prec``. 
+``rel_prec``. Negative values sets them equal to ``rel_prec``.
 
 The ``kain`` keyword sets the size of the iterative subspace that is used
 in the KAIN accelerator for the orbital optimization.
@@ -335,7 +336,7 @@ Example 2
 ---------
 
 The following input will compute the B3LYP energy (six digits) and dipole moment
-(four digits) of carbon monoxide 
+(four digits) of carbon monoxide
 
 .. code-block:: bash
 

--- a/src/SCFDriver.cpp
+++ b/src/SCFDriver.cpp
@@ -62,109 +62,109 @@ SCFDriver::SCFDriver(Getkw &input) {
     rel_prec = input.get<double>("rel_prec");
     nuc_prec = input.get<double>("nuc_prec");
 
-    gauge = input.getDblVec("MRA.gauge_origin");
-    center_of_mass = input.get<bool>("MRA.center_of_mass");
-    center_of_charge = input.get<bool>("MRA.center_of_charge");
+    gauge = input.getDblVec("mra.gauge_origin");
+    center_of_mass = input.get<bool>("mra.center_of_mass");
+    center_of_charge = input.get<bool>("mra.center_of_charge");
 
-    diff_kin = input.get<std::string>("Derivatives.kinetic");
-    diff_orb = input.get<std::string>("Derivatives.h_orb");
-    diff_pso = input.get<std::string>("Derivatives.h_pso");
+    diff_kin = input.get<std::string>("derivatives.kinetic");
+    diff_orb = input.get<std::string>("derivatives.h_orb");
+    diff_pso = input.get<std::string>("derivatives.h_pso");
 
-    calc_scf_energy = input.get<bool>("Properties.scf_energy");
-    calc_dipole_moment = input.get<bool>("Properties.dipole_moment");
-    calc_quadrupole_moment = input.get<bool>("Properties.quadrupole_moment");
-    calc_magnetizability = input.get<bool>("Properties.magnetizability");
-    calc_nmr_shielding = input.get<bool>("Properties.nmr_shielding");
-    calc_hyperfine_coupling = input.get<bool>("Properties.hyperfine_coupling");
-    calc_spin_spin_coupling = input.get<bool>("Properties.spin_spin_coupling");
-    calc_polarizability = input.get<bool>("Properties.polarizability");
-    calc_hyperpolarizability = input.get<bool>("Properties.hyperpolarizability");
-    calc_optical_rotation = input.get<bool>("Properties.optical_rotation");
-    calc_geometry_derivatives = input.get<bool>("Properties.geometry_derivatives");
+    calc_scf_energy = input.get<bool>("properties.scf_energy");
+    calc_dipole_moment = input.get<bool>("properties.dipole_moment");
+    calc_quadrupole_moment = input.get<bool>("properties.quadrupole_moment");
+    calc_magnetizability = input.get<bool>("properties.magnetizability");
+    calc_nmr_shielding = input.get<bool>("properties.nmr_shielding");
+    calc_hyperfine_coupling = input.get<bool>("properties.hyperfine_coupling");
+    calc_spin_spin_coupling = input.get<bool>("properties.spin_spin_coupling");
+    calc_polarizability = input.get<bool>("properties.polarizability");
+    calc_hyperpolarizability = input.get<bool>("properties.hyperpolarizability");
+    calc_optical_rotation = input.get<bool>("properties.optical_rotation");
+    calc_geometry_derivatives = input.get<bool>("properties.geometry_derivatives");
 
-    nmr_perturbation = input.get<std::string>("NMRShielding.perturbation");
-    nmr_nucleus_k = input.getIntVec("NMRShielding.nucleus_k");
-    hfcc_nucleus_k = input.getIntVec("HyperfineCoupling.nucleus_k");
-    sscc_nucleus_k = input.getIntVec("SpinSpinCoupling.nucleus_k");
-    sscc_nucleus_l = input.getIntVec("SpinSpinCoupling.nucleus_l");
-    pol_velocity = input.get<bool>("Polarizability.velocity");
-    pol_frequency = input.getDblVec("Polarizability.frequency");
-    optrot_velocity = input.get<bool>("OpticalRotation.velocity");
-    optrot_frequency = input.getDblVec("OpticalRotation.frequency");
-    optrot_perturbation = input.get<std::string>("OpticalRotation.perturbation");
+    nmr_perturbation = input.get<std::string>("nmrshielding.perturbation");
+    nmr_nucleus_k = input.getIntVec("nmrshielding.nucleus_k");
+    hfcc_nucleus_k = input.getIntVec("hyperfinecoupling.nucleus_k");
+    sscc_nucleus_k = input.getIntVec("spinspincoupling.nucleus_k");
+    sscc_nucleus_l = input.getIntVec("spinspincoupling.nucleus_l");
+    pol_velocity = input.get<bool>("polarizability.velocity");
+    pol_frequency = input.getDblVec("polarizability.frequency");
+    optrot_velocity = input.get<bool>("opticalrotation.velocity");
+    optrot_frequency = input.getDblVec("opticalrotation.frequency");
+    optrot_perturbation = input.get<std::string>("opticalrotation.perturbation");
 
-    mol_charge = input.get<int>("Molecule.charge");
-    mol_multiplicity = input.get<int>("Molecule.multiplicity");
-    mol_coords = input.getData("Molecule.coords");
+    mol_charge = input.get<int>("molecule.charge");
+    mol_multiplicity = input.get<int>("molecule.multiplicity");
+    mol_coords = input.getData("molecule.coords");
 
-    wf_restricted = input.get<bool>("WaveFunction.restricted");
-    wf_method = input.get<std::string>("WaveFunction.method");
+    wf_restricted = input.get<bool>("wavefunction.restricted");
+    wf_method = input.get<std::string>("wavefunction.method");
 
-    if (wf_method == "DFT") {
-        dft_spin = input.get<bool>("DFT.spin");
-        dft_use_gamma = input.get<bool>("DFT.use_gamma");
-        dft_cutoff = input.get<double>("DFT.density_cutoff");
-        dft_func_coefs = input.getDblVec("DFT.func_coefs");
-        dft_func_names = input.getData("DFT.functionals");
+    if (wf_method == "dft") {
+        dft_spin = input.get<bool>("dft.spin");
+        dft_use_gamma = input.get<bool>("dft.use_gamma");
+        dft_cutoff = input.get<double>("dft.density_cutoff");
+        dft_func_coefs = input.getDblVec("dft.func_coefs");
+        dft_func_names = input.getData("dft.functionals");
     }
 
-    scf_run = input.get<bool>("SCF.run");
-    scf_start = input.get<std::string>("SCF.initial_guess");
-    scf_kain = input.get<int>("SCF.kain");
-    scf_max_iter = input.get<int>("SCF.max_iter");
-    scf_rotation = input.get<int>("SCF.rotation");
-    scf_canonical = input.get<bool>("SCF.canonical");
-    scf_write_orbitals = input.get<bool>("SCF.write_orbitals");
-    scf_orbital_thrs = input.get<double>("SCF.orbital_thrs");
-    scf_property_thrs = input.get<double>("SCF.property_thrs");
-    scf_lambda_thrs = input.get<double>("SCF.lambda_thrs");
-    scf_orbital_prec = input.getDblVec("SCF.orbital_prec");
+    scf_run = input.get<bool>("scf.run");
+    scf_start = input.get<std::string>("scf.initial_guess");
+    scf_kain = input.get<int>("scf.kain");
+    scf_max_iter = input.get<int>("scf.max_iter");
+    scf_rotation = input.get<int>("scf.rotation");
+    scf_canonical = input.get<bool>("scf.canonical");
+    scf_write_orbitals = input.get<bool>("scf.write_orbitals");
+    scf_orbital_thrs = input.get<double>("scf.orbital_thrs");
+    scf_property_thrs = input.get<double>("scf.property_thrs");
+    scf_lambda_thrs = input.get<double>("scf.lambda_thrs");
+    scf_orbital_prec = input.getDblVec("scf.orbital_prec");
 
-    kin_free_run = input.get<bool>("KineticFree.run");
-    kin_free_max_iter = input.get<int>("KineticFree.max_iter");
-    kin_free_canonical = input.get<bool>("KineticFree.canonical");
-    kin_free_orb_thrs = input.get<double>("KineticFree.orbital_thrs");
-    kin_free_prop_thrs = input.get<double>("KineticFree.property_thrs");
+    kin_free_run = input.get<bool>("kineticfree.run");
+    kin_free_max_iter = input.get<int>("kineticfree.max_iter");
+    kin_free_canonical = input.get<bool>("kineticfree.canonical");
+    kin_free_orb_thrs = input.get<double>("kineticfree.orbital_thrs");
+    kin_free_prop_thrs = input.get<double>("kineticfree.property_thrs");
 
-    rsp_run = input.get<bool>("Response.run");
-    rsp_start = input.get<std::string>("Response.initial_guess");
-    rsp_kain = input.get<int>("Response.kain");
-    rsp_max_iter = input.get<int>("Response.max_iter");
-    rsp_canonical = input.get<bool>("Response.canonical");
-    rsp_write_orbitals = input.get<bool>("Response.write_orbitals");
-    rsp_orbital_thrs = input.get<double>("Response.orbital_thrs");
-    rsp_property_thrs = input.get<double>("Response.property_thrs");
-    rsp_directions = input.getIntVec("Response.directions");
-    rsp_orbital_prec = input.getDblVec("Response.orbital_prec");
+    rsp_run = input.get<bool>("response.run");
+    rsp_start = input.get<std::string>("response.initial_guess");
+    rsp_kain = input.get<int>("response.kain");
+    rsp_max_iter = input.get<int>("response.max_iter");
+    rsp_canonical = input.get<bool>("response.canonical");
+    rsp_write_orbitals = input.get<bool>("response.write_orbitals");
+    rsp_orbital_thrs = input.get<double>("response.orbital_thrs");
+    rsp_property_thrs = input.get<double>("response.property_thrs");
+    rsp_directions = input.getIntVec("response.directions");
+    rsp_orbital_prec = input.getDblVec("response.orbital_prec");
 
-    ext_electric = input.get<bool>("ExternalField.electric_run");
-    ext_magnetic = input.get<bool>("ExternalField.magnetic_run");
+    ext_electric = input.get<bool>("externalfield.electric_run");
+    ext_magnetic = input.get<bool>("externalfield.magnetic_run");
     if (ext_electric) {
-        std::vector<double> tmp = input.getDblVec("ExternalField.electric_field");
+        std::vector<double> tmp = input.getDblVec("externalfield.electric_field");
         ext_electric_field[0] = tmp[0];
         ext_electric_field[1] = tmp[1];
         ext_electric_field[2] = tmp[2];
     }
     if (ext_magnetic) {
-        std::vector<double> tmp = input.getDblVec("ExternalField.magnetic_field");
+        std::vector<double> tmp = input.getDblVec("externalfield.magnetic_field");
         ext_magnetic_field[0] = tmp[0];
         ext_magnetic_field[1] = tmp[1];
         ext_magnetic_field[2] = tmp[2];
     }
 
-    file_start_orbitals = input.get<std::string>("Files.start_orbitals");
-    file_final_orbitals = input.get<std::string>("Files.final_orbitals");
-    file_start_x_orbs = input.get<std::string>("Files.start_x_orbs");
-    file_final_x_orbs = input.get<std::string>("Files.final_x_orbs");
-    file_start_y_orbs = input.get<std::string>("Files.start_y_orbs");
-    file_final_y_orbs = input.get<std::string>("Files.final_y_orbs");
-    file_basis_set = input.get<std::string>("Files.basis_set");
-    file_dens_mat_a = input.get<std::string>("Files.dens_mat_a");
-    file_dens_mat_b = input.get<std::string>("Files.dens_mat_b");
-    file_fock_mat = input.get<std::string>("Files.fock_mat");
-    file_energy_vec = input.get<std::string>("Files.energy_vec");
-    file_mo_mat_a = input.get<std::string>("Files.mo_mat_a");
-    file_mo_mat_b = input.get<std::string>("Files.mo_mat_b");
+    file_start_orbitals = input.get<std::string>("files.start_orbitals");
+    file_final_orbitals = input.get<std::string>("files.final_orbitals");
+    file_start_x_orbs = input.get<std::string>("files.start_x_orbs");
+    file_final_x_orbs = input.get<std::string>("files.final_x_orbs");
+    file_start_y_orbs = input.get<std::string>("files.start_y_orbs");
+    file_final_y_orbs = input.get<std::string>("files.final_y_orbs");
+    file_basis_set = input.get<std::string>("files.basis_set");
+    file_dens_mat_a = input.get<std::string>("files.dens_mat_a");
+    file_dens_mat_b = input.get<std::string>("files.dens_mat_b");
+    file_fock_mat = input.get<std::string>("files.fock_mat");
+    file_energy_vec = input.get<std::string>("files.energy_vec");
+    file_mo_mat_a = input.get<std::string>("files.mo_mat_a");
+    file_mo_mat_b = input.get<std::string>("files.mo_mat_b");
 
     r_O[0] = 0.0;
     r_O[1] = 0.0;
@@ -383,17 +383,17 @@ void SCFDriver::setup() {
     // All cases need kinetic energy and nuclear potential
     fock = new FockOperator(T, V);
     // For Hartree, HF and DFT we need the coulomb part
-    if (wf_method == "Hartree" or wf_method == "HF" or wf_method == "DFT") {
+    if (wf_method == "hartree" or wf_method == "hf" or wf_method == "dft") {
         J = new CoulombOperator(P, phi);
         fock->setCoulombOperator(J);
     }
     // For HF we need the full HF exchange
-    if (wf_method == "HF") {
+    if (wf_method == "hf") {
         K = new ExchangeOperator(P, phi);
         fock->setExchangeOperator(K);
     }
     // For DFT we need the XC operator
-    if (wf_method == "DFT") {
+    if (wf_method == "dft") {
         xcfun = setupFunctional(MRDFT::Gradient);
         XC = new XCOperator(xcfun, phi);
         fock->setXCOperator(XC);
@@ -418,9 +418,9 @@ void SCFDriver::setup() {
  *
  */
 mrcpp::DerivativeOperator<3> *SCFDriver::useDerivative(string derivative_name) {
-    if (derivative_name == "PH_1") return PH_1;
-    if (derivative_name == "ABGV_00") return ABGV_00;
-    if (derivative_name == "ABGV_55") return ABGV_55;
+    if (derivative_name == "ph_1") return PH_1;
+    if (derivative_name == "abgv_00") return ABGV_00;
+    if (derivative_name == "abgv_55") return ABGV_55;
     MSG_FATAL("No such derivative operator");
 }
 
@@ -463,17 +463,17 @@ void SCFDriver::setup_np1() {
 
     fock_np1 = new FockOperator(T, V);
     // For Hartree, HF and DFT we need the coulomb part
-    if (wf_method == "Hartree" or wf_method == "HF" or wf_method == "DFT") {
+    if (wf_method == "hartree" or wf_method == "hf" or wf_method == "dft") {
         J_np1 = new CoulombOperator(P, phi_np1);
         fock_np1->setCoulombOperator(J_np1);
     }
     // For HF we need the full HF exchange
-    if (wf_method == "HF") {
+    if (wf_method == "hf") {
         K_np1 = new ExchangeOperator(P, phi);
         fock_np1->setExchangeOperator(K_np1);
     }
     // For DFT we need the XC operator
-    if (wf_method == "DFT") {
+    if (wf_method == "dft") {
         xcfun = setupFunctional(MRDFT::Gradient);
         XC_np1 = new XCOperator(xcfun, phi_np1);
         fock_np1->setXCOperator(XC_np1);
@@ -496,28 +496,28 @@ void SCFDriver::clear_np1() {
 
 void SCFDriver::setupInitialGroundState() {
     double prec = scf_orbital_prec[0];
-    if (scf_start == "GTO")
+    if (scf_start == "gto")
         if (wf_restricted)
             *phi = initial_guess::gto::setup(prec, *molecule, file_basis_set, file_mo_mat_a);
         else
             *phi = initial_guess::gto::setup(prec, *molecule, file_basis_set, file_mo_mat_a, file_mo_mat_b);
-    else if (scf_start == "CORE_SZ")
+    else if (scf_start == "core_sz")
         *phi = initial_guess::core::setup(prec, *molecule, wf_restricted, 1);
-    else if (scf_start == "CORE_DZ")
+    else if (scf_start == "core_dz")
         *phi = initial_guess::core::setup(prec, *molecule, wf_restricted, 2);
-    else if (scf_start == "CORE_TZ")
+    else if (scf_start == "core_tz")
         *phi = initial_guess::core::setup(prec, *molecule, wf_restricted, 3);
-    else if (scf_start == "CORE_QZ")
+    else if (scf_start == "core_qz")
         *phi = initial_guess::core::setup(prec, *molecule, wf_restricted, 4);
-    else if (scf_start == "SAD_SZ")
+    else if (scf_start == "sad_sz")
         *phi = initial_guess::sad::setup(prec, *molecule, wf_restricted, 1);
-    else if (scf_start == "SAD_DZ")
+    else if (scf_start == "sad_dz")
         *phi = initial_guess::sad::setup(prec, *molecule, wf_restricted, 2);
-    else if (scf_start == "SAD_TZ")
+    else if (scf_start == "sad_tz")
         *phi = initial_guess::sad::setup(prec, *molecule, wf_restricted, 3);
-    else if (scf_start == "SAD_QZ")
+    else if (scf_start == "sad_qz")
         *phi = initial_guess::sad::setup(prec, *molecule, wf_restricted, 4);
-    else if (scf_start == "MW")
+    else if (scf_start == "mw")
         *phi = orbital::load_orbitals(file_start_orbitals);
     else
         MSG_FATAL("Invalid initial guess");
@@ -592,9 +592,9 @@ void SCFDriver::setupPerturbedOperators(const ResponseCalculation &rsp_calc) {
     if (phi_y == nullptr) MSG_ERROR("Y orbitals not initialized");
 
     double xFac = 0.0;
-    if (wf_method == "HF") {
+    if (wf_method == "hf") {
         xFac = 1.0;
-    } else if (wf_method == "DFT") {
+    } else if (wf_method == "dft") {
         xFac = xcfun->amountEXX();
         xcfun = setupFunctional(MRDFT::Hessian);
         dXC = new XCOperator(xcfun, phi, phi_x, phi_y);

--- a/src/initial_guess/core_guess.cpp
+++ b/src/initial_guess/core_guess.cpp
@@ -36,7 +36,7 @@
 #include "qmfunctions/Orbital.h"
 #include "qmfunctions/orbital_utils.h"
 
-Getkw mrchem::Input;
+Getkw mrchem::input;
 mrcpp::MultiResolutionAnalysis<3> *mrchem::MRA;
 
 using namespace mrcpp;
@@ -68,19 +68,19 @@ int main(int argc, char **argv) {
     Timer timer;
 
     // Reading input
-    double prec = Input.get<double>("rel_prec");
-    bool wf_restricted = Input.get<bool>("WaveFunction.restricted");
-    int mol_charge = Input.get<int>("Molecule.charge");
-    int mol_multiplicity = Input.get<int>("Molecule.multiplicity");
-    std::vector<std::string> mol_coords = Input.getData("Molecule.coords");
-    std::string scf_guess = Input.get<std::string>("SCF.initial_guess");
-    std::string orb_file = Input.get<std::string>("Files.start_orbitals");
+    double prec = input.get<double>("rel_prec");
+    bool wf_restricted = input.get<bool>("wavefunction.restricted");
+    int mol_charge = input.get<int>("molecule.charge");
+    int mol_multiplicity = input.get<int>("molecule.multiplicity");
+    std::vector<std::string> mol_coords = input.getData("molecule.coords");
+    std::string scf_guess = input.get<std::string>("scf.initial_guess");
+    std::string orb_file = input.get<std::string>("files.start_orbitals");
 
     int ig_zeta = 0;
-         if (scf_guess == "CORE_SZ") { ig_zeta = 1; }
-    else if (scf_guess == "CORE_DZ") { ig_zeta = 2; }
-    else if (scf_guess == "CORE_TZ") { ig_zeta = 3; }
-    else if (scf_guess == "CORE_QZ") { ig_zeta = 4; }
+         if (scf_guess == "core_sz") { ig_zeta = 1; }
+    else if (scf_guess == "core_dz") { ig_zeta = 2; }
+    else if (scf_guess == "core_tz") { ig_zeta = 3; }
+    else if (scf_guess == "core_qz") { ig_zeta = 4; }
     else { MSG_FATAL("Invalid initial guess"); }
 
     // Setting up molecule

--- a/src/initial_guess/gto_guess.cpp
+++ b/src/initial_guess/gto_guess.cpp
@@ -36,7 +36,7 @@
 #include "qmfunctions/Orbital.h"
 #include "qmfunctions/orbital_utils.h"
 
-Getkw mrchem::Input;
+Getkw mrchem::input;
 mrcpp::MultiResolutionAnalysis<3> *mrchem::MRA;
 
 using namespace mrcpp;
@@ -66,18 +66,18 @@ int main(int argc, char **argv) {
     Timer timer;
 
     // Reading input
-    double prec = Input.get<double>("rel_prec");
-    bool wf_restricted = Input.get<bool>("WaveFunction.restricted");
-    int mol_charge = Input.get<int>("Molecule.charge");
-    int mol_multiplicity = Input.get<int>("Molecule.multiplicity");
-    std::vector<std::string> mol_coords = Input.getData("Molecule.coords");
-    std::string scf_guess = Input.get<std::string>("SCF.initial_guess");
-    std::string orb_file = Input.get<std::string>("Files.start_orbitals");
-    std::string bas_file = Input.get<std::string>("Files.basis_set");
-    std::string moa_file = Input.get<std::string>("Files.mo_mat_a");
-    std::string mob_file = Input.get<std::string>("Files.mo_mat_b");
+    double prec = input.get<double>("rel_prec");
+    bool wf_restricted = input.get<bool>("wavefunction.restricted");
+    int mol_charge = input.get<int>("molecule.charge");
+    int mol_multiplicity = input.get<int>("molecule.multiplicity");
+    std::vector<std::string> mol_coords = input.getData("molecule.coords");
+    std::string scf_guess = input.get<std::string>("scf.initial_guess");
+    std::string orb_file = input.get<std::string>("files.start_orbitals");
+    std::string bas_file = input.get<std::string>("files.basis_set");
+    std::string moa_file = input.get<std::string>("files.mo_mat_a");
+    std::string mob_file = input.get<std::string>("files.mo_mat_b");
 
-    if (scf_guess != "GTO") MSG_FATAL("Invalid initial guess");
+    if (scf_guess != "gto") MSG_FATAL("Invalid initial guess");
 
     // Setting up molecule
     Molecule mol(mol_coords, mol_charge, mol_multiplicity);

--- a/src/initial_guess/lsdalton/lsdalton.py
+++ b/src/initial_guess/lsdalton/lsdalton.py
@@ -1,7 +1,9 @@
 import os
 import re
-from periodictable import PeriodicTableByZ as PTz
+
 from periodictable import PeriodicTableByName as PTn
+from periodictable import PeriodicTableByZ as PTz
+
 
 def makexyz(coords):
     nAtoms = len(coords)
@@ -26,7 +28,7 @@ def makedal(coords, method, charge, mult):
     lsdal = "**GENERAL\n"
     lsdal += ".NOGCBASIS\n"
     lsdal += "**WAVE FUNCTIONS\n"
-    if method == "HF":
+    if method == "hf":
         lsdal += ".HF\n"
     else:
         lsdal += ".DFT\n"

--- a/src/initial_guess/sad_guess.cpp
+++ b/src/initial_guess/sad_guess.cpp
@@ -36,7 +36,7 @@
 #include "qmfunctions/Orbital.h"
 #include "qmfunctions/orbital_utils.h"
 
-Getkw mrchem::Input;
+Getkw mrchem::input;
 mrcpp::MultiResolutionAnalysis<3> *mrchem::MRA;
 
 using namespace mrcpp;
@@ -64,19 +64,19 @@ int main(int argc, char **argv) {
     Timer timer;
 
     // Reading input
-    double prec = Input.get<double>("rel_prec");
-    bool wf_restricted = Input.get<bool>("WaveFunction.restricted");
-    int mol_charge = Input.get<int>("Molecule.charge");
-    int mol_multiplicity = Input.get<int>("Molecule.multiplicity");
-    std::vector<std::string> mol_coords = Input.getData("Molecule.coords");
-    std::string scf_guess = Input.get<std::string>("SCF.initial_guess");
-    std::string orb_file = Input.get<std::string>("Files.start_orbitals");
+    double prec = input.get<double>("rel_prec");
+    bool wf_restricted = input.get<bool>("wavefunction.restricted");
+    int mol_charge = input.get<int>("molecule.charge");
+    int mol_multiplicity = input.get<int>("molecule.multiplicity");
+    std::vector<std::string> mol_coords = input.getData("molecule.coords");
+    std::string scf_guess = input.get<std::string>("scf.initial_guess");
+    std::string orb_file = input.get<std::string>("files.start_orbitals");
 
     int ig_zeta = 0;
-         if (scf_guess == "SAD_SZ") { ig_zeta = 1; }
-    else if (scf_guess == "SAD_DZ") { ig_zeta = 2; }
-    else if (scf_guess == "SAD_TZ") { ig_zeta = 3; }
-    else if (scf_guess == "SAD_QZ") { ig_zeta = 4; }
+         if (scf_guess == "sad_sz") { ig_zeta = 1; }
+    else if (scf_guess == "sad_dz") { ig_zeta = 2; }
+    else if (scf_guess == "sad_tz") { ig_zeta = 3; }
+    else if (scf_guess == "sad_qz") { ig_zeta = 4; }
     else { MSG_FATAL("Invalid initial guess"); }
 
     // Setting up molecule

--- a/src/mrchem.cpp
+++ b/src/mrchem.cpp
@@ -19,7 +19,7 @@
 
 #include "SCFDriver.h"
 
-Getkw mrchem::Input;
+Getkw mrchem::input;
 mrcpp::MultiResolutionAnalysis<3> *mrchem::MRA;
 
 using namespace mrcpp;
@@ -31,7 +31,7 @@ int main(int argc, char **argv) {
 
     Timer timer;
 
-    SCFDriver driver(Input);
+    SCFDriver driver(input);
     driver.setup();
     driver.run();
     driver.clear();

--- a/src/mrchem.h
+++ b/src/mrchem.h
@@ -43,7 +43,7 @@ namespace NUMBER { enum type { Total, Real, Imag }; }
 namespace DENSITY { enum type { Total, Spin, Alpha, Beta }; }
 namespace MRDFT {enum type {Function, Gradient, Hessian}; }
 
- 
+
 using ComplexInt = std::complex<int>;
 using ComplexDouble = std::complex<double>;
 
@@ -55,7 +55,7 @@ using IntMatrix = Eigen::MatrixXi;
 using DoubleMatrix = Eigen::MatrixXd;
 using ComplexMatrix = Eigen::MatrixXcd;
 
-extern Getkw Input;
+extern Getkw input;
 extern mrcpp::MultiResolutionAnalysis<3> *MRA; //< Global MRA
 
 } //namespace mrchem

--- a/src/mrchem.in
+++ b/src/mrchem.in
@@ -75,8 +75,12 @@ def main():
     if printlevel > 1:
         print("Starting " + sys.argv[0])
 
-    input = getkw.GetkwParser()
-    inkw = input.parseFile(inpfil)
+    # Generate temporary file with case fixed (all uppercase)
+    lced = convert_to_lower_case(inpfil)
+    # Parse temporary input file
+    inkw = getkw.GetkwParser().parseFile(lced)
+    # Remove temporary input file
+    os.remove(lced)
     inkw.sanitize(valid_keywords)
     topsect = inkw.get_topsect()
     inkw.run_callbacks(valid_keywords)
@@ -92,6 +96,27 @@ def main():
             fd.seek(0)
             p = subprocess.Popen(executable, stdin=fd)
             sts = os.waitpid(p.pid, 0)[1]
+
+
+            def convert_to_lower_case(filename):
+    """
+    Reads contents of filename and converts them to lowercase.
+    The case-converted contents are written back to a temporary file.
+    """
+    contents = ''
+    final = ''
+    with open(filename, 'r') as inputFile:
+        contents = inputFile.readlines()
+    final = [l.lower() for l in contents]
+
+    # Write to temporary file in current working directory
+    # The temporary file has the name of the input file, joined with a unique id
+    temp, path = tempfile.mkstemp(prefix=filename + '.', dir=os.getcwd())
+    with open(path, 'w') as fout:
+        for l in final:
+            fout.write('{:s}'.format(l))
+        os.close(temp)
+    return path
 
 
 def parse_cmdline():
@@ -154,7 +179,7 @@ def setup_keywords(input_dir):
     top.add_kw('teletype',              'BOOL', False)
     # yapf: enable
 
-    mpi = getkw.Section('MPI')
+    mpi = getkw.Section('mpi')
     # yapf: disable
     mpi.add_kw('numerically_exact',      'BOOL', False)
     mpi.add_kw('share_nuclear_potential','BOOL', False)
@@ -166,10 +191,10 @@ def setup_keywords(input_dir):
     # yapf: enable
     top.add_sect(mpi)
 
-    mra = getkw.Section('MRA', callback=verify_mra)
+    mra = getkw.Section('mra', callback=verify_mra)
     # yapf: disable
     mra.add_kw('order',                 'INT', -1)
-    mra.add_kw('basis_type',            'STR', 'Interpolating')
+    mra.add_kw('basis_type',            'STR', 'interpolating')
     mra.add_kw('min_scale',             'INT', 0)
     mra.add_kw('max_scale',             'INT', 25)
     mra.add_kw('boxes',                 'INT_ARRAY', [1, 1, 1])
@@ -180,16 +205,16 @@ def setup_keywords(input_dir):
     # yapf: enable
     top.add_sect(mra)
 
-    derivatives = getkw.Section('Derivatives')
+    derivatives = getkw.Section('derivatives')
     # yapf: disable
-    derivatives.add_kw('kinetic',       'STR', 'ABGV_55')
-    derivatives.add_kw('h_orb',         'STR', 'ABGV_00')
-    derivatives.add_kw('h_pso',         'STR', 'ABGV_00')
-    derivatives.add_kw('dft',           'STR', 'ABGV_00')
+    derivatives.add_kw('kinetic',       'STR', 'abgv_55')
+    derivatives.add_kw('h_orb',         'STR', 'abgv_00')
+    derivatives.add_kw('h_pso',         'STR', 'abgv_00')
+    derivatives.add_kw('dft',           'STR', 'abgv_00')
     # yapf: enable
     top.add_sect(derivatives)
 
-    molecule = getkw.Section('Molecule', callback=verify_molecule)
+    molecule = getkw.Section('molecule', callback=verify_molecule)
     # yapf: disable
     molecule.add_kw('charge',           'INT', 0)
     molecule.add_kw('multiplicity',     'INT', 1)
@@ -198,14 +223,14 @@ def setup_keywords(input_dir):
     # yapf: enable
     top.add_sect(molecule)
 
-    wavefunction = getkw.Section('WaveFunction', callback=verify_wf)
+    wavefunction = getkw.Section('wavefunction', callback=verify_wf)
     # yapf: disable
     wavefunction.add_kw('restricted',   'BOOL', True)
-    wavefunction.add_kw('method',       'STR', 'HF')
+    wavefunction.add_kw('method',       'STR', 'hf')
     # yapf: enable
     top.add_sect(wavefunction)
 
-    dft = getkw.Section('DFT', callback=verify_dft)
+    dft = getkw.Section('dft', callback=verify_dft)
     # yapf: disable
     dft.add_kw('spin',                  'BOOL', False)
     dft.add_kw('orbital_free',          'BOOL', False)
@@ -216,7 +241,7 @@ def setup_keywords(input_dir):
     # yapf: enable
     top.add_sect(dft)
 
-    properties = getkw.Section('Properties')
+    properties = getkw.Section('properties')
     # yapf: disable
     properties.add_kw('scf_energy',             'BOOL', False)
     properties.add_kw('dipole_moment',          'BOOL', False)
@@ -232,7 +257,7 @@ def setup_keywords(input_dir):
     # yapf: enable
     top.add_sect(properties)
 
-    external_field = getkw.Section('ExternalField', callback=verify_ext_field)
+    external_field = getkw.Section('externalfield', callback=verify_ext_field)
     # yapf: disable
     external_field.add_kw('electric_run',       'BOOL', False)
     external_field.add_kw('electric_field',     'DBL_ARRAY')
@@ -241,7 +266,7 @@ def setup_keywords(input_dir):
     # yapf: enable
     top.add_sect(external_field)
 
-    polarizability = getkw.Section('Polarizability', callback=verify_pol)
+    polarizability = getkw.Section('polarizability', callback=verify_pol)
     # yapf: disable
     polarizability.add_kw('velocity',           'BOOL', False)
     polarizability.add_kw('frequency',          'DBL_ARRAY')
@@ -249,36 +274,36 @@ def setup_keywords(input_dir):
     # yapf: enable
     top.add_sect(polarizability)
 
-    optical_rotation = getkw.Section('OpticalRotation', callback=verify_optrot)
+    optical_rotation = getkw.Section('opticalrotation', callback=verify_optrot)
     # yapf: disable
-    optical_rotation.add_kw('perturbation',     'STR', 'E')
+    optical_rotation.add_kw('perturbation',     'STR', 'e')
     optical_rotation.add_kw('velocity',         'BOOL', False)
     optical_rotation.add_kw('frequency',        'DBL_ARRAY')
     optical_rotation.add_kw('wavelength',       'DBL_ARRAY')
     # yapf: enable
     top.add_sect(optical_rotation)
 
-    nmr = getkw.Section('NMRShielding', callback=verify_nmr)
+    nmr = getkw.Section('nmrshielding', callback=verify_nmr)
     # yapf: disable
-    nmr.add_kw('perturbation',          'STR', 'B')
+    nmr.add_kw('perturbation',          'STR', 'b')
     nmr.add_kw('nucleus_k',             'INT_ARRAY')
     # yapf: enable
     top.add_sect(nmr)
 
-    sscc = getkw.Section('SpinSpinCoupling', callback=verify_sscc)
+    sscc = getkw.Section('spinspincoupling', callback=verify_sscc)
     # yapf: disable
     sscc.add_kw('nucleus_k',            'INT_ARRAY')
     sscc.add_kw('nucleus_l',            'INT_ARRAY')
     # yapf: enable
     top.add_sect(sscc)
 
-    hfcc = getkw.Section('HyperfineCoupling', callback=verify_hfcc)
+    hfcc = getkw.Section('hyperfinecoupling', callback=verify_hfcc)
     # yapf: disable
     hfcc.add_kw('nucleus_k',            'INT_ARRAY')
     # yapf: enable
     top.add_sect(hfcc)
 
-    scf = getkw.Section('SCF', callback=verify_scf)
+    scf = getkw.Section('scf', callback=verify_scf)
     # yapf: disable
     scf.add_kw('run',                   'BOOL', True)
     scf.add_kw('max_iter',              'INT', -1)
@@ -294,7 +319,7 @@ def setup_keywords(input_dir):
     # yapf: enable
     top.add_sect(scf)
 
-    kinetic_free = getkw.Section('KineticFree', callback=verify_kinetic_free)
+    kinetic_free = getkw.Section('kineticfree', callback=verify_kinetic_free)
     # yapf: disable
     kinetic_free.add_kw('run',                   'BOOL', False)
     kinetic_free.add_kw('max_iter',              'INT', -1)
@@ -304,7 +329,7 @@ def setup_keywords(input_dir):
     # yapf: enable
     top.add_sect(kinetic_free)
 
-    response = getkw.Section('Response', callback=verify_response)
+    response = getkw.Section('response', callback=verify_response)
     # yapf: disable
     response.add_kw('run',              'BOOL', True)
     response.add_kw('max_iter',         'INT', -1)
@@ -319,15 +344,15 @@ def setup_keywords(input_dir):
     # yapf: enable
     top.add_sect(response)
 
-    initial = getkw.Section('LSDalton')
+    initial = getkw.Section('lsdalton')
     # yapf: disable
     initial.add_kw('run',               'BOOL', False)
-    initial.add_kw('basis',             'STR', '3-21G')
-    initial.add_kw('method',            'STR', 'HF')
+    initial.add_kw('basis',             'STR', '3-21g')
+    initial.add_kw('method',            'STR', 'hf')
     # yapf: enable
     top.add_sect(initial)
 
-    files = getkw.Section('Files')
+    files = getkw.Section('files')
     # Set up directory for orbitals, subdirectory of input_dir
     orbs_dir = os.path.join(input_dir, 'orbitals')
     if not os.path.exists(orbs_dir):
@@ -356,7 +381,7 @@ def setup_keywords(input_dir):
     # yapf: enable
     top.add_sect(files)
 
-    pilot = getkw.Section('Pilot')
+    pilot = getkw.Section('pilot')
     # yapf: disable
     pilot.add_kw('run_projection',      'BOOL', False)
     pilot.add_kw('run_addition',        'BOOL', False)
@@ -374,7 +399,7 @@ def setup_keywords(input_dir):
 def verify_top(top):
     if not top.get('rel_prec').is_set():
         if not top.get('est_norm').is_set():
-            mol = topsect.fetch_sect('Molecule')
+            mol = topsect.fetch_sect('molecule')
             if mol.get('coords').is_set():
                 coords = mol.get('coords').get()
                 est_au = estimate_energy(coords)
@@ -400,9 +425,9 @@ def verify_mra(mra):
     basis_type = mra.get('basis_type')
     wlet = basis_type.get()
     if re.match('legen.*', wlet, re.I):
-        basis_type.set("L")
+        basis_type.set("l")
     elif re.match('inter.*', wlet, re.I):
-        basis_type.set("I")
+        basis_type.set("i")
     else:
         print("Invalid basis type: ", basis_type)
         sys.exit(1)
@@ -419,7 +444,7 @@ def verify_molecule(mol):
         AA = 1.889725989
     coords = mol.get('coords').get()
     i = 0
-    for line in coords[:]:
+    for line in coords:
         sp = line.split()
         elm = sp[0].lower()
         x_a, y_a, z_a = list(map(float, sp[1:]))
@@ -432,7 +457,7 @@ def verify_molecule(mol):
 
 def verify_response(rsp):
     if not rsp.get('canonical').is_set():
-        scf = topsect.fetch_sect('SCF')
+        scf = topsect.fetch_sect('scf')
         rsp['canonical'][0] = scf['canonical'][0]
     if rsp['orbital_prec'][1] < 0:
         rsp['orbital_prec'][1] = topsect['rel_prec'][0]
@@ -473,7 +498,7 @@ def verify_pol(pol):
 
 def verify_optrot(optrot):
     pert = optrot['perturbation'].get()
-    if pert != 'B' and pert != 'E':
+    if pert != 'b' and pert != 'e':
         print("invalid optical rotation perturbation:", pert)
         exit()
     if optrot.get('wavelength').is_set():
@@ -486,7 +511,7 @@ def verify_optrot(optrot):
 
 def verify_nmr(nmr):
     pert = nmr['perturbation'].get()
-    if pert != 'B' and pert != 'M':
+    if pert != 'b' and pert != 'm':
         print("invalid NMR shielding perturbation:", pert)
         exit()
     if not nmr.get('nucleus_k').is_set():
@@ -506,28 +531,23 @@ def verify_hfcc(hfcc):
 
 
 def verify_wf(wf):
-    valid_methods = {
-        'Core',
-        'Hartree',
-        'HF',
-        'DFT'
-    }
+    valid_methods = {'core', 'hartree', 'hf', 'dft'}
     default_functionals = {
-        'LDA',
-        'PBE',
-        'PBE0',
-        'BLYP',
-        'B3LYP',
-        'BP86',
-        'PW91',
+        'lda',
+        'pbe',
+        'pbe0',
+        'blyp',
+        'b3lyp',
+        'bp86',
+        'pw91',
     }
     method = wf['method'][0]
     if method in default_functionals:
-        dft = topsect.fetch_sect('DFT')
+        dft = topsect.fetch_sect('dft')
         if dft['functionals'].is_set():
             print('Cannot overwrite default functional: ' + method)
             exit()
-        wf['method'][0] = 'DFT'
+        wf['method'][0] = 'dft'
         dft['functionals'].get().append(method + ' 1.00')
     elif not (method in valid_methods):
         print('Invalid WaveFunction method: ' + method)
@@ -535,7 +555,7 @@ def verify_wf(wf):
 
 
 def verify_dft(dft):
-    wf = topsect.fetch_sect('WaveFunction')
+    wf = topsect.fetch_sect('wavefunction')
     # does not allow spin-separated functionals for a closed shell system
     if wf['restricted'][0]:
         dft['spin'][0] = False
@@ -581,7 +601,7 @@ def verify_kinetic_free(kinetic_free):
 # is used to set the precision parameter in mrchem in case of abs_prec.
 def estimate_energy(coords):
     est_en = 0.0
-    for line in coords[:]:
+    for line in coords:
         sp = line.split()
         elm = sp[0].lower()
         Z = PT[elm].Z

--- a/src/mrchem.in
+++ b/src/mrchem.in
@@ -98,7 +98,7 @@ def main():
             sts = os.waitpid(p.pid, 0)[1]
 
 
-            def convert_to_lower_case(filename):
+def convert_to_lower_case(filename):
     """
     Reads contents of filename and converts them to lowercase.
     The case-converted contents are written back to a temporary file.

--- a/src/mrenv.cpp
+++ b/src/mrenv.cpp
@@ -26,11 +26,11 @@ void initialize(int argc, char **argv) {
     }
 
     // Initialize input
-    Input = Getkw(infile, false, true);
+    input = Getkw(infile, false, true);
 
     // Initialize printing
-    int printlevel = Input.get<int>("printlevel");
-    bool teletype = Input.get<bool>("teletype");
+    int printlevel = input.get<int>("printlevel");
+    bool teletype = input.get<bool>("teletype");
     if (teletype) {
         Printer::init(printlevel, mpi::orb_rank, mpi::orb_size, "mrchem");
     } else {
@@ -38,19 +38,19 @@ void initialize(int argc, char **argv) {
     }
     Printer::setPrecision(15);
 
-    mpi::numerically_exact = Input.get<bool>("MPI.numerically_exact");
-    mpi::share_nuc_pot = Input.get<bool>("MPI.share_nuclear_potential");
-    mpi::share_coul_dens = Input.get<bool>("MPI.share_coulomb_density");
-    mpi::share_coul_pot = Input.get<bool>("MPI.share_coulomb_potential");
-    mpi::share_xc_dens = Input.get<bool>("MPI.share_xc_density");
-    mpi::share_xc_pot = Input.get<bool>("MPI.share_xc_potential");
-    mpi::shared_memory_size = Input.get<int>("MPI.shared_memory_size");
+    mpi::numerically_exact = input.get<bool>("mpi.numerically_exact");
+    mpi::share_nuc_pot = input.get<bool>("mpi.share_nuclear_potential");
+    mpi::share_coul_dens = input.get<bool>("mpi.share_coulomb_density");
+    mpi::share_coul_pot = input.get<bool>("mpi.share_coulomb_potential");
+    mpi::share_xc_dens = input.get<bool>("mpi.share_xc_density");
+    mpi::share_xc_pot = input.get<bool>("mpi.share_xc_potential");
+    mpi::shared_memory_size = input.get<int>("mpi.shared_memory_size");
 
     // Initialize world box
-    int min_scale = Input.get<int>("MRA.min_scale");
-    int max_scale = Input.get<int>("MRA.max_scale");
-    vector<int> corner = Input.getIntVec("MRA.corner");
-    vector<int> boxes = Input.getIntVec("MRA.boxes");
+    int min_scale = input.get<int>("mra.min_scale");
+    int max_scale = input.get<int>("mra.max_scale");
+    vector<int> corner = input.getIntVec("mra.corner");
+    vector<int> boxes = input.getIntVec("mra.boxes");
     std::array<int, 3> c_idx;
     std::array<int, 3> n_bxs;
     std::copy_n(corner.begin(), 3, c_idx.begin());
@@ -58,8 +58,8 @@ void initialize(int argc, char **argv) {
     BoundingBox<3> world(min_scale, c_idx, n_bxs);
 
     // Initialize scaling basis
-    int order = Input.get<int>("MRA.order");
-    string btype = Input.get<string>("MRA.basis_type");
+    int order = input.get<int>("mra.order");
+    string btype = input.get<string>("mra.basis_type");
 
     int max_depth = max_scale - min_scale;
     if (min_scale < MinScale) MSG_FATAL("Root scale too large");
@@ -67,10 +67,10 @@ void initialize(int argc, char **argv) {
     if (max_depth > MaxDepth) MSG_FATAL("Max depth too large");
 
     // Initialize global MRA
-    if (btype == "I") {
+    if (btype == "i") {
         InterpolatingBasis basis(order);
         MRA = new MultiResolutionAnalysis<3>(world, basis, max_depth);
-    } else if (btype == "L") {
+    } else if (btype == "l") {
         LegendreBasis basis(order);
         MRA = new MultiResolutionAnalysis<3>(world, basis, max_depth);
     } else {


### PR DESCRIPTION
The input file is read in and converted to lowercase before moving on to the parser.
This fixes the case at the very beginning, allowing users to not care about the case of input parameters.
When used internally, all keys are accessible in _lowercase_