### PR TITLE
Improve handling of JSON input

### DIFF
--- a/src/input/mrchem.in
+++ b/src/input/mrchem.in
@@ -53,11 +53,24 @@ def main():
     # Parse command line
     launcher, executable, dryrun, stdout, inp_json, inp_name = parse_cmdline()
 
-    inp_file = Path(inp_name) if inp_name.endswith(".inp") else Path(inp_name + ".inp")
+    suffix = Path(inp_name).suffix
+    if suffix == ".inp":
+       inp_file = Path(inp_name)
+    elif suffix == ".json":
+       inp_file = Path(inp_name)
+       inp_json = True
+    elif suffix == "":
+       # no suffix, infer from inp_json
+       if inp_json:
+          inp_file = Path(inp_name + ".json")
+       else:
+          inp_file = Path(inp_name + ".inp")
+    else:
+       raise(f"Unrecognized file format ({suffix}) as input file.")
     name = inp_file.stem
     # these two are always in the current working directory
     out_file = f"{name}.out"
-    json_file = f"{name}.json"
+    json_file = f"{name}_out.json"
 
     # read user input file (JSONDict <- getkw file) or (JSONDict <- json file)
     if inp_json:

--- a/src/mrenv.cpp
+++ b/src/mrenv.cpp
@@ -241,7 +241,7 @@ void mrenv::dump_json(const json &json_inp, const json &json_out) {
     const auto file_name = detail::remove_extension(json_inp["printer"]["file_name"].get<std::string>());
     if (mpi::grand_master()) {
         std::ofstream ofs;
-        ofs.open(file_name + ".json", std::ios::out);
+        ofs.open(file_name + "_out.json", std::ios::out);
         ofs << json_tot.dump(2) << std::endl;
         ofs.close();
     }

--- a/tests/tester.py
+++ b/tests/tester.py
@@ -98,7 +98,7 @@ def run(options, *, input_file, filters=None, extra_args=None):
             print(f"\nstderr\n{child.stderr}")
             return 137
 
-    computed = Path(options.work_dir) / f"{inp_no_suffix}.json"
+    computed = Path(options.work_dir) / f"{inp_no_suffix}_out.json"
     expected = caller_dir / f"reference/{inp_no_suffix}.json"
     with computed.open("r") as o_json, expected.open("r") as r_json:
         out = json.load(o_json)


### PR DESCRIPTION
- Allow to pass suffixed (`.inp`, `.json`) or unsuffixed input files.
- Recognize format from suffix, if present, else follow `--json` flag.
- JSON output file is named `<inp_name>_out.json`, such that the JSON
  input is not overwritten.