### PR TITLE
Property printing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,3 +123,5 @@ doc/xml/
 *_inst
 *_build
 .ccls-cache/
+
+Pipfile.lock

--- a/src/chemistry/Molecule.cpp
+++ b/src/chemistry/Molecule.cpp
@@ -271,10 +271,10 @@ void Molecule::printProperties() const {
     if (this->energy != nullptr) this->energy->print();
     if (this->dipole != nullptr) this->dipole->print();
     if (this->quadrupole != nullptr) this->quadrupole->print();
-    if (this->magnetizability != nullptr) this->magnetizability->print();
     for (auto &pol : this->polarizability) {
         if (pol != nullptr) pol->print();
     }
+    if (this->magnetizability != nullptr) this->magnetizability->print();
     for (auto &nmr_k : this->nmr) {
         if (nmr_k != nullptr) nmr_k->print();
     }

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -510,7 +510,7 @@ void driver::calc_scf_properties(const json &json_prop, Molecule &mol) {
         Q.getElectronic() = h.trace(Phi).real();
         h.clear();
         mrcpp::print::footer(2, t_lap, 2);
-        if (plevel == 1) mrcpp::print::time(1, "Dipole moment", t_lap);
+        if (plevel == 1) mrcpp::print::time(1, "Quadrupole moment", t_lap);
     }
 
     auto json_hyperpolarizability = json_prop.find("hyperpolarizability");

--- a/src/properties/DipoleMoment.h
+++ b/src/properties/DipoleMoment.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include "mrchem.h"
+
+#include "utils/math_utils.h"
 #include "utils/print_utils.h"
 
 namespace mrchem {
@@ -64,8 +66,8 @@ public:
     }
 
 private:
-    DoubleVector nuc_tensor{DoubleVector::Zero(3)};
-    DoubleVector el_tensor{DoubleVector::Zero(3)};
+    DoubleVector nuc_tensor{math_utils::init_nan(3)};
+    DoubleVector el_tensor{math_utils::init_nan(3)};
 };
 // clang-format on
 

--- a/src/properties/Magnetizability.h
+++ b/src/properties/Magnetizability.h
@@ -27,6 +27,7 @@
 
 #include "mrchem.h"
 
+#include "utils/math_utils.h"
 #include "utils/print_utils.h"
 
 namespace mrchem {
@@ -66,8 +67,8 @@ public:
     }
 
 private:
-    DoubleMatrix dia_tensor{DoubleMatrix::Zero(3,3)};
-    DoubleMatrix para_tensor{DoubleMatrix::Zero(3,3)};
+    DoubleMatrix dia_tensor{math_utils::init_nan(3,3)};
+    DoubleMatrix para_tensor{math_utils::init_nan(3,3)};
 };
 // clang-format on
 

--- a/src/properties/NMRShielding.h
+++ b/src/properties/NMRShielding.h
@@ -27,6 +27,7 @@
 
 #include "mrchem.h"
 
+#include "utils/math_utils.h"
 #include "utils/print_utils.h"
 
 namespace mrchem {
@@ -67,8 +68,8 @@ public:
 private:
     const int K;
     const Nucleus nuc;
-    DoubleMatrix dia_tensor{DoubleMatrix::Zero(3,3)};
-    DoubleMatrix para_tensor{DoubleMatrix::Zero(3,3)};
+    DoubleMatrix dia_tensor{math_utils::init_nan(3,3)};
+    DoubleMatrix para_tensor{math_utils::init_nan(3,3)};
 };
 // clang-format on
 

--- a/src/properties/Polarizability.h
+++ b/src/properties/Polarizability.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include "mrchem.h"
+
+#include "utils/math_utils.h"
 #include "utils/print_utils.h"
 
 namespace mrchem {
@@ -59,7 +61,7 @@ public:
 
 private:
     double frequency;
-    DoubleMatrix tensor{DoubleMatrix::Zero(3,3)};
+    DoubleMatrix tensor{math_utils::init_nan(3,3)};
 };
 // clang-format on
 

--- a/src/properties/QuadrupoleMoment.h
+++ b/src/properties/QuadrupoleMoment.h
@@ -26,6 +26,8 @@
 #pragma once
 
 #include "mrchem.h"
