### PR TITLE
Guess cleanup part 2: Checkpointing

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -175,6 +175,7 @@ bool driver::guess_scf_orbitals(const json &json_guess, Molecule &mol) {
     for (auto p = 0; p < Np; p++) Phi.push_back(Orbital(SPIN::Paired));
     for (auto a = 0; a < Na; a++) Phi.push_back(Orbital(SPIN::Alpha));
     for (auto b = 0; b < Nb; b++) Phi.push_back(Orbital(SPIN::Beta));
+    mpi::distribute(Phi);
 
     auto success = true;
     if (type == "chk") {

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -145,10 +145,13 @@ bool driver::guess_scf_orbitals(const json &json_guess, Molecule &mol) {
     auto prec = json_guess["prec"];
     auto zeta = json_guess["zeta"];
     auto type = json_guess["type"];
-    auto file_p = json_guess["file_phi_p"];
-    auto file_a = json_guess["file_phi_a"];
-    auto file_b = json_guess["file_phi_b"];
-    auto file_bas = json_guess["file_basis"];
+    auto mw_p = json_guess["file_phi_p"];
+    auto mw_a = json_guess["file_phi_a"];
+    auto mw_b = json_guess["file_phi_b"];
+    auto gto_p = json_guess["file_gto_p"];
+    auto gto_a = json_guess["file_gto_a"];
+    auto gto_b = json_guess["file_gto_b"];
+    auto gto_bas = json_guess["file_basis"];
     auto file_chk = json_guess["file_chk"];
     auto restricted = json_guess["restricted"];
 
@@ -179,13 +182,13 @@ bool driver::guess_scf_orbitals(const json &json_guess, Molecule &mol) {
     if (type == "chk") {
         success = initial_guess::chk::setup(Phi, file_chk);
     } else if (type == "mw") {
-        success = initial_guess::mw::setup(Phi, prec, file_p, file_a, file_b);
+        success = initial_guess::mw::setup(Phi, prec, mw_p, mw_a, mw_b);
     } else if (type == "core") {
         success = initial_guess::core::setup(Phi, prec, nucs, zeta);
     } else if (type == "sad") {
         success = initial_guess::sad::setup(Phi, prec, nucs, zeta);
     } else if (type == "gto") {
-        success = initial_guess::gto::setup(Phi, prec, file_bas, file_p, file_a, file_b);
+        success = initial_guess::gto::setup(Phi, prec, gto_bas, gto_p, gto_a, gto_b);
     } else {
         MSG_ERROR("Invalid initial guess");
         success = false;

--- a/src/initial_guess/CMakeLists.txt
+++ b/src/initial_guess/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(mrchem
   PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/chk.cpp
     ${CMAKE_CURRENT_LIST_DIR}/core.cpp
     ${CMAKE_CURRENT_LIST_DIR}/gto.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mw.cpp

--- a/src/initial_guess/chk.cpp
+++ b/src/initial_guess/chk.cpp
@@ -23,7 +23,7 @@
  * <https://mrchem.readthedocs.io/>
  */
 
-#include "MRCPP/Printer"
+#include <MRCPP/Printer>
 
 #include "chk.h"
 
@@ -34,7 +34,8 @@ namespace mrchem {
 
 bool initial_guess::chk::setup(OrbitalVector &Phi, const std::string &chk_file) {
     mrcpp::print::separator(0, '~');
-    print_utils::text(0, "Calculation     ", "Read checkpoint file");
+    print_utils::text(0, "Calculation     ", "Compute initial orbitals");
+    print_utils::text(0, "Method          ", "Read checkpoint file");
     print_utils::text(0, "Checkpoint file ", chk_file);
     mrcpp::print::separator(0, '~', 2);
 

--- a/src/initial_guess/chk.cpp
+++ b/src/initial_guess/chk.cpp
@@ -1,0 +1,50 @@
+/*
+ * MRChem, a numerical real-space code for molecular electronic structure
+ * calculations within the self-consistent field (SCF) approximations of quantum
+ * chemistry (Hartree-Fock and Density Functional Theory).
+ * Copyright (C) 2020 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ *
+ * This file is part of MRChem.
+ *
+ * MRChem is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MRChem is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with MRChem.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * For information on the complete list of contributors to MRChem, see:
+ * <https://mrchem.readthedocs.io/>
+ */
+
+#include "MRCPP/Printer"
+
+#include "chk.h"
+
+#include "qmfunctions/orbital_utils.h"
+#include "utils/print_utils.h"
+
+namespace mrchem {
+
+bool initial_guess::chk::setup(OrbitalVector &Phi, const std::string &chk_file) {
+    mrcpp::print::separator(0, '~');
+    print_utils::text(0, "Calculation     ", "Read checkpoint file");
+    print_utils::text(0, "Checkpoint file ", chk_file);
+    mrcpp::print::separator(0, '~', 2);
+
+    auto success = true;
+    auto Psi = orbital::load_orbitals(chk_file);
+    if (Psi.size() > 0) {
+        success = orbital::compare(Psi, Phi);
+        Phi = Psi;
+    }
+    return success;
+}
+
+} // namespace mrchem

--- a/src/initial_guess/chk.h
+++ b/src/initial_guess/chk.h
@@ -1,0 +1,47 @@
+/*
+ * MRChem, a numerical real-space code for molecular electronic structure
+ * calculations within the self-consistent field (SCF) approximations of quantum
+ * chemistry (Hartree-Fock and Density Functional Theory).
+ * Copyright (C) 2020 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ *
+ * This file is part of MRChem.
+ *
+ * MRChem is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MRChem is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with MRChem.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * For information on the complete list of contributors to MRChem, see:
+ * <https://mrchem.readthedocs.io/>
+ */
+
+#pragma once
+
+#include "qmfunctions/Orbital.h"
+#include "qmfunctions/qmfunction_fwd.h"
+
+/** @file chk.h
+ *
+ * @brief Module for generating initial guess from checkpoint file
+ *
+ * The initial_guess::chk namespace provides functionality to setup an initial
+ * guess from orbitals dumped in a checkpoint file in a precious calculation.
+ */
+
+namespace mrchem {
+namespace initial_guess {
+namespace chk {
+
+bool setup(OrbitalVector &Phi, const std::string &chk_file);
+
+} // namespace chk
+} // namespace initial_guess
+} // namespace mrchem

--- a/src/initial_guess/mw.cpp
+++ b/src/initial_guess/mw.cpp
@@ -109,7 +109,7 @@ void initial_guess::mw::project_mo(OrbitalVector &Phi, double prec, const std::s
         Timer t_i;
         if (mpi::my_orb(Phi[i])) {
             std::stringstream orbname;
-            orbname << mo_file << "_" << i;
+            orbname << mo_file << "_idx_" << i;
 
             Orbital phi_i;
             phi_i.loadOrbital(orbname.str());

--- a/src/input/mrchem.in
+++ b/src/input/mrchem.in
@@ -274,6 +274,7 @@ def write_scf_guess(user_dict, method_name):
 
     scf_dict = user_dict["SCF"]
     file_dict = user_dict["Files"]
+    print(file_dict["guess_basis"])
     guess_dict = {
         "prec": scf_dict["guess_prec"],
         "zeta": zeta,
@@ -283,6 +284,9 @@ def write_scf_guess(user_dict, method_name):
         "restricted": user_dict["WaveFunction"]["restricted"],
         "file_chk": scf_dict["path_checkpoint"] + "/phi_scf",
         "file_basis": file_dict["guess_basis"],
+        "file_gto_p": file_dict["guess_gto_p"],
+        "file_gto_a": file_dict["guess_gto_a"],
+        "file_gto_b": file_dict["guess_gto_b"],
         "file_phi_p": file_dict["guess_phi_p"] + "_scf",
         "file_phi_a": file_dict["guess_phi_a"] + "_scf",
         "file_phi_b": file_dict["guess_phi_b"] + "_scf"

--- a/src/input/mrchem.in
+++ b/src/input/mrchem.in
@@ -48,7 +48,7 @@ def main():
     this_path = Path(__file__).parent
 
     # create necessary directories
-    for d in ['orbitals', 'initial_guess', 'plots']:
+    for d in ['checkpoint', 'orbitals', 'initial_guess', 'plots']:
         if not os.path.exists(d):
             os.mkdir(d)
 
@@ -279,6 +279,7 @@ def write_scf_guess(user_dict, method_name):
         "method": method_name,
         "localize": user_dict["SCF"]["localize"],
         "restricted": user_dict["WaveFunction"]["restricted"],
+        "file_chk": user_dict["Files"]["file_chk"],
         "file_gto_basis": user_dict["Files"]["file_gto_basis"],
         "file_gto_paired": user_dict["Files"]["file_gto_paired"],
         "file_gto_alpha": user_dict["Files"]["file_gto_alpha"],
@@ -319,6 +320,8 @@ def write_scf_solver(user_dict, method_name):
         "max_iter": user_dict["SCF"]["max_iter"],
         "rotation": user_dict["SCF"]["rotation"],
         "localize": user_dict["SCF"]["localize"],
+        "file_chk": user_dict["Files"]["file_chk"],
+        "checkpoint": user_dict["SCF"]["write_checkpoint"],
         "start_prec": start_prec,
         "final_prec": final_prec,
         "energy_thrs": energy_thrs,

--- a/src/input/mrchem.in
+++ b/src/input/mrchem.in
@@ -272,21 +272,20 @@ def write_scf_guess(user_dict, method_name):
         else:
             print("Invalid zeta:" + guess_suffix)
 
+    scf_dict = user_dict["SCF"]
+    file_dict = user_dict["Files"]
     guess_dict = {
-        "prec": user_dict["SCF"]["guess_prec"],
+        "prec": scf_dict["guess_prec"],
         "zeta": zeta,
         "type": guess_type,
         "method": method_name,
-        "localize": user_dict["SCF"]["localize"],
+        "localize": scf_dict["localize"],
         "restricted": user_dict["WaveFunction"]["restricted"],
-        "file_chk": user_dict["Files"]["file_chk"],
-        "file_gto_basis": user_dict["Files"]["file_gto_basis"],
-        "file_gto_paired": user_dict["Files"]["file_gto_paired"],
-        "file_gto_alpha": user_dict["Files"]["file_gto_alpha"],
-        "file_gto_beta": user_dict["Files"]["file_gto_beta"],
-        "file_mw_paired": user_dict["Files"]["file_mw_paired"],
-        "file_mw_alpha": user_dict["Files"]["file_mw_alpha"],
-        "file_mw_beta": user_dict["Files"]["file_mw_beta"]
+        "file_chk": scf_dict["path_checkpoint"] + "/phi_scf",
+        "file_basis": file_dict["guess_basis"],
+        "file_phi_p": file_dict["guess_phi_p"] + "_scf",
+        "file_phi_a": file_dict["guess_phi_a"] + "_scf",
+        "file_phi_b": file_dict["guess_phi_b"] + "_scf"
     }
     return guess_dict
 
@@ -320,7 +319,7 @@ def write_scf_solver(user_dict, method_name):
         "max_iter": user_dict["SCF"]["max_iter"],
         "rotation": user_dict["SCF"]["rotation"],
         "localize": user_dict["SCF"]["localize"],
-        "file_chk": user_dict["Files"]["file_chk"],
+        "file_chk": user_dict["SCF"]["path_checkpoint"] + "/phi_scf",
         "checkpoint": user_dict["SCF"]["write_checkpoint"],
         "start_prec": start_prec,
         "final_prec": final_prec,
@@ -524,10 +523,16 @@ def write_scf_calculation(user_dict, mol_dict):
     method_name, wf_method, dft_funcs = parse_wf_method(user_dict)
 
     scf_dict = {}
-    scf_dict["write_orbitals"] = user_dict["SCF"]["write_orbitals"]
-    scf_dict["file_orbitals"] = user_dict["Files"]["file_orbitals"]
     scf_dict["fock_operator"] = write_scf_fock(user_dict, mol_dict, wf_method, dft_funcs)
     scf_dict["initial_guess"] = write_scf_guess(user_dict, method_name)
+
+    path_orbitals = user_dict["SCF"]["path_orbitals"]
+    if user_dict["SCF"]["write_orbitals"]:
+        scf_dict["write_orbitals"] = {
+            "file_phi_p": path_orbitals + "/phi_p_scf",
+            "file_phi_a": path_orbitals + "/phi_a_scf",
+            "file_phi_b": path_orbitals + "/phi_b_scf"
+        }
 
     if user_dict["SCF"]["run"]:
         scf_dict["scf_solver"] = write_scf_solver(user_dict, method_name)
@@ -635,8 +640,6 @@ def write_rsp_calc(omega, user_dict, mol_dict):
     rsp_calc["frequency"] = omega
     rsp_calc["dynamic"] = (omega > 1.0e-12)
     rsp_calc["directions"] = user_dict["Response"]["directions"]
-    rsp_calc["file_orbitals"] = user_dict["Files"]["file_orbitals"]
-    rsp_calc["write_orbitals"] = user_dict["Response"]["write_orbitals"]
     rsp_calc["fock_operator"] = write_rsp_fock(user_dict, mol_dict, wf_method, dft_funcs)
     rsp_calc["initial_guess"] = write_rsp_guess(user_dict, method_name)
 

--- a/src/input/template.yml
+++ b/src/input/template.yml
@@ -418,6 +418,12 @@ sections:
     docstring: |
       Defines file paths used for program input/output.
     keywords:
+      - name: file_chk
+        type: str
+        default: "checkpoint/phi"
+        docstring: |
+          File name for checkpoint files during SCF, used with 'write_checkpoint'
+          and 'chk' guess.
       - name: file_gto_basis
         type: str
         default: "initial_guess/mrchem.bas"
@@ -522,6 +528,7 @@ sections:
         predicates:
           - "value.lower() in
             ['mw',
+             'chk',
              'gto',
              'core_sz',
              'core_dz',
@@ -533,6 +540,10 @@ sections:
              'sad_qz']"
         docstring: |
           Type of initial guess for ground state orbitals.
+          'chk' restarts a previous calculation which was dumped using the
+          'write_checkpoint' keyword. This will load MRA and electron spin
+          configuration directly from the checkpoint files, which are thus
+          required to be identical in the two calculations.
           'mw' will start from final orbitals in a previous calculation written
           using the 'write_orbitals' keyword. The orbitals will be re-projected
           into the new computational setup, which means that the electron spin
@@ -542,6 +553,12 @@ sections:
           'core' and 'sad' will diagonalize the Fock matrix in the given AO
           basis (SZ, DZ, TZ or QZ) using a Core or Superposition of Atomic
           Densities Hamiltonian, respectively.
+      - name: write_checkpoint
+        type: bool
+        default: false
+        docstring: |
+          Write orbitals to disk in each iteration. Can be used as 'chk' initial
+          guess in subsequent calculations.
       - name: plot_density
         type: bool
         default: false

--- a/src/input/template.yml
+++ b/src/input/template.yml
@@ -423,6 +423,21 @@ sections:
         default: "initial_guess/mrchem.bas"
         docstring: |
           File name for GTO basis set, used with 'gto' guess.
+      - name: guess_gto_p
+        type: str
+        default: "initial_guess/mrchem.mop"
+        docstring: |
+          File name for paired orbitals, used with 'mw' and 'gto' guess.
+      - name: guess_gto_a
+        type: str
+        default: "initial_guess/mrchem.moa"
+        docstring: |
+          File name for alpha orbitals, used with 'mw' and 'gto' guess.
+      - name: guess_gto_b
+        type: str
+        default: "initial_guess/mrchem.mob"
+        docstring: |
+          File name for beta orbitals, used with 'mw' and 'gto' guess.
       - name: guess_phi_p
         type: str
         default: "initial_guess/phi_p"

--- a/src/input/template.yml
+++ b/src/input/template.yml
@@ -418,53 +418,56 @@ sections:
     docstring: |
       Defines file paths used for program input/output.
     keywords:
-      - name: file_chk
-        type: str
-        default: "checkpoint/phi"
-        docstring: |
-          File name for checkpoint files during SCF, used with 'write_checkpoint'
-          and 'chk' guess.
-      - name: file_gto_basis
+      - name: guess_basis
         type: str
         default: "initial_guess/mrchem.bas"
         docstring: |
           File name for GTO basis set, used with 'gto' guess.
-      - name: file_gto_paired
+      - name: guess_phi_p
         type: str
-        default: "initial_guess/mrchem.mop"
+        default: "initial_guess/phi_p"
         docstring: |
-          File name for paired MO matrix, used with 'gto' guess.
-      - name: file_gto_alpha
+          File name for paired orbitals, used with 'mw' and 'gto' guess.
+      - name: guess_phi_a
         type: str
-        default: "initial_guess/mrchem.moa"
+        default: "initial_guess/phi_a"
         docstring: |
-          File name for alpha MO matrix, used with 'gto' guess.
-      - name: file_gto_beta
+          File name for alpha orbitals, used with 'mw' and 'gto' guess.
+      - name: guess_phi_b
         type: str
-        default: "initial_guess/mrchem.mob"
+        default: "initial_guess/phi_b"
         docstring: |
-          File name for beta MO matrix, used with 'gto' guess.
-      - name: file_mw_paired
+          File name for beta orbitals, used with 'mw' and 'gto' guess.
+      - name: guess_x_p
         type: str
-        default: "orbitals/phi_p"
+        default: "initial_guess/X_p"
         docstring: |
-          File name for paired orbitals, used with 'mw' guess.
-      - name: file_mw_alpha
+          File name for paired response orbitals, used with 'mw' guess.
+      - name: guess_x_a
         type: str
-        default: "orbitals/phi_a"
+        default: "initial_guess/X_a"
         docstring: |
-          File name for alpha orbitals, used with 'mw' guess.
-      - name: file_mw_beta
+          File name for alpha response orbitals, used with 'mw' guess.
+      - name: guess_x_b
         type: str
-        default: "orbitals/phi_b"
+        default: "initial_guess/X_b"
         docstring: |
-          File name for beta orbitals, used with 'mw' guess.
-      - name: file_orbitals
+          File name for beta response orbitals, used with 'mw' guess.
+      - name: guess_y_p
         type: str
-        default: "orbitals/phi"
+        default: "initial_guess/Y_p"
         docstring: |
-          File name for orbitals, used with 'write_orbitals', will get
-          "_p", "_a" or "_b" extension.
+          File name for paired response orbitals, used with 'mw' guess.
+      - name: guess_y_a
+        type: str
+        default: "initial_guess/Y_a"
+        docstring: |
+          File name for alpha response orbitals, used with 'mw' guess.
+      - name: guess_y_b
+        type: str
+        default: "initial_guess/Y_b"
+        docstring: |
+          File name for beta response orbitals, used with 'mw' guess.
   - name: SCF
     docstring: |
       Includes parameters related to the ground state SCF orbital optimization
@@ -557,8 +560,28 @@ sections:
         type: bool
         default: false
         docstring: |
-          Write orbitals to disk in each iteration. Can be used as 'chk' initial
+          Write orbitals to disk in each iteration, file name
+          "<path_checkpoint>/phi_scf_idx_<0..N>". Can be used as 'chk' initial
           guess in subsequent calculations.
+      - name: path_checkpoint
+        type: str
+        default: "checkpoint"
+        docstring: |
+          Path to checkpoint files during SCF, used with 'write_checkpoint'
+          and 'chk' guess.
+      - name: write_orbitals
+        type: bool
+        default: false
+        docstring: |
+          Write final orbitals to disk, file name
+          "<path_orbitals>/phi_<p/a/b>_scf_idx_<0..Np/Na/Nb>".
+          Can be used as 'mw' initial guess in subsequent calculations.
+      - name: path_orbitals
+        type: str
+        default: "orbitals"
+        docstring: |
+          Path to where converged orbitals will be written in connection with
+          the 'write_orbitals' keyword.
       - name: plot_density
         type: bool
         default: false
@@ -570,12 +593,6 @@ sections:
         docstring: |
           Plot converged molecular orbitals of given index. If the first index
           is negative, all orbitals will be plotted.
-      - name: write_orbitals
-        type: bool
-        default: false
-        docstring: |
-          Write final orbitals to disk. Can be used as 'mw' initial
-          guess in subsequent calculations.
   - name: Response
     docstring: |
       Includes parameters related to the response SCF optimization.
@@ -637,13 +654,40 @@ sections:
         default: 'none'
         predicates:
           - "value.lower() in
-            ['none']"
+            ['none',
+             'chk',
+             'mw']"
         docstring: |
           Type of initial guess for response.
           'none' will start from a zero guess for the response functions.
+          'chk' restarts a previous calculation which was dumped using the
+          'write_checkpoint' keyword.
+          'mw' will start from final orbitals in a previous calculation written
+          using the 'write_orbitals' keyword. The orbitals will be re-projected
+          into the new computational setup.
+      - name: write_checkpoint
+        type: bool
+        default: false
+        docstring: |
+          Write perturbed orbitals to disk in each iteration, file name
+          "<path_checkpoint>/<X/Y>_rsp_<direction>_idx_<0..N>". Can be used as 'chk'
+          initial guess in subsequent calculations.
+      - name: path_checkpoint
+        type: str
+        default: "checkpoint"
+        docstring: |
+          Path to checkpoint files during SCF, used with 'write_checkpoint'
+          and 'chk' guess.
       - name: write_orbitals
         type: bool
         default: false
         docstring: |
-          Write final perturbed orbitals to disk. Can be used as 'mw' initial
-          guess in subsequent calculations.
+          Write final perturbed orbitals to disk, file name
+          "<path_orbitals>/<X/Y>_<p/a/b>_rsp_<direction>_idx_<0..Np/Na/Nb>".
+          Can be used as 'mw' initial guess in subsequent calculations.
+      - name: path_orbitals
+        type: str
+        default: "orbitals"
+        docstring: |
+          Path to where converged orbitals will be written in connection with
+          the 'write_orbitals' keyword.

--- a/src/qmfunctions/orbital_utils.cpp
+++ b/src/qmfunctions/orbital_utils.cpp
@@ -350,11 +350,7 @@ void orbital::save_orbitals(OrbitalVector &Phi, const std::string &file, int spi
         if ((Phi[i].spin() == spin) or (spin < 0)) {
             Timer t1;
             std::stringstream orbname;
-            orbname << file;
-            if (spin == SPIN::Paired) orbname << "_p";
-            if (spin == SPIN::Alpha) orbname << "_a";
-            if (spin == SPIN::Beta) orbname << "_b";
-            orbname << "_" << n;
+            orbname << file << "_idx_" << i;
             if (mpi::my_orb(Phi[i])) Phi[i].saveOrbital(orbname.str());
             print_utils::qmfunction(2, "'" + orbname.str() + "'", Phi[i], t1);
             n++;
@@ -384,7 +380,7 @@ OrbitalVector orbital::load_orbitals(const std::string &file, int n_orbs) {
         Timer t1;
         Orbital phi_i;
         std::stringstream orbname;
-        orbname << file << "_" << i;
+        orbname << file << "_idx_" << i;
         phi_i.loadOrbital(orbname.str());
         phi_i.setRankID(mpi::orb_rank);
         if (phi_i.hasReal() or phi_i.hasImag()) {

--- a/src/scf_solver/GroundStateSolver.cpp
+++ b/src/scf_solver/GroundStateSolver.cpp
@@ -166,6 +166,7 @@ void GroundStateSolver::printParameters(const std::string &calculation) const {
     mrcpp::print::separator(0, '~');
     print_utils::text(0, "Calculation        ", calculation);
     print_utils::text(0, "Method             ", this->methodName);
+    print_utils::text(0, "Checkpointing      ", (this->checkpoint) ? "On" : "Off");
     print_utils::text(0, "Max iterations     ", o_iter.str());
     print_utils::text(0, "KAIN solver        ", o_kain.str());
     print_utils::text(0, "Localization       ", o_loc.str());
@@ -311,6 +312,9 @@ bool GroundStateSolver::optimize(Molecule &mol, FockOperator &F) {
             F.rotate(U_mat);
             kain.clear();
         }
+
+        // Save checkpoint file
+        if (this->checkpoint) orbital::save_orbitals(Phi_n, this->chkFile);
 
         // Finalize SCF cycle
         if (plevel < 1) printConvergenceRow(nIter);

--- a/src/scf_solver/GroundStateSolver.h
+++ b/src/scf_solver/GroundStateSolver.h
@@ -55,12 +55,14 @@ public:
 
     void setRotation(int iter) { this->rotation = iter; }
     void setLocalize(bool loc) { this->localize = loc; }
+    void setCheckpointFile(const std::string &file) { this->chkFile = file; }
 
     bool optimize(Molecule &mol, FockOperator &F);
 
 protected:
     int rotation{0};      ///< Number of iterations between localization/diagonalization
     bool localize{false}; ///< Use localized or canonical orbitals
+    std::string chkFile;  ///< Name of checkpoint file
     std::vector<SCFEnergy> energy;
 
     void reset() override;

--- a/src/scf_solver/LinearResponseSolver.cpp
+++ b/src/scf_solver/LinearResponseSolver.cpp
@@ -157,6 +157,9 @@ bool LinearResponseSolver::optimize(double omega, Molecule &mol, FockOperator &F
 
             // Prepare for next iteration
             X_n = orbital::add(1.0, X_n, 1.0, dX_n);
+
+            // Save checkpoint file
+            if (this->checkpoint) orbital::save_orbitals(X_n, this->chkFileX);
         }
 
         if (dynamic and plevel == 1) mrcpp::print::separator(1, '-');
@@ -205,6 +208,9 @@ bool LinearResponseSolver::optimize(double omega, Molecule &mol, FockOperator &F
 
             // Prepare for next iteration
             Y_n = orbital::add(1.0, Y_n, 1.0, dY_n);
+
+            // Save checkpoint file
+            if (this->checkpoint) orbital::save_orbitals(Y_n, this->chkFileY);
         }
 
         // Compute property
@@ -326,6 +332,7 @@ void LinearResponseSolver::printParameters(double omega, const std::string &oper
     print_utils::text(0, "Calculation        ", o_calc.str());
     if (dynamic) print_utils::text(0, "Frequency          ", o_omega.str());
     print_utils::text(0, "Method             ", this->methodName);
+    print_utils::text(0, "Checkpointing      ", (this->checkpoint) ? "On" : "Off");
     print_utils::text(0, "Perturbation       ", oper);
     print_utils::text(0, "Max iterations     ", o_iter.str());
     print_utils::text(0, "KAIN solver        ", o_kain.str());

--- a/src/scf_solver/LinearResponseSolver.h
+++ b/src/scf_solver/LinearResponseSolver.h
@@ -44,10 +44,16 @@ public:
 
     bool optimize(double omega, Molecule &mol, FockOperator &F_0, FockOperator &F_1);
     void setOrthPrec(double prec) { this->orth_prec = prec; }
+    void setCheckpointFile(const std::string &file_x, const std::string &file_y) {
+        this->chkFileX = file_x;
+        this->chkFileY = file_y;
+    }
 
 protected:
     const bool dynamic;
     double orth_prec{mrcpp::MachineZero};
+    std::string chkFileX; ///< Name of checkpoint file
+    std::string chkFileY; ///< Name of checkpoint file
 
     void printProperty() const;
     void printParameters(double omega, const std::string &oper) const;

--- a/src/scf_solver/SCFSolver.h
+++ b/src/scf_solver/SCFSolver.h
@@ -49,15 +49,17 @@ public:
     virtual ~SCFSolver() = default;
 
     void setHistory(int hist) { this->history = hist; }
+    void setCheckpoint(bool chk) { this->checkpoint = chk; }
     void setThreshold(double orb, double prop);
     void setOrbitalPrec(double init, double final);
     void setHelmholtzPrec(double prec) { this->helmPrec = prec; }
-    void setMaxIterations(int m_iter) { this->maxIter = m_iter; }
+    void setMaxIterations(int iter) { this->maxIter = iter; }
     void setMethodName(const std::string &name) { this->methodName = name; }
 
 protected:
     int history{0};                      ///< Maximum length of KAIN history
     int maxIter{-1};                     ///< Maximum number of iterations
+    bool checkpoint{false};              ///< Dump orbitals to file every iteration
     double orbThrs{-1.0};                ///< Convergence threshold for norm of orbital update
     double propThrs{-1.0};               ///< Convergence threshold for property
     double helmPrec{-1.0};               ///< Precision for construction of Helmholtz operators


### PR DESCRIPTION
Added new checkpointing feature which dumps orbitals at each iteration, so that a particular run can be restarted if something happens (out of memory, time limit, non-convergence, etc). This feature is slightly different from the new MW initial guess in #276, but more closely resemble the old MW guess. Some notable differences:

MW write
------------
- only final orbitals
- keywords: `SCF { write_orbitals = true }` and ` SCF { path_orbitals = "orbitals" }`
- separates between paired/alpha/beta orbitals in the file names, by `phi_p`/`phi_a`/`phi_b` extension

MW read
------------
- keywords: `SCF { guess_type = mw }` and `Files { guess_phi_<p/a/b> = orbitals/phi_<p/a/b> }`
- re-projects MW orbitals, which allows for different MRAs
- sets up orbital configuration (N orbs, spins, etc) from new molecule input, and then projects necessary orbitals from available files

CHK write
-------------
- writes in each SCF iteration
- keywords: `SCF { write_checkpoint = true }` and `SCF { path_checkpoint = "checkpoint" } `
- dumps the `OrbitalVector` as a whole, i.e. does not separate between spins

CHK read
-------------
- keywords: `SCF { guess_type = chk }` and `SCF { path_checkpoint = "checkpoint" }`
- reads orbitals directly from file, i.e. no re-projection and MRAs *must* be identical
- reads orbital configuration (N orbs, spins, etc) from file, e.i. identical setup as before
