### PR TITLE
Revamp MW guess

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: cpp
-sudo: false
 dist: bionic
 ruby: 2.5.3
 

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -143,11 +143,13 @@ bool driver::guess_scf_orbitals(const json &json_guess, Molecule &mol) {
     auto prec = json_guess["prec"];
     auto zeta = json_guess["zeta"];
     auto type = json_guess["type"];
+    auto mw_p = json_guess["file_mw_paired"];
+    auto mw_a = json_guess["file_mw_alpha"];
+    auto mw_b = json_guess["file_mw_beta"];
     auto gto_p = json_guess["file_gto_paired"];
     auto gto_a = json_guess["file_gto_alpha"];
     auto gto_b = json_guess["file_gto_beta"];
     auto gto_bas = json_guess["file_gto_basis"];
-    auto mw_file = json_guess["file_orbitals"];
     auto restricted = json_guess["restricted"];
 
     // Figure out number of electrons
@@ -174,7 +176,7 @@ bool driver::guess_scf_orbitals(const json &json_guess, Molecule &mol) {
 
     auto success = true;
     if (type == "mw") {
-        success = initial_guess::mw::setup(Phi, mw_file);
+        success = initial_guess::mw::setup(Phi, prec, mw_p, mw_a, mw_b);
     } else if (type == "core") {
         success = initial_guess::core::setup(Phi, prec, nucs, zeta);
     } else if (type == "sad") {
@@ -294,7 +296,9 @@ bool driver::run_scf(const json &json_scf, Molecule &mol) {
     if (success) {
         if (json_scf["write_orbitals"]) {
             auto &Phi = mol.getOrbitals();
-            orbital::save_orbitals(Phi, json_scf["file_orbitals"]);
+            orbital::save_orbitals(Phi, json_scf["file_orbitals"], SPIN::Paired);
+            orbital::save_orbitals(Phi, json_scf["file_orbitals"], SPIN::Alpha);
+            orbital::save_orbitals(Phi, json_scf["file_orbitals"], SPIN::Beta);
         }
 
         auto json_prop = json_scf.find("properties");

--- a/src/initial_guess/core.cpp
+++ b/src/initial_guess/core.cpp
@@ -88,10 +88,10 @@ int PT[29][2] = {
  */
 bool initial_guess::core::setup(OrbitalVector &Phi, double prec, const Nuclei &nucs, int zeta) {
     mrcpp::print::separator(0, '~');
-    print_utils::text(0, "Calculation ", "Diagonalize Hamiltonian matrix");
+    print_utils::text(0, "Calculation ", "Compute initial orbitals");
+    print_utils::text(0, "Method      ", "Diagonalize Core Hamiltonian matrix");
     print_utils::text(0, "Precision   ", print_utils::dbl_to_str(prec, 5, true));
     print_utils::text(0, "Restricted  ", (orbital::size_singly(Phi)) ? "False" : "True");
-    print_utils::text(0, "Hamiltonian ", "Core");
     print_utils::text(0, "AO basis    ", "Hydrogenic orbitals");
     print_utils::text(0, "Zeta quality", std::to_string(zeta));
     mrcpp::print::separator(0, '~', 2);

--- a/src/initial_guess/gto.cpp
+++ b/src/initial_guess/gto.cpp
@@ -75,7 +75,8 @@ bool initial_guess::gto::setup(OrbitalVector &Phi,
     if (Phi.size() == 0) return false;
 
     mrcpp::print::separator(0, '~');
-    print_utils::text(0, "Calculation   ", "Read orbitals from file (GTO)");
+    print_utils::text(0, "Calculation   ", "Compute initial orbitals");
+    print_utils::text(0, "Method        ", "Project GTO molecular orbitals");
     print_utils::text(0, "Precision     ", print_utils::dbl_to_str(prec, 5, true));
     if (orbital::size_singly(Phi)) {
         print_utils::text(0, "Restricted    ", "False");

--- a/src/initial_guess/mw.cpp
+++ b/src/initial_guess/mw.cpp
@@ -55,7 +55,8 @@ bool initial_guess::mw::setup(OrbitalVector &Phi,
     if (Phi.size() == 0) return false;
 
     mrcpp::print::separator(0, '~');
-    print_utils::text(0, "Calculation   ", "Read orbitals from file (MW)");
+    print_utils::text(0, "Calculation   ", "Compute initial orbitals");
+    print_utils::text(0, "Method        ", "Project MW molecular orbitals");
     print_utils::text(0, "Precision     ", print_utils::dbl_to_str(prec, 5, true));
     if (orbital::size_singly(Phi)) {
         print_utils::text(0, "Restricted    ", "False");

--- a/src/initial_guess/mw.h
+++ b/src/initial_guess/mw.h
@@ -25,6 +25,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "qmfunctions/qmfunction_fwd.h"
 
 /** @file mw.h
@@ -36,11 +38,14 @@
  */
 
 namespace mrchem {
-
 namespace initial_guess {
 namespace mw {
 
-bool setup(OrbitalVector &Phi, const std::string &file);
+bool setup(OrbitalVector &Phi,
+           double prec,
+           const std::string &file_p,
+           const std::string &file_a,
+           const std::string &file_b);
 
 } // namespace mw
 } // namespace initial_guess

--- a/src/initial_guess/sad.cpp
+++ b/src/initial_guess/sad.cpp
@@ -65,10 +65,10 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, const Nuclei &nu
 
     auto restricted = (orbital::size_singly(Phi)) ? false : true;
     mrcpp::print::separator(0, '~');
-    print_utils::text(0, "Calculation ", "Diagonalize Hamiltonian matrix");
+    print_utils::text(0, "Calculation ", "Compute initial orbitals");
+    print_utils::text(0, "Method      ", "Diagonalize SAD Hamiltonian");
     print_utils::text(0, "Precision   ", print_utils::dbl_to_str(prec, 5, true));
     print_utils::text(0, "Restricted  ", (restricted) ? "True" : "False");
-    print_utils::text(0, "Hamiltonian ", "Superposition of Atomic Densities (SAD)");
     print_utils::text(0, "Functional  ", "LDA (SVWN5)");
     print_utils::text(0, "AO basis    ", "Hydrogenic orbitals");
     print_utils::text(0, "Zeta quality", std::to_string(zeta));

--- a/src/input/mrchem.in
+++ b/src/input/mrchem.in
@@ -283,7 +283,9 @@ def write_scf_guess(user_dict, method_name):
         "file_gto_paired": user_dict["Files"]["file_gto_paired"],
         "file_gto_alpha": user_dict["Files"]["file_gto_alpha"],
         "file_gto_beta": user_dict["Files"]["file_gto_beta"],
-        "file_orbitals": user_dict["Files"]["file_orbitals"],
+        "file_mw_paired": user_dict["Files"]["file_mw_paired"],
+        "file_mw_alpha": user_dict["Files"]["file_mw_alpha"],
+        "file_mw_beta": user_dict["Files"]["file_mw_beta"]
     }
     return guess_dict
 

--- a/src/input/template.yml
+++ b/src/input/template.yml
@@ -438,11 +438,27 @@ sections:
         default: "initial_guess/mrchem.mob"
         docstring: |
           File name for beta MO matrix, used with 'gto' guess.
+      - name: file_mw_paired
+        type: str
+        default: "orbitals/phi_p"
+        docstring: |
+          File name for paired orbitals, used with 'mw' guess.
+      - name: file_mw_alpha
+        type: str
+        default: "orbitals/phi_a"
+        docstring: |
+          File name for alpha orbitals, used with 'mw' guess.
+      - name: file_mw_beta
+        type: str
+        default: "orbitals/phi_b"
+        docstring: |
+          File name for beta orbitals, used with 'mw' guess.
       - name: file_orbitals
         type: str
         default: "orbitals/phi"
         docstring: |
-          File name for orbitals, used with 'write_orbitals'.
+          File name for orbitals, used with 'write_orbitals', will get
+          "_p", "_a" or "_b" extension.
   - name: SCF
     docstring: |
       Includes parameters related to the ground state SCF orbital optimization

--- a/src/qmfunctions/ComplexFunction.h
+++ b/src/qmfunctions/ComplexFunction.h
@@ -25,24 +25,32 @@
 
 #pragma once
 
+#include <MRCPP/MWFunctions>
+
 #include "mrchem.h"
 #include "parallel.h"
 
 namespace mrchem {
 
 struct FunctionData {
-    int real_size;
-    int imag_size;
-    bool is_shared;
+    int type{0};
+    int order{1};
+    int scale{0};
+    int depth{0};
+    int boxes[3] = {0, 0, 0};
+    int corner[3] = {0, 0, 0};
+    int real_size{0};
+    int imag_size{0};
+    bool is_shared{false};
 };
 
 class ComplexFunction final {
 public:
     explicit ComplexFunction(bool share)
-            : func_data({0, 0, share})
-            , shared_mem(nullptr)
+            : shared_mem(nullptr)
             , re(nullptr)
             , im(nullptr) {
+        this->func_data.is_shared = share;
         if (this->func_data.is_shared and mpi::share_size > 1) {
             // Memory size in MB defined in input. Virtual memory, does not cost anything if not used.
             this->shared_mem = new mrcpp::SharedMemory(mpi::comm_share, mpi::shared_memory_size);
@@ -66,8 +74,28 @@ private:
     void flushFuncData() {
         this->func_data.real_size = 0;
         this->func_data.imag_size = 0;
-        if (this->re != nullptr) this->func_data.real_size = this->re->getNChunksUsed();
-        if (this->im != nullptr) this->func_data.imag_size = this->im->getNChunksUsed();
+        if (this->re != nullptr) {
+            this->func_data.real_size = this->re->getNChunksUsed();
+            flushMRAData(this->re->getMRA());
+        }
+        if (this->im != nullptr) {
+            this->func_data.imag_size = this->im->getNChunksUsed();
+            flushMRAData(this->im->getMRA());
+        }
+    }
+
+    void flushMRAData(const mrcpp::MultiResolutionAnalysis<3> &mra) {
+        const auto &box = mra.getWorldBox();
+        this->func_data.type = mra.getScalingBasis().getScalingType();
+        this->func_data.order = mra.getOrder();
+        this->func_data.depth = mra.getMaxDepth();
+        this->func_data.scale = box.getScale();
+        this->func_data.boxes[0] = box.size(0);
+        this->func_data.boxes[1] = box.size(1);
+        this->func_data.boxes[2] = box.size(2);
+        this->func_data.corner[0] = box.getCornerIndex().getTranslation(0);
+        this->func_data.corner[1] = box.getCornerIndex().getTranslation(1);
+        this->func_data.corner[2] = box.getCornerIndex().getTranslation(2);
     }
 };
 

--- a/src/qmfunctions/QMFunction.cpp
+++ b/src/qmfunctions/QMFunction.cpp
@@ -64,14 +64,15 @@ void QMFunction::setImag(mrcpp::FunctionTree<3> *tree) {
     this->func_ptr->im = tree;
 }
 
-void QMFunction::alloc(int type) {
+void QMFunction::alloc(int type, mrcpp::MultiResolutionAnalysis<3> *mra) {
+    if (mra == nullptr) MSG_ABORT("Invalid argument");
     if (type == NUMBER::Real or type == NUMBER::Total) {
         if (hasReal()) MSG_ABORT("Real part already allocated");
-        this->func_ptr->re = new mrcpp::FunctionTree<3>(*MRA, this->func_ptr->shared_mem);
+        this->func_ptr->re = new mrcpp::FunctionTree<3>(*mra, this->func_ptr->shared_mem);
     }
     if (type == NUMBER::Imag or type == NUMBER::Total) {
         if (hasImag()) MSG_ABORT("Imaginary part already allocated");
-        this->func_ptr->im = new mrcpp::FunctionTree<3>(*MRA, this->func_ptr->shared_mem);
+        this->func_ptr->im = new mrcpp::FunctionTree<3>(*mra, this->func_ptr->shared_mem);
     }
 }
 

--- a/src/qmfunctions/QMFunction.h
+++ b/src/qmfunctions/QMFunction.h
@@ -40,7 +40,7 @@ public:
     QMFunction dagger();
     virtual ~QMFunction() = default;
 
-    void alloc(int type);
+    void alloc(int type, mrcpp::MultiResolutionAnalysis<3> *mra = MRA);
     void free(int type);
 
     bool isShared() const { return this->func_ptr->func_data.is_shared; }
@@ -49,6 +49,7 @@ public:
 
     int getSizeNodes(int type) const;
     int getNNodes(int type) const;
+
     FunctionData &getFunctionData();
 
     void setReal(mrcpp::FunctionTree<3> *tree);

--- a/src/qmfunctions/orbital_utils.cpp
+++ b/src/qmfunctions/orbital_utils.cpp
@@ -143,6 +143,62 @@ int orbital::compare_spin(const Orbital &phi_a, const Orbital &phi_b) {
     return comp;
 }
 
+/** @brief Compare spin and occupancy of two orbital vector
+ *
+ *  Returns true if orbital parameters are the same, orbital ordering
+ *  NOT taken into account.
+ *
+ */
+bool orbital::compare(const OrbitalVector &Phi_a, const OrbitalVector &Phi_b) {
+    bool comp = true;
+    if (orbital::size_alpha(Phi_a) != orbital::size_alpha(Phi_b)) {
+        MSG_WARN("Different alpha occupancy");
+        comp = false;
+    }
+    if (orbital::size_beta(Phi_a) != orbital::size_beta(Phi_b)) {
+        MSG_WARN("Different beta occupancy");
+        comp = false;
+    }
+    if (orbital::size_paired(Phi_a) != orbital::size_paired(Phi_b)) {
+        MSG_WARN("Different paired occupancy");
+        comp = false;
+    }
+    if (orbital::size_empty(Phi_a) != orbital::size_empty(Phi_b)) {
+        MSG_WARN("Different empty occupancy");
+        comp = false;
+    }
+    if (orbital::size_singly(Phi_a) != orbital::size_singly(Phi_b)) {
+        MSG_WARN("Different single occupancy");
+        comp = false;
+    }
+    if (orbital::size_doubly(Phi_a) != orbital::size_doubly(Phi_b)) {
+        MSG_WARN("Different double occupancy");
+        comp = false;
+    }
+    if (orbital::size_occupied(Phi_a) != orbital::size_occupied(Phi_b)) {
+        MSG_WARN("Different total occupancy");
+        comp = false;
+    }
+
+    for (auto &phi_a : Phi_a) {
+        const mrcpp::MultiResolutionAnalysis<3> *mra_a{nullptr};
+        if (phi_a.hasReal()) mra_a = &phi_a.real().getMRA();
+        if (phi_a.hasImag()) mra_a = &phi_a.imag().getMRA();
+        if (mra_a == nullptr) continue;
+        for (auto &phi_b : Phi_b) {
+            const mrcpp::MultiResolutionAnalysis<3> *mra_b{nullptr};
+            if (phi_b.hasReal()) mra_b = &phi_a.real().getMRA();
+            if (phi_b.hasImag()) mra_b = &phi_a.imag().getMRA();
+            if (mra_b == nullptr) continue;
+            if (*mra_a != *mra_b) {
+                MSG_WARN("Different MRA");
+                comp = false;
+            }
+        }
+    }
+    return comp;
+}
+
 /** @brief out_i = a*(inp_a)_i + b*(inp_b)_i
  *
  *  Component-wise addition of orbitals.

--- a/src/qmfunctions/orbital_utils.h
+++ b/src/qmfunctions/orbital_utils.h
@@ -52,8 +52,8 @@ OrbitalVector param_copy(const OrbitalVector &Phi);
 OrbitalVector adjoin(OrbitalVector &Phi_a, OrbitalVector &Phi_b);
 OrbitalVector disjoin(OrbitalVector &Phi, int spin);
 
-void save_orbitals(OrbitalVector &Phi, const std::string &file, const std::string &suffix = "", int n_orbs = -1);
-OrbitalVector load_orbitals(const std::string &file, const std::string &suffix = "", int n_orbs = -1);
+void save_orbitals(OrbitalVector &Phi, const std::string &file, int spin = -1);
+OrbitalVector load_orbitals(const std::string &file, int n_orbs = -1);
 
 void normalize(OrbitalVector &Phi);
 void orthogonalize(double prec, OrbitalVector &Phi);

--- a/src/qmfunctions/orbital_utils.h
+++ b/src/qmfunctions/orbital_utils.h
@@ -31,6 +31,7 @@
 namespace mrchem {
 namespace orbital {
 
+bool compare(const OrbitalVector &Phi_a, const OrbitalVector &Phi_b);
 bool compare(const Orbital &phi_a, const Orbital &phi_b);
 int compare_occ(const Orbital &phi_a, const Orbital &phi_b);
 int compare_spin(const Orbital &phi_a, const Orbital &phi_b);


### PR DESCRIPTION
Improve MW guess to allow re-projection of MW orbitals onto a different MRA (world and basis).

Typical work flow I
------------------------
1. Run low prec calculation and write orbitals
```
world_prec = 1.0e-3    # results in order 5
SCF {
  guess_type = sad_dz
  write_orbitals = true
}
```
2. Rerun calculation with higher prec with MW guess

```
world_prec = 1.0e-6    # results in order 9
SCF {
  guess_type = mw
}
```
By default paired/alpha/beta orbitals are written to (and read from) `orbitals/phi_[p/a/b]` but you can override in the `Files` input section
```
Files {
  file_mw_paired = orbitals/phi_p  # where 'mw' guess reads paired orbitals
  file_mw_alpha = orbitals/phi_a   # where 'mw' guess reads alpha orbitals
  file_mw_beta = orbitals/phi_b    # where 'mw' guess reads beta orbitals
  file_orbitals = orbitals/phi     # where 'write_orbitals' writes converged orbitals, with '_p', '_a, '_b extension
}
```

Typical work flow II
-------------------------
1.  Run closed shell LDA calculation for Ne
```
Molecule {
  multiplicity = 1
$coords
Ne  0.0  0.0  0.0
$end
}
WaveFunction {
  method = LDA
  restricted = true
}
Files {
  file_orbitals = orbitals/phi  # will save Ne orbitals as 'orbitals/phi_p'
}
SCF {
  guess_type = sad_dz
  write_orbitals = true
}
```
2. Use the restricted Ne orbitals as initial guess for an unrestricted PBE calculation of F
```
Molecule {
  multiplicity = 2
$coords
F  0.0  0.0  0.0
$end
}
WaveFunction {
  method = PBE
  restricted = false
}
Files {
  file_mw_alpha = orbitals/phi_p # use Ne (paired) orbitals as alpha guess
  file_mw_beta = orbitals/phi_p  # use Ne (paired) orbitals as beta guess
}
SCF {
  guess_type = mw
}
```