### PR TITLE
Accept json format in input files

### DIFF
--- a/src/input/mrchem.in
+++ b/src/input/mrchem.in
@@ -40,7 +40,7 @@ from pathlib import Path
 sys.path.append("@CMAKE_INSTALL_PREFIX@/@PYTHON_SITE_INSTALL_DIR@")
 sys.path.append('@PROJECT_SOURCE_DIR@/src/chemistry')
 
-from parselglossy.api import parse
+from parselglossy.api import parse, validate
 from periodictable import PeriodicTable as PT
 
 
@@ -53,20 +53,24 @@ def main():
             os.mkdir(d)
 
     # Parse command line
-    executable, dryrun, inp_file_cmd = parse_cmdline()
+    executable, dryrun, inp_json, inp_file_cmd = parse_cmdline()
 
     in_path = Path(inp_file_cmd)
     tmpl_path = Path('@PROJECT_SOURCE_DIR@/src/input/template.yml')
 
-    # read user input file (JSONDict <- getkw file)
-    user_dict = parse(infile=in_path, template=tmpl_path, grammar='getkw')
+    # read user input file (JSONDict <- getkw file) or (JSONDict <- json file)
+    if inp_json:
+        user_dict = validate(infile=in_path, template=tmpl_path)
+    else:
+        user_dict = parse(infile=in_path, template=tmpl_path, grammar='getkw')
+
 
     # now that all keywords have sensible values,
     # we can translate user input into program input
     program_dict = translate_input(user_dict)
 
     inp_name, ext_ext = os.path.splitext(inp_file_cmd)
-    xfile = inp_name + '.json'
+    xfile = inp_name + '_parsed.json'
     with open(xfile, 'w') as fd:
         fd.write(json.dumps(program_dict, indent=2))
 
@@ -96,11 +100,20 @@ def parse_cmdline():
         type='string',
         default='@MRCHEM_EXECUTABLE@',
         help='set executable name')
+    cmdln.add_option(
+        '-j',
+        '--json',
+        action='store_true',
+        dest='inp_json',
+        default=False,
+        help='Input file is in json format')
+
 
     opts, args = cmdln.parse_args()
 
     executable = opts.executable
     dryrun = opts.dryrun
+    inp_json = opts.inp_json
 
     if (len(args) == 0):
         cmdln.error('No input file passed!')
@@ -111,7 +124,7 @@ def parse_cmdline():
         cmdln.error('Incorrect number of files')
         sys.exit(1)
 
-    return executable, dryrun, inp_file
+    return executable, dryrun, inp_json, inp_file
 
 def translate_input(user_dict):
     program_dict = {}

--- a/tests/h2_pol_lda/mrchem.inp
+++ b/tests/h2_pol_lda/mrchem.inp
@@ -1,49 +1,41 @@
-# vim:syntax=sh:
-
-world_prec = 1.0e-3               # Overall relative precision
-world_size = 6                    # Size of simulation box 2^n
-
-MPI {
-  numerically_exact = true        # Guarantee identical results in MPI
+{
+    "world_prec": 0.001,
+    "world_size": 6,
+    "MPI": {
+        "numerically_exact": true
+    },
+    "Molecule": {
+        "angstrom": true,
+        "coords": "H      0.0000 0.0000   -0.3705\nH      0.0000 0.0000    0.3705\n"
+    },
+    "WaveFunction": {
+        "method": "DFT",
+        "restricted": false
+    },
+    "DFT": {
+        "functionals": "LDA\n"
+    },
+    "Properties": {
+        "scf_energy": true,
+        "polarizability": true
+    },
+    "Polarizability": {
+        "frequency": [
+            0.0
+        ]
+    },
+    "SCF": {
+        "run": false,
+        "initial_guess": "GTO"
+    },
+    "Response": {
+        "kain": 3,
+        "max_iter": 10,
+        "orbital_thrs": 0.01,
+        "directions": [
+            0,
+            0,
+            1
+        ]
+    }
 }
-
-Molecule {
-  angstrom = true
-$coords
-H      0.0000 0.0000   -0.3705
-H      0.0000 0.0000    0.3705
-$end
-}
-
-WaveFunction {
-  method = DFT                    # Wave function method (HF or DFT)
-  restricted = false              # Unrestricted calculation
-}
-
-DFT {
-$functionals
-LDA
-$end
-}
-
-Properties {
-  scf_energy = true               # Compute ground state energy
-  polarizability = true           # Compute electric polarizability
-}
-
-Polarizability {
-  frequency = [0.0]               # Static polarizability 
-}
-
-SCF {
-  run = false                     # Use initial guess, don't optimize
-  initial_guess = GTO             # Reading precomputed GTO MOs
-}
-
-Response {
-  kain = 3                        # Length of KAIN iterative history
-  max_iter = 10
-  orbital_thrs = 1.0e-2           # Convergence threshold in orbital residual
-  directions = [0,0,1]            # Compute only in z direction
-}
-

--- a/tests/h2_pol_lda/test
+++ b/tests/h2_pol_lda/test
@@ -29,6 +29,6 @@ options = cli()
 
 ierr = 0
 ierr += run(
-    options, configure, input_files=['mrchem.inp'], filters={'stdout': f})
+    options, configure, input_files=['mrchem.inp'], filters={'stdout': f}, extra_args=['--json'])
 
 sys.exit(ierr)

--- a/tests/runtest_config.py
+++ b/tests/runtest_config.py
@@ -7,17 +7,15 @@ def configure(options, input_files, extra_args):
     This function configures runtest
     at runtime for code specific launch command and file naming.
     """
-
     launcher = 'mrchem'
     launcher_full_path = path.normpath(path.join(options.binary_dir, launcher))
 
     command = []
     command.append(launcher_full_path)
     command.append(input_files[0])
-    command.append('--executable={:s}/{:s}'.format(options.binary_dir, 'mrchem.x'))
-
+    command.append(f'--executable={options.binary_dir}/mrchem.x')
     if extra_args is not None:
-        command.append(extra_args)
+        command += extra_args
 
     full_command = ' '.join(command)
 


### PR DESCRIPTION
`mrchem.in` accepts input files both in `getkw` format and `json` format.

to use `json` as input add the `--json` or `-j` flag e.g.;

`./mrchem --json mrchem.json`
`./mrchem -j mrchem.json`

the parsed `json` are now named `mrchem_parsed.json`

The following files are both accepted by `mrchem.in` and produces the same
`mrchem_parsed.json` files 

Getkw format:
```
world_prec = 1.0e-6
world_size = 6

Molecule {
    translate = true
$coords
O   0.0000     0.0000     0.0000
H   0.0000     1.4375     1.1500
H   0.0000    -1.4375     1.1500
$end
}

WaveFunction {
    method = HF
}

Properties {
    scf_energy = true
}

SCF {
    kain = 3
    initial_guess = sad_sz
}

```
Json format:
```
{
    "world_prec": 1e-06,
    "world_size": 6,
    "Molecule": {
        "translate": true,
        "coords": "O   0.0000     0.0000     0.0000\n
                         H   0.0000     1.4375     1.1500\n
                         H   0.0000    -1.4375     1.1500\n"
    },
    "WaveFunction": {
        "method": "HF"
    },
    "Properties": {
        "scf_energy": true
    },
    "SCF": {
        "kain": 3,
        "initial_guess": "sad_sz"
    }
}
```
