### PR TITLE
Build libmrchem as static library

### DIFF
--- a/external/upstream/fetch_xcfun.cmake
+++ b/external/upstream/fetch_xcfun.cmake
@@ -18,7 +18,6 @@ else()
 
   set(CMAKE_BUILD_TYPE Release)
   set(ENABLE_TESTALL FALSE CACHE BOOL "")
-  set(STATIC_LIBRARY_ONLY TRUE CACHE BOOL "")
   set(XCFUN_MAX_ORDER 3)  # TODO Maybe as a user-facing option?
   set(XCFUN_PYTHON_INTERFACE FALSE CACHE BOOL "")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 # <<< Build MRChem library >>>
+set(BUILD_SHARED_LIBS OFF)
 add_library(mrchem
   driver.cpp
   parallel.cpp


### PR DESCRIPTION
This fixes an obscure issue with dynamic linking that has annoyed @stigrj for quite a long time now. I still don't understand the original issue, but we agreed it's fine to have this fix in rather than break our teeth on getting dynamic linking right.