### PR TITLE
Fix installation of SAD input files

### DIFF
--- a/cmake/custom/sad_basis.cmake
+++ b/cmake/custom/sad_basis.cmake
@@ -1,7 +1,7 @@
 set(SAD_BASIS_SOURCE_DIR ${PROJECT_SOURCE_DIR}/share/sad_basis CACHE STRING "Path to SAD basis and density files")
 set(SAD_BASIS_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/share/${PROJECT_NAME}/sad_basis)
 install(
-  DIRECTORY ${SAD_BASIS_DIR}
-  DESTINATION share/${PROJECT_NAME}/sad_basis
+  DIRECTORY share/sad_basis
+  DESTINATION share/${PROJECT_NAME}
   )
 


### PR DESCRIPTION
`SAD_BASIS_DIR` was not defined, so the files were not installed.

Now the installed package is finally fully self-contained, and we can nuke the source repo after installation :tada: 