+
+#include "utils/math_utils.h"
 #include "utils/print_utils.h"
 
 namespace mrchem {
@@ -50,8 +52,8 @@ public:
     }
 
 private:
-    DoubleMatrix nuc_tensor{DoubleVector::Zero(3)};
-    DoubleMatrix el_tensor{DoubleVector::Zero(3)};
+    DoubleMatrix nuc_tensor{math_utils::init_nan(3)};
+    DoubleMatrix el_tensor{math_utils::init_nan(3)};
 };
 // clang-format on
 

--- a/src/utils/math_utils.cpp
+++ b/src/utils/math_utils.cpp
@@ -32,6 +32,20 @@
 namespace mrchem {
 namespace math_utils {
 
+DoubleVector init_nan(int I) {
+    DoubleVector V(I);
+    for (int i = 0; i < I; i++) V(i) = std::numeric_limits<double>::quiet_NaN();
+    return V;
+}
+
+DoubleMatrix init_nan(int I, int J) {
+    DoubleMatrix M(I, J);
+    for (int i = 0; i < I; i++) {
+        for (int j = 0; j < J; j++) M(i, j) = std::numeric_limits<double>::quiet_NaN();
+    }
+    return M;
+}
+
 /** @brief Calculate the distance between two points in three dimensions */
 double calc_distance(const mrcpp::Coord<3> &a, const mrcpp::Coord<3> &b) {
     double r_x = a[0] - b[0];

--- a/src/utils/math_utils.h
+++ b/src/utils/math_utils.h
@@ -38,6 +38,9 @@ namespace math_utils {
 
 double calc_distance(const mrcpp::Coord<3> &a, const mrcpp::Coord<3> &b);
 
+DoubleVector init_nan(int I);
+DoubleMatrix init_nan(int I, int J);
+
 DoubleMatrix read_matrix_file(const std::string &file);
 DoubleMatrix skew_matrix_exp(const DoubleMatrix &A);
 ComplexMatrix hermitian_matrix_pow(const ComplexMatrix &A, double b);

--- a/src/utils/print_utils.cpp
+++ b/src/utils/print_utils.cpp
@@ -94,7 +94,9 @@ void print_utils::scalar(int level, const std::string &txt, double val, const st
     std::stringstream o;
     o << " " << txt << std::string(w3, ' ') << ":";
     o << std::setw(w1) << unit;
-    if (s) {
+    if (std::isnan(val)) {
+        o << std::setw(2 * w1) << "N/A";
+    } else if (s) {
         o << std::setw(2 * w1) << std::setprecision(p) << std::scientific << val;
     } else {
         o << std::setw(2 * w1) << std::setprecision(p) << std::fixed << val;
@@ -112,7 +114,9 @@ void print_utils::vector(int level, const std::string &txt, const DoubleVector &
     std::stringstream o;
     o << " " << txt << std::string(w3, ' ') << ":";
     for (int i = 0; i < val.size(); i++) {
-        if (s) {
+        if (std::isnan(val(i))) {
+            o << std::setw(w1) << "N/A";
+        } else if (s) {
             o << std::setw(w1) << std::setprecision(p) << std::scientific << val(i);
         } else {
             o << std::setw(w1) << std::setprecision(p) << std::fixed << val(i);
@@ -136,7 +140,9 @@ void print_utils::matrix(int level, const std::string &txt, const DoubleMatrix &
             o << " " << std::string(w2 - 1, ' ') << ":";
         }
         for (int j = 0; j < val.cols(); j++) {
-            if (s) {
+            if (std::isnan(val(i, j))) {
+                o << std::setw(w1) << "N/A";
+            } else if (s) {
                 o << std::setw(w1) << std::setprecision(p) << std::scientific << val(i, j);
             } else {
                 o << std::setw(w1) << std::setprecision(p) << std::fixed << val(i, j);

--- a/tests/h2_pol_lda/reference/mrchem.stdout
+++ b/tests/h2_pol_lda/reference/mrchem.stdout
@@ -3,29 +3,37 @@
 **********************************************************************
 ***                                                                ***
 ***                                                                ***
-***          __  __ ____   ____ _                                  ***
-***         |  \/  |  _ \ / ___| |__   ___ _ __ ___                ***
-***         | |\/| | |_) | |   | '_ \ / _ \ '_ ` _ \               ***
-***         | |  | |  _ <| |___| | | |  __/ | | | | |              ***
-***         |_|  |_|_| \_\\____|_| |_|\___|_| |_| |_|              ***
+***        __  __ ____   ____ _                                    ***
+***       |  \/  |  _ \ / ___| |__   ___ _ __ ___                  ***
+***       | |\/| | |_) | |   | '_ \ / _ \ '_ ` _ \                 ***
+***       | |  | |  _ <| |___| | | |  __/ | | | | |                ***
+***       |_|  |_|_| \_\\____|_| |_|\___|_| |_| |_|                ***
 ***                                                                ***
-***         VERSION    0.2.0        (rev.   eb2c9f6b)              ***
+***       VERSION            0.3.0-alpha                           ***
 ***                                                                ***
-***         Stig Rune Jensen   <stig.r.jensen@uit.no>              ***
-***         Luca Frediani      <luca.frediani@uit.no>              ***
-***         Peter Wind         <peter.wind@uit.no>                 ***
+***       Git branch         prop-print                            ***
+***       Git commit hash    3bfae167fa1d92f7c42c                  ***
+***       Git commit author  Stig Rune Jensen                      ***
+***       Git commit date    Mon Mar 16 18:22:17 2020 +0100        ***
+***                                                                ***
+***       Magnar Bjorgve     <magnar.bjorgve@uit.no>               ***
+***       Roberto Di Remigio <roberto.di.remigio@uit.no>           ***
+***       Luca Frediani      <luca.frediani@uit.no>                ***
+***       Gabriel Gerez      <gsa017@post.uit.no>                  ***
+***       Stig Rune Jensen   <stig.r.jensen@uit.no>                ***
+***       Peter Wind         <peter.wind@uit.no>                   ***
 ***                                                                ***
 **********************************************************************
 
 ----------------------------------------------------------------------
 
- MPI processes         :                                            1
+ MPI processes         :      (no bank)                             1
  OpenMP threads        :                                            1
  Total cores           :                                            1
                                                                       
 ----------------------------------------------------------------------
 
-XCFun DFT library Copyright 2009-2011 Ulf Ekstrom and contributors.
+XCFun DFT library Copyright 2009-2020 Ulf Ekstrom and contributors.
 See http://dftlibs.org/xcfun/ for more information.
 
 This is free software; see the source code for copying conditions.
@@ -37,8 +45,11 @@ J.Chem.Theor.Comp. 2010, DOI: 10.1021/ct100117s
 
 ----------------------------------------------------------------------
 
- MRCPP version         : 1.0.1
- Git revision          : bfaa4387
+ MRCPP version         : 1.2.0-alpha2
+ Git branch            : prop-print
+ Git commit hash       : 64ff947f46ad4042b90b
+ Git commit author     : Stig Rune Jensen
+ Git commit date       : Mon Mar 16 16:56:57 2020 +0100
 
  Linear algebra        : EIGEN v3.3.7
  Parallelization       : OpenMP
@@ -170,7 +181,6 @@ J.Chem.Theor.Comp. 2010, DOI: 10.1021/ct100117s
  Perturbation          : h_E_dip[z]
  Max iterations        : 10
  KAIN solver           : 3
- Localization          : Off
  Start precision       : 1.00000e-03
  Final precision       : 1.00000e-03
  Helmholtz precision   : 1.00000e-03
@@ -183,10 +193,10 @@ J.Chem.Theor.Comp. 2010, DOI: 10.1021/ct100117s
  Iter         MO residual      Symmetric property              Update
 ----------------------------------------------------------------------
     0        1.000000e+00          0.000000000000        0.000000e+00
-    1        2.061933e+00         -5.523951430940       -5.523951e+00
-    2        4.484976e-01         -7.124862206329       -1.600911e+00
-    3        3.142219e-02         -7.211439925326       -8.657772e-02
-    4        5.670596e-03         -7.222017736988       -1.057781e-02
+    1        2.061933e+00         -5.523958969627       -5.523959e+00
+    2        4.485058e-01         -7.124916590397       -1.600958e+00
+    3        3.140761e-02         -7.211411969279       -8.649538e-02
+    4        5.671671e-03         -7.222012691491       -1.060072e-02
 ----------------------------------------------------------------------
                    SCF converged in 4 iterations!
 ======================================================================
@@ -255,10 +265,10 @@ J.Chem.Theor.Comp. 2010, DOI: 10.1021/ct100117s
  Frequency             :           (au)                      0.000000
                        :         (cm-1)                      0.000000
 ----------------------------------------------------------------------
- Total tensor          :       0.000000       0.000000       0.000000
-                       :       0.000000       0.000000       0.000000
-                       :      -0.000000      -0.000000       7.222018
- Isotropic average     :           (au)                      2.407339
+ Total tensor          :            N/A            N/A            N/A
+                       :            N/A            N/A            N/A
+                       :      -0.000000      -0.000000       7.222013
+ Isotropic average     :           (au)                           N/A
 ======================================================================
 
 
@@ -268,7 +278,7 @@ J.Chem.Theor.Comp. 2010, DOI: 10.1021/ct100117s
 ***                                                                ***
 ***                         Exiting MRChem                         ***
 ***                                                                ***
-***                    Wall time :  0h  0m 35s                     ***
+***                    Wall time :  0h  0m 24s                     ***
 ***                                                                ***
 **********************************************************************
                                                                       

--- a/tests/h2_pol_lda/test
+++ b/tests/h2_pol_lda/test
@@ -11,18 +11,18 @@ from runtest_config import configure  # isort:skip
 assert version_info.major == 2
 
 f = [
-    get_filter(string='Sum occupied',                 rel_tolerance=1.0e-6),
-    get_filter(string='Kinetic energy',               rel_tolerance=1.0e-6),
-    get_filter(string='E-N energy',                   rel_tolerance=1.0e-6),
-    get_filter(string='Coulomb energy',               rel_tolerance=1.0e-6),
-    get_filter(string='Exchange energy',              rel_tolerance=1.0e-6),
-    get_filter(string='X-C energy',                   rel_tolerance=1.0e-6),
-    get_filter(string='Electronic energy',            rel_tolerance=1.0e-6),
-    get_filter(string='Nuclear energy',               rel_tolerance=1.0e-6),
-    get_filter(string='(kcal/mol)',                   rel_tolerance=1.0e-6),
-    get_filter(string='(kJ/mol)',                     rel_tolerance=1.0e-6),
-    get_filter(string='(eV)',                         rel_tolerance=1.0e-6),
-    get_filter(string='Isotropic average',            rel_tolerance=1.0e-6),
+    get_filter(string='Sum occupied',                   rel_tolerance=1.0e-6),
+    get_filter(string='Kinetic energy',                 rel_tolerance=1.0e-6),
+    get_filter(string='E-N energy',                     rel_tolerance=1.0e-6),
+    get_filter(string='Coulomb energy',                 rel_tolerance=1.0e-6),
+    get_filter(string='Exchange energy',                rel_tolerance=1.0e-6),
+    get_filter(string='X-C energy',                     rel_tolerance=1.0e-6),
+    get_filter(string='Electronic energy',              rel_tolerance=1.0e-6),
+    get_filter(string='Nuclear energy',                 rel_tolerance=1.0e-6),
+    get_filter(string='(kcal/mol)',                     rel_tolerance=1.0e-6),
+    get_filter(string='(kJ/mol)',                       rel_tolerance=1.0e-6),
+    get_filter(string='(eV)',                           rel_tolerance=1.0e-6),
+    get_filter(from_string='Total tensor', num_lines=3, rel_tolerance=1.0e-6),
 ]
 
 options = cli()

--- a/tests/li_pol_lda/reference/mrchem.stdout
+++ b/tests/li_pol_lda/reference/mrchem.stdout
@@ -3,29 +3,37 @@
 **********************************************************************
 ***                                                                ***
 ***                                                                ***
-***          __  __ ____   ____ _                                  ***
-***         |  \/  |  _ \ / ___| |__   ___ _ __ ___                ***
-***         | |\/| | |_) | |   | '_ \ / _ \ '_ ` _ \               ***
-***         | |  | |  _ <| |___| | | |  __/ | | | | |              ***
-***         |_|  |_|_| \_\\____|_| |_|\___|_| |_| |_|              ***
+***        __  __ ____   ____ _                                    ***
+***       |  \/  |  _ \ / ___| |__   ___ _ __ ___                  ***
+***       | |\/| | |_) | |   | '_ \ / _ \ '_ ` _ \                 ***
+***       | |  | |  _ <| |___| | | |  __/ | | | | |                ***
+***       |_|  |_|_| \_\\____|_| |_|\___|_| |_| |_|                ***
 ***                                                                ***
-***         VERSION    0.2.0        (rev.   81247d7b)              ***
+***       VERSION            0.3.0-alpha                           ***
 ***                                                                ***
-***         Stig Rune Jensen   <stig.r.jensen@uit.no>              ***
-***         Luca Frediani      <luca.frediani@uit.no>              ***
-***         Peter Wind         <peter.wind@uit.no>                 ***
+***       Git branch         prop-print                            ***
+***       Git commit hash    3bfae167fa1d92f7c42c                  ***
+***       Git commit author  Stig Rune Jensen                      ***
+***       Git commit date    Mon Mar 16 18:22:17 2020 +0100        ***
+***                                                                ***
+***       Magnar Bjorgve     <magnar.bjorgve@uit.no>               ***
+***       Roberto Di Remigio <roberto.di.remigio@uit.no>           ***
+***       Luca Frediani      <luca.frediani@uit.no>                ***
+***       Gabriel Gerez      <gsa017@post.uit.no>                  ***
+***       Stig Rune Jensen   <stig.r.jensen@uit.no>                ***
+***       Peter Wind         <peter.wind@uit.no>                   ***
 ***                                                                ***
 **********************************************************************
 
 ----------------------------------------------------------------------
 
- MPI processes         :                                            1
+ MPI processes         :      (no bank)                             1
  OpenMP threads        :                                            1
  Total cores           :                                            1
                                                                       
 ----------------------------------------------------------------------
 
-XCFun DFT library Copyright 2009-2011 Ulf Ekstrom and contributors.
+XCFun DFT library Copyright 2009-2020 Ulf Ekstrom and contributors.
 See http://dftlibs.org/xcfun/ for more information.
 
 This is free software; see the source code for copying conditions.
@@ -37,11 +45,14 @@ J.Chem.Theor.Comp. 2010, DOI: 10.1021/ct100117s
 
 ----------------------------------------------------------------------
 
- MRCPP version         : 1.1.0
- Git revision          : 36888523
+ MRCPP version         : 1.2.0-alpha2
+ Git branch            : prop-print
+ Git commit hash       : 64ff947f46ad4042b90b
+ Git commit author     : Stig Rune Jensen
+ Git commit date       : Mon Mar 16 16:56:57 2020 +0100
 
  Linear algebra        : EIGEN v3.3.7
- Parallelization       : NONE
+ Parallelization       : OpenMP
 
 ----------------------------------------------------------------------
 
@@ -171,7 +182,6 @@ J.Chem.Theor.Comp. 2010, DOI: 10.1021/ct100117s
  Perturbation          : h_E_dip[z]
  Max iterations        : 10
  KAIN solver           : 3
- Localization          : Off
  Start precision       : 1.00000e-03
  Final precision       : 1.00000e-03
  Helmholtz precision   : 1.00000e-03
@@ -185,14 +195,14 @@ J.Chem.Theor.Comp. 2010, DOI: 10.1021/ct100117s
 ----------------------------------------------------------------------
     0        1.000000e+00          0.000000000000        0.000000e+00
     1        1.179433e+01        -53.790213511671       -5.379021e+01
-    2        6.322027e+00       -116.122330136539       -6.233212e+01
-    3        1.539591e+00       -120.285459241636       -4.163129e+00
-    4        1.181818e+00       -135.982272744216       -1.569681e+01
-    5        3.464292e-01       -137.352895647902       -1.370623e+00
-    6        1.612162e-01       -138.631855971302       -1.278960e+00
-    7        5.890191e-02       -139.486608699907       -8.547527e-01
-    8        1.300792e-02       -139.566251916183       -7.964322e-02
-    9        3.801377e-03       -139.574487320761       -8.235405e-03
+    2        6.322027e+00       -116.122330136540       -6.233212e+01
+    3        1.539591e+00       -120.285459241638       -4.163129e+00
+    4        1.181818e+00       -135.982272745208       -1.569681e+01
+    5        3.464292e-01       -137.352895651252       -1.370623e+00
+    6        1.612162e-01       -138.631855987029       -1.278960e+00
+    7        5.890191e-02       -139.486608662079       -8.547527e-01
+    8        1.300792e-02       -139.566251909986       -7.964325e-02
+    9        3.801376e-03       -139.574487350566       -8.235441e-03
 ----------------------------------------------------------------------
                    SCF converged in 9 iterations!
 ======================================================================
@@ -261,10 +271,10 @@ J.Chem.Theor.Comp. 2010, DOI: 10.1021/ct100117s
  Frequency             :           (au)                      0.000000
                        :         (cm-1)                      0.000000
 ----------------------------------------------------------------------
- Total tensor          :       0.000000       0.000000       0.000000
-                       :       0.000000       0.000000       0.000000
+ Total tensor          :            N/A            N/A            N/A
+                       :            N/A            N/A            N/A
                        :      -0.000000      -0.000000     139.574487
- Isotropic average     :           (au)                     46.524829
+ Isotropic average     :           (au)                           N/A
 ======================================================================
 
 
@@ -274,7 +284,7 @@ J.Chem.Theor.Comp. 2010, DOI: 10.1021/ct100117s
 ***                                                                ***
 ***                         Exiting MRChem                         ***
 ***                                                                ***
-***                    Wall time :  0h  1m 40s                     ***
+***                    Wall time :  0h  1m  4s                     ***
 ***                                                                ***
 **********************************************************************
                                                                       

--- a/tests/li_pol_lda/test
+++ b/tests/li_pol_lda/test
@@ -11,18 +11,18 @@ from runtest_config import configure  # isort:skip
 assert version_info.major == 2
 
 f = [
-    get_filter(string='Sum occupied',                 rel_tolerance=1.0e-6),
-    get_filter(string='Kinetic energy',               rel_tolerance=1.0e-6),
-    get_filter(string='E-N energy',                   rel_tolerance=1.0e-6),
-    get_filter(string='Coulomb energy',               rel_tolerance=1.0e-6),
-    get_filter(string='Exchange energy',              rel_tolerance=1.0e-6),
-    get_filter(string='X-C energy',                   rel_tolerance=1.0e-6),
-    get_filter(string='Electronic energy',            rel_tolerance=1.0e-6),
-    get_filter(string='Nuclear energy',               rel_tolerance=1.0e-6),
-    get_filter(string='(kcal/mol)',                   rel_tolerance=1.0e-6),
-    get_filter(string='(kJ/mol)',                     rel_tolerance=1.0e-6),
-    get_filter(string='(eV)',                         rel_tolerance=1.0e-6),
-    get_filter(string='Isotropic average',            rel_tolerance=1.0e-6),
+    get_filter(string='Sum occupied',                   rel_tolerance=1.0e-6),
+    get_filter(string='Kinetic energy',                 rel_tolerance=1.0e-6),
+    get_filter(string='E-N energy',                     rel_tolerance=1.0e-6),
+    get_filter(string='Coulomb energy',                 rel_tolerance=1.0e-6),
+    get_filter(string='Exchange energy',                rel_tolerance=1.0e-6),
+    get_filter(string='X-C energy',                     rel_tolerance=1.0e-6),
+    get_filter(string='Electronic energy',              rel_tolerance=1.0e-6),
+    get_filter(string='Nuclear energy',                 rel_tolerance=1.0e-6),
+    get_filter(string='(kcal/mol)',                     rel_tolerance=1.0e-6),
+    get_filter(string='(kJ/mol)',                       rel_tolerance=1.0e-6),
+    get_filter(string='(eV)',                           rel_tolerance=1.0e-6),
+    get_filter(from_string='Total tensor', num_lines=3, rel_tolerance=1.0e-6),
 ]
 
 options = cli()


### PR DESCRIPTION
Initialize properties to NaN, so that un-computed properties are not confused with zero value.

E.g. polarizability computed only in x and y `directions=[1,1,0]` will look like this
```
======================================================================
                            Polarizability
----------------------------------------------------------------------
 Wavelength            :           (nm)                    694.573171
 Frequency             :           (au)                      0.065600
                       :         (cm-1)                  14397.331226
----------------------------------------------------------------------
 Total tensor          :       1.668198       0.000000       0.000000
                       :       0.000000       1.668198       0.000000
                       :            N/A            N/A            N/A
 Isotropic average     :           (au)                           N/A
======================================================================
```