### PR TITLE
MPI fixes

### DIFF
--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -147,7 +147,7 @@ void mpi::allreduce_vector(DoubleVector &vec, MPI_Comm comm) {
 void mpi::allreduce_vector(ComplexVector &vec, MPI_Comm comm) {
 #ifdef HAVE_MPI
     int N = vec.size();
-    MPI_Allreduce(MPI_IN_PLACE, vec.data(), N, MPI_DOUBLE_COMPLEX, MPI_SUM, comm);
+    MPI_Allreduce(MPI_IN_PLACE, vec.data(), N, MPI_CXX_DOUBLE_COMPLEX, MPI_SUM, comm);
 #endif
 }
 
@@ -171,7 +171,7 @@ void mpi::allreduce_matrix(DoubleMatrix &mat, MPI_Comm comm) {
 void mpi::allreduce_matrix(ComplexMatrix &mat, MPI_Comm comm) {
 #ifdef HAVE_MPI
     int N = mat.size();
-    MPI_Allreduce(MPI_IN_PLACE, mat.data(), N, MPI_DOUBLE_COMPLEX, MPI_SUM, comm);
+    MPI_Allreduce(MPI_IN_PLACE, mat.data(), N, MPI_CXX_DOUBLE_COMPLEX, MPI_SUM, comm);
 #endif
 }
 


### PR DESCRIPTION
- Allow oversubscription in `mpirun` of tests, so that `mpirun -np 5` works on a dual core laptop.
- `MPI_DOUBLE_COMPLEX` -> `MPI_CXX_DOUBLE_COMPLEX`. The former fails in some OpenMPI implementations.