### PR TITLE
CMakeList fix for MAC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,13 @@ set_target_properties(mrchem
     PUBLIC_HEADER "${_public_headers}"
   )
 
+if(APPLE)
+  set_target_properties(mrchem
+    PROPERTIES
+      LINK_FLAGS "-undefined dynamic_lookup"
+    )
+endif()
+
 install(
   TARGETS
     mrchem


### PR DESCRIPTION
Small fix from @robertodr to make MAC compiler postopne resolving undefined symbols.