### PR TITLE
Bug fix #244: Core initial guess

### DIFF
--- a/src/initial_guess/core.h
+++ b/src/initial_guess/core.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "mrchem.h"
 #include "qmfunctions/qmfunction_fwd.h"
 
 /** @file core.h
@@ -44,6 +45,7 @@ namespace core {
 
 OrbitalVector setup(double prec, const Molecule &mol, bool restricted, int zeta);
 OrbitalVector project_ao(double prec, const Nuclei &nucs, int spin, int zeta);
+OrbitalVector rotate_orbitals(double prec, ComplexMatrix &U, OrbitalVector &Phi, int N, int spin);
 
 } // namespace core
 } // namespace initial_guess


### PR DESCRIPTION
Fixing issue #244. Problem was not open-shell but rather that the core guess orbitals were not correctly distributed with MPI. Moved the `initial_guess::rotate_orbitals` from sad.cpp to core.cpp since the latter is more fundamental.

- [x] Ready to merge