### PR TITLE
Remove redundant lines

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,11 +70,6 @@ target_sources(mrchem.x
     $<BUILD_INTERFACE:$<JOIN:${CMAKE_CURRENT_LIST_DIR}/,${_public_headers}>>
   )
 
-target_link_libraries(mrchem.x
-  PRIVATE
-    mrchem
-  )
-
 set_target_properties(mrchem.x
   PROPERTIES
     MACOSX_RPATH ON


### PR DESCRIPTION
The removed line just looks like an incomplete duplicate of what going on, on lines: 87 to 91 in `src/CMakeLists.txt`. At the very least it seems to run fine without it. 