### PR TITLE
Fix MPI deadlock

### DIFF
--- a/.github/workflows/all-hail-minazo-bot.yml
+++ b/.github/workflows/all-hail-minazo-bot.yml
@@ -8,9 +8,7 @@ jobs:
   danger:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
+    - uses: actions/checkout@v1
         
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/all-hail-minazo-bot.yml
+++ b/.github/workflows/all-hail-minazo-bot.yml
@@ -25,5 +25,5 @@ jobs:
     - name: Run Danger
       env:
         BUNDLE_GEMFILE: ".github/Gemfile"
-        DANGER_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}
       run: bundle exec danger --dangerfile=.github/Dangerfile

--- a/src/qmfunctions/ComplexFunction.h
+++ b/src/qmfunctions/ComplexFunction.h
@@ -50,10 +50,10 @@ public:
             : shared_mem(nullptr)
             , re(nullptr)
             , im(nullptr) {
-        if (share and mpi::share_size > 1) {
+        this->func_data.is_shared = share;
+        if (this->func_data.is_shared and mpi::share_size > 1) {
             // Memory size in MB defined in input. Virtual memory, does not cost anything if not used.
 #ifdef MRCPP_HAS_MPI
-            this->func_data.is_shared = true;
             this->shared_mem = new mrcpp::SharedMemory(mpi::comm_share, mpi::shared_memory_size);
 #endif
         }


### PR DESCRIPTION
Fixes MPI deadlock introduced in #328. The lock is triggered whenever the MPI orbital bank occupies _all but one_ rank on a particular node, _and_ at the same time a function is allocated in shared memory. Then the remaining rank on the node would mark the function as non-shared (because it's not actually sharing with anyone), which lead to subsequent `broadcast_function` to be called with a different communicator, thus deadlock.