### PR TITLE
Fix precision issue with chk initial guess

### DIFF
--- a/python/mrchem/helpers.py
+++ b/python/mrchem/helpers.py
@@ -113,7 +113,13 @@ def write_scf_guess(user_dict, method_name):
     guess_str = user_dict["SCF"]["guess_type"].lower()
     guess_type = guess_str.split('_')[0]
     zeta = 0
-    if guess_type == 'sad' or guess_type == 'core':
+
+    scf_dict = user_dict["SCF"]
+    guess_prec = scf_dict["guess_prec"]
+    if guess_type == 'chk':
+        guess_prec = user_dict['world_prec']
+
+    if guess_type in ['core', 'sad']:
         zeta_str = guess_str.split('_')[1]
         if zeta_str == 'sz':
             zeta = 1
@@ -126,11 +132,10 @@ def write_scf_guess(user_dict, method_name):
         else:
             print("Invalid zeta:" + guess_suffix)
 
-    scf_dict = user_dict["SCF"]
     file_dict = user_dict["Files"]
     guess_dict = {
-        "prec": scf_dict["guess_prec"],
         "zeta": zeta,
+        "prec": guess_prec,
         "type": guess_type,
         "method": method_name,
         "localize": scf_dict["localize"],
@@ -233,12 +238,18 @@ def write_rsp_calc(omega, user_dict, mol_dict, origin):
                                         dft_funcs, origin)
     }
 
+    guess_str = rsp_dict["guess_type"].lower()
+    guess_type = guess_str.split('_')[0]
+    guess_prec = rsp_dict["guess_prec"]
+    if guess_type == 'chk':
+        guess_prec = user_dict['world_prec']
+
     rsp_calc["components"] = []
     for d in [0, 1, 2]:
         rsp_comp = {}
         rsp_comp["initial_guess"] = {
-            "type": rsp_dict["guess_type"].lower(),
-            "precision": rsp_dict["guess_prec"],
+            "prec": guess_prec,
+            "type": guess_type,
             "file_chk_x": rsp_dict["path_checkpoint"] + "/X_rsp_" + str(d),
             "file_chk_y": rsp_dict["path_checkpoint"] + "/Y_rsp_" + str(d),
             "file_x_p": file_dict["guess_x_p"] + "_rsp_" + str(d),

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -347,7 +347,7 @@ bool driver::scf::guess_orbitals(const json &json_guess, Molecule &mol) {
 }
 
 bool driver::scf::guess_energy(const json &json_guess, Molecule &mol, FockOperator &F) {
-    double prec = json_guess["prec"];
+    auto prec = json_guess["prec"];
     auto method = json_guess["method"];
     auto localize = json_guess["localize"];
 
@@ -771,7 +771,7 @@ json driver::rsp::run(const json &json_rsp, Molecule &mol) {
  */
 bool driver::rsp::guess_orbitals(const json &json_guess, Molecule &mol) {
     auto type = json_guess["type"];
-    auto prec = json_guess["precision"];
+    auto prec = json_guess["prec"];
     auto mw_xp = json_guess["file_x_p"];
     auto mw_xa = json_guess["file_x_a"];
     auto mw_xb = json_guess["file_x_b"];


### PR DESCRIPTION
Fixes issue reported by Anders that `chk` initial guesses was limited by the chosen `guess_prec`, due to an orbital rotation immediately after loading the orbitals. Now the `chk` guess will get the full `world_prec` for this rotation. All other guesses will still use `guess_prec`, but they are anyway inherently limited by this precision in their construction (unlike `chk`).