### PR TITLE
Fix displayed final precision in response

### DIFF
--- a/src/qmoperators/two_electron/ExchangePotentialD1.cpp
+++ b/src/qmoperators/two_electron/ExchangePotentialD1.cpp
@@ -172,7 +172,7 @@ Orbital ExchangePotentialD1::calcExchange(Orbital phi_p) {
     Orbital ex_p = phi_p.paramCopy();
     Eigen::Map<ComplexVector> coefs(coef_vec.data(), coef_vec.size());
     qmfunction::linear_combination(ex_p, coefs, func_vec, -1.0);
-    print_utils::qmfunction(0, "Applied exchange", ex_p, timer);
+    print_utils::qmfunction(3, "Applied exchange", ex_p, timer);
     return ex_p;
 }
 

--- a/src/scf_solver/GroundStateSolver.cpp
+++ b/src/scf_solver/GroundStateSolver.cpp
@@ -170,9 +170,9 @@ void GroundStateSolver::printParameters(const std::string &calculation) const {
     print_utils::text(0, "KAIN solver        ", o_kain.str());
     print_utils::text(0, "Localization       ", o_loc.str());
     print_utils::text(0, "Diagonalization    ", o_diag.str());
-    print_utils::text(0, "Helmholtz precision", o_helm.str());
     print_utils::text(0, "Start precision    ", o_prec_0.str());
     print_utils::text(0, "Final precision    ", o_prec_1.str());
+    print_utils::text(0, "Helmholtz precision", o_helm.str());
     print_utils::text(0, "Energy threshold   ", o_thrs_p.str());
     print_utils::text(0, "Orbital threshold  ", o_thrs_o.str());
     mrcpp::print::separator(0, '~', 2);

--- a/src/scf_solver/LinearResponseSolver.cpp
+++ b/src/scf_solver/LinearResponseSolver.cpp
@@ -302,8 +302,8 @@ void LinearResponseSolver::printParameters(double omega, const std::string &oper
     }
 
     std::stringstream o_prec_0, o_prec_1;
-    o_prec_0 << std::setprecision(5) << std::scientific << this->orbPrec[0];
-    o_prec_1 << std::setprecision(5) << std::scientific << this->orbPrec[1];
+    o_prec_0 << std::setprecision(5) << std::scientific << this->orbPrec[1];
+    o_prec_1 << std::setprecision(5) << std::scientific << this->orbPrec[2];
 
     std::stringstream o_thrs_p;
     if (this->propThrs < 0.0) {


### PR DESCRIPTION
Response solver printed out `current_prec` and `start_prec` instead of `start_prec` and `final_prec`