### PR TITLE
Change fetch-depth

### DIFF
--- a/.github/workflows/all-hail-minazo-bot.yml
+++ b/.github/workflows/all-hail-minazo-bot.yml
@@ -1,6 +1,9 @@
 name: All hail Minazo bot
 
-on: pull_request #_target
+on: 
+  pull_request_target:
+    branches: [ master, release/* ]
+
 
 jobs:
   danger:
@@ -9,8 +12,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-        ref: ${{ github.event.pull_request.head.ref }}
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
         
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/all-hail-minazo-bot.yml
+++ b/.github/workflows/all-hail-minazo-bot.yml
@@ -22,5 +22,5 @@ jobs:
     
     - name: Run Danger
       env:
-        DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+        DANGER_GITHUB_API_TOKEN: 0f8e593f9b3cb43e20657052785715081537661b
       run: BUNDLE_GEMFILE=.github/Gemfile bundle exec danger --dangerfile=.github/Dangerfile

--- a/.github/workflows/all-hail-minazo-bot.yml
+++ b/.github/workflows/all-hail-minazo-bot.yml
@@ -2,12 +2,13 @@ name: All hail Minazo bot
 
 on: pull_request
 
-
 jobs:
   danger:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
@@ -22,4 +23,5 @@ jobs:
     - name: Run Danger
       env:
         DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
       run: BUNDLE_GEMFILE=.github/Gemfile bundle exec danger --dangerfile=.github/Dangerfile

--- a/.github/workflows/all-hail-minazo-bot.yml
+++ b/.github/workflows/all-hail-minazo-bot.yml
@@ -6,9 +6,9 @@ jobs:
   danger:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
+      #with:
+      #  fetch-depth: 0
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
@@ -22,5 +22,5 @@ jobs:
     
     - name: Run Danger
       env:
-        DANGER_GITHUB_API_TOKEN: 0f8e593f9b3cb43e20657052785715081537661b
+        DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: BUNDLE_GEMFILE=.github/Gemfile bundle exec danger --dangerfile=.github/Dangerfile

--- a/.github/workflows/all-hail-minazo-bot.yml
+++ b/.github/workflows/all-hail-minazo-bot.yml
@@ -23,5 +23,5 @@ jobs:
     - name: Run Danger
       env:
         DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
+        #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
       run: BUNDLE_GEMFILE=.github/Gemfile bundle exec danger --dangerfile=.github/Dangerfile

--- a/.github/workflows/all-hail-minazo-bot.yml
+++ b/.github/workflows/all-hail-minazo-bot.yml
@@ -22,6 +22,6 @@ jobs:
     
     - name: Run Danger
       env:
-        DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
+        #DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
       run: BUNDLE_GEMFILE=.github/Gemfile bundle exec danger --dangerfile=.github/Dangerfile

--- a/.github/workflows/all-hail-minazo-bot.yml
+++ b/.github/workflows/all-hail-minazo-bot.yml
@@ -22,6 +22,6 @@ jobs:
     
     - name: Run Danger
       env:
-        #DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
+        DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
+        #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
       run: BUNDLE_GEMFILE=.github/Gemfile bundle exec danger --dangerfile=.github/Dangerfile

--- a/.github/workflows/all-hail-minazo-bot.yml
+++ b/.github/workflows/all-hail-minazo-bot.yml
@@ -4,7 +4,6 @@ on: pull_request_target
 
 jobs:
   danger:
-    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/all-hail-minazo-bot.yml
+++ b/.github/workflows/all-hail-minazo-bot.yml
@@ -23,5 +23,4 @@ jobs:
     - name: Run Danger
       env:
         DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
-        #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
       run: BUNDLE_GEMFILE=.github/Gemfile bundle exec danger --dangerfile=.github/Dangerfile

--- a/.github/workflows/all-hail-minazo-bot.yml
+++ b/.github/workflows/all-hail-minazo-bot.yml
@@ -1,15 +1,18 @@
 name: All hail Minazo bot
 
-on: pull_request
+on: pull_request_target
 
 jobs:
   danger:
+    if: github.event_name == 'pull_request' || github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-      #with:
-      #  fetch-depth: 0
-
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{github.event.pull_request.head.ref}}
+        repository: ${{github.event.pull_request.head.repo.full_name}}
+        
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/all-hail-minazo-bot.yml
+++ b/.github/workflows/all-hail-minazo-bot.yml
@@ -1,6 +1,6 @@
 name: All hail Minazo bot
 
-on: pull_request_target
+on: pull_request #_target
 
 jobs:
   danger:
@@ -9,8 +9,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-        ref: ${{github.event.pull_request.head.ref}}
-        repository: ${{github.event.pull_request.head.repo.full_name}}
+        ref: ${{ github.event.pull_request.head.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
         
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1

--- a/src/driver.h
+++ b/src/driver.h
@@ -32,7 +32,10 @@ class Molecule;
 namespace driver {
 
 void init_molecule(const nlohmann::json &input, Molecule &mol);
-nlohmann::json print_properties(const Molecule &mol);
+nlohmann::json 
+      print_properties(const 
+                           Molecule &
+                    mol);
 
 namespace scf {
 nlohmann::json run(const nlohmann::json &input, Molecule &mol);

--- a/src/driver.h
+++ b/src/driver.h
@@ -32,10 +32,7 @@ class Molecule;
 namespace driver {
 
 void init_molecule(const nlohmann::json &input, Molecule &mol);
-nlohmann::json 
-      print_properties(const 
-                           Molecule &
-                    mol);
+nlohmann::json print_properties(const Molecule &mol);
 
 namespace scf {
 nlohmann::json run(const nlohmann::json &input, Molecule &mol);


### PR DESCRIPTION
See here: https://github.com/danger/danger/issues/1103#issuecomment-635539947

Minazo is partially healed: 
1. If there are no comments to post, the job completes successfully.
2. If there are comments to post, the job fails because the bot's permissions are not sufficient to comment on open PRs.
I have changed the event that triggers Minazo from `pull_request` to `pull_request_target`, which presumably exposes secrets correctly. However, changing triggers is not picked up until the PR is merged...