### PR TITLE
Superfast rotate

### DIFF
--- a/.github/mrchem-codecov.yml
+++ b/.github/mrchem-codecov.yml
@@ -6,7 +6,6 @@ dependencies:
   - cxx-compiler
   - eigen
   - lcov
-  - mrcpp
   - ninja
   - nlohmann_json
   - xcfun

--- a/.github/mrchem-gha.yml
+++ b/.github/mrchem-gha.yml
@@ -5,7 +5,6 @@ dependencies:
   - cmake
   - cxx-compiler
   - eigen
-  - mrcpp
   - ninja
   - nlohmann_json
   - xcfun

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -457,7 +457,7 @@ def setup(app):
             '@PROJECT_BINARY_DIR@' : project_root_dir,
             '@PERL_EXECUTABLE@'    : which('perl')
           }
-#    tup = (os.walk(project_src_dir)) 
+#    tup = (os.walk(project_src_dir))
 #    for root, dirs, files in os.walk(project_src_dir):
 #        if 'mwfilters' in dirs:
 #            dirs.remove('mwfilters')
@@ -486,3 +486,6 @@ def setup(app):
         app.connect("builder-inited", generate_doxygen_xml)
     else:
         run_doxygen(project_doc_dir)
+
+# configure sphinxcontrib.bibtex
+bibtex_bibfiles = ["bibliography.bib"]

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,4 +2,4 @@ breathe
 recommonmark
 Sphinx>=2.0
 sphinx_rtd_theme
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex==1.0.0

--- a/doc/users/betzy_example.job
+++ b/doc/users/betzy_example.job
@@ -1,0 +1,9 @@
+#!/bin/bash -l
+#SBATCH --nodes=4
+#SBATCH --tasks-per-node=8
+#SBATCH --cpus-per-task=16
+
+export UCX_LOG_LEVEL=ERROR
+export OMP_NUM_THREADS=16
+
+~/my_path/to/mrchem --launcher='mpirun --rank-by node --map-by numa --bind-to numa' mw6

--- a/doc/users/running.rst
+++ b/doc/users/running.rst
@@ -137,6 +137,35 @@ as it will be literally prepended to the ``mrchem.x`` command when the
     definitely not *more* than one process per orbital).
 
 
+Job example (Betzy)
++++++++++++++++++++
+
+This job will use 4 compute nodes, with 8 MPI processes on each, and each MPI
+process will use 16 OpenMP threads. The flags are optimized for OpenMPI (foss)
+library on Betzy.
+
+.. literalinclude:: betzy_example.job
+
+``--rank-by node``
+  Tells the system to place the first MPI rank on the first node, the second MPI
+  rank on the second node, until the last node, then start at the first node again.
+
+``--map-by numa``
+  Tells the system to map MPI ranks according to NUMA (Non Uniform Memory Access).
+  On Betzy memory configuration groups cores by groups of 16, with cores in the same
+  group having the same access to memory (other cores will have access to that part
+  of the memory too, but slower).
+
+``--bind-to numa``
+  Tells the system to bind cores to one NUMA group. That means that a process will
+  only be allowed to use one of the 16 cores of the group. (The operating system may
+  change the core assigned to a thread/process and, without precautions, it may be
+  assigned to any other core, which would result in much reduced performance). The 16
+  cores of the group may then be used by the threads initiated by that MPI process.
+
+More examples can be found in the `mrchem-examples <https://github.com/MRChemSoft/mrchem-examples>`_
+repository on GitHub.
+
 Parallel pitfalls
 -----------------
 

--- a/external/upstream/fetch_mrcpp.cmake
+++ b/external/upstream/fetch_mrcpp.cmake
@@ -36,9 +36,11 @@ else()
 
   FetchContent_Declare(mrcpp_sources
     QUIET
-    URL
-      https://github.com/MRChemSoft/mrcpp/archive/v1.3.6.tar.gz
-    )
+    GIT_REPOSITORY
+    https://github.com/MRChemSoft/mrcpp.git
+  GIT_TAG
+    3445540b49faaa09acc38d2bb52312c07655f52c
+  )
 
   FetchContent_GetProperties(mrcpp_sources)
 

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -24,6 +24,7 @@
  */
 
 #include <MRCPP/Printer>
+#include <MRCPP/Timer>
 
 #include "parallel.h"
 #include "qmfunctions/ComplexFunction.h"
@@ -55,6 +56,8 @@ int n_threads = mrchem_get_max_threads();
 
 } // namespace omp
 
+using namespace Eigen;
+
 namespace mpi {
 
 bool numerically_exact = false;
@@ -83,6 +86,9 @@ Bank orb_bank;
 } // namespace mpi
 
 int id_shift; // to ensure that nodes, orbitals and functions do not collide
+
+int metadata_block[3]; // can add more metadata in future
+int const size_metadata = 3;
 
 void mpi::initialize() {
     Eigen::setNbThreads(1);
@@ -149,11 +155,11 @@ void mpi::initialize() {
     MPI_Comm_rank(mpi::comm_orb, &mpi::orb_rank);
     MPI_Comm_size(mpi::comm_orb, &mpi::orb_size);
 
-    //determine the maximum value alowed for mpi tags
+    // determine the maximum value alowed for mpi tags
     void *val;
     int flag;
     MPI_Comm_get_attr(MPI_COMM_WORLD, MPI_TAG_UB, &val, &flag); // max value allowed by MPI for tags
-    id_shift = *(int*)val / 2; // half is reserved for non orbital.
+    id_shift = *(int *)val / 2;                                 // half is reserved for non orbital.
 
     if (mpi::is_bank) {
         // bank is open until end of program
@@ -168,8 +174,8 @@ void mpi::initialize() {
 
 void mpi::finalize() {
 #ifdef MRCHEM_HAS_MPI
-    if (mpi::bank_size > 0 and mpi::grand_master()){
-        println(2, " max data in bank " << mpi::orb_bank.get_maxtotalsize() << " MB ");
+    if (mpi::bank_size > 0 and mpi::grand_master()) {
+        println(3, " max data in bank " << mpi::orb_bank.get_maxtotalsize() << " MB ");
         mpi::orb_bank.close();
     }
     MPI_Barrier(MPI_COMM_WORLD); // to ensure everybody got here
@@ -391,6 +397,67 @@ void mpi::reduce_function(double prec, QMFunction &func, MPI_Comm comm) {
 #endif
 }
 
+/** @brief make union tree and send into rank zero */
+void mpi::reduce_Tree_noCoeff(mrcpp::FunctionTree<3> &tree, MPI_Comm comm) {
+/* 1) Each odd rank send to the left rank
+   2) All odd ranks are "deleted" (can exit routine)
+   3) new "effective" ranks are defined within the non-deleted ranks
+      effective rank = rank/fac , where fac are powers of 2
+   4) repeat
+ */
+#ifdef MRCHEM_HAS_MPI
+    int comm_size, comm_rank;
+    MPI_Comm_rank(comm, &comm_rank);
+    MPI_Comm_size(comm, &comm_size);
+    if (comm_size == 1) return;
+
+    int fac = 1; // powers of 2
+    while (fac < comm_size) {
+        if ((comm_rank / fac) % 2 == 0) {
+            // receive
+            int src = comm_rank + fac;
+            if (src < comm_size) {
+                int tag = 3333 + src;
+                mrcpp::FunctionTree<3> tree_i(*MRA);
+                mrcpp::recv_tree(tree_i, src, tag, comm, -1, false);
+                tree.appendTreeNoCoeff(tree_i); // make union grid
+            }
+        }
+        if ((comm_rank / fac) % 2 == 1) {
+            // send
+            int dest = comm_rank - fac;
+            if (dest >= 0) {
+                int tag = 3333 + comm_rank;
+                mrcpp::send_tree(tree, dest, tag, comm, -1, false);
+                break; // once data is sent we are done
+            }
+        }
+        fac *= 2;
+    }
+    MPI_Barrier(comm);
+#endif
+}
+
+/** @brief make union tree without coeff and send to all
+ *  Include both real and imaginary parts
+ */
+void mpi::allreduce_Tree_noCoeff(mrcpp::FunctionTree<3> &tree, OrbitalVector &Phi, MPI_Comm comm) {
+    /* 1) make union grid of own orbitals
+       2) make union grid with others orbitals (sent to rank zero)
+       3) rank zero broadcast func to everybody
+     */
+    int N = Phi.size();
+    for (int j = 0; j < N; j++) {
+        if (not mpi::my_orb(Phi[j])) continue;
+        if (Phi[j].hasReal()) tree.appendTreeNoCoeff(Phi[j].real());
+        if (Phi[j].hasImag()) tree.appendTreeNoCoeff(Phi[j].imag());
+    }
+#ifdef MRCHEM_HAS_MPI
+    mpi::reduce_Tree_noCoeff(tree, mpi::comm_orb);
+    mpi::broadcast_Tree_noCoeff(tree, mpi::comm_orb);
+#endif
+}
+
 /** @brief Distribute rank zero function to all ranks */
 void mpi::broadcast_function(QMFunction &func, MPI_Comm comm) {
 /* use same strategy as a reduce, but in reverse order */
@@ -423,6 +490,38 @@ void mpi::broadcast_function(QMFunction &func, MPI_Comm comm) {
 #endif
 }
 
+/** @brief Distribute rank zero function to all ranks */
+void mpi::broadcast_Tree_noCoeff(mrcpp::FunctionTree<3> &tree, MPI_Comm comm) {
+/* use same strategy as a reduce, but in reverse order */
+#ifdef MRCHEM_HAS_MPI
+    int comm_size, comm_rank;
+    MPI_Comm_rank(comm, &comm_rank);
+    MPI_Comm_size(comm, &comm_size);
+    if (comm_size == 1) return;
+
+    int fac = 1; // powers of 2
+    while (fac < comm_size) fac *= 2;
+    fac /= 2;
+
+    while (fac > 0) {
+        if (comm_rank % fac == 0 and (comm_rank / fac) % 2 == 1) {
+            // receive
+            int src = comm_rank - fac;
+            int tag = 4334 + comm_rank;
+            mrcpp::recv_tree(tree, src, tag, comm, -1, false);
+        }
+        if (comm_rank % fac == 0 and (comm_rank / fac) % 2 == 0) {
+            // send
+            int dst = comm_rank + fac;
+            int tag = 4334 + dst;
+            if (dst < comm_size) mrcpp::send_tree(tree, dst, tag, comm, -1, false);
+        }
+        fac /= 2;
+    }
+    MPI_Barrier(comm);
+#endif
+}
+
 /**************************
  * Bank related functions *
  **************************/
@@ -439,6 +538,17 @@ void Bank::open() {
     int n_chunks, ix;
     int message;
     int datasize = -1;
+    struct Blockdata_struct {
+        std::vector<double *> data; // to store the incoming data
+        std::vector<bool> deleted;  // to indicate if it has been deleted already
+        MatrixXd BlockData;         // to put the final block
+        // eigen matrix are per default stored column-major (one can add columns at the end)
+        std::vector<int> N_rows;
+        std::map<int, int> id2data; // internal index of the data in the block
+        std::vector<int> id;        // the id of each column. Either nodeid, or orbid
+    };
+    std::map<int, Blockdata_struct *> nodeid2block; // to get block from its nodeid (all coeff for one node)
+    std::map<int, Blockdata_struct *> orbid2block;  // to get block from its orbid
 
     deposits.resize(1); // we reserve 0, since it is the value returned for undefined key
     queue.resize(1);    // we reserve 0, since it is the value returned for undefined key
@@ -457,17 +567,195 @@ void Bank::open() {
         }
         if (message == CLEAR_BANK) {
             this->clear_bank();
+            for (auto const &block : nodeid2block) {
+                if (block.second == nullptr) continue;
+                for (int i = 0; i < block.second->data.size(); i++) {
+                    if (not block.second->deleted[i]) {
+                        this->currentsize -= block.second->N_rows[i] / 128; // converted into kB
+                        delete[] block.second->data[i];
+                    }
+                }
+                delete block.second;
+            }
+            nodeid2block.clear();
+            orbid2block.clear();
             // send message that it is ready (value of message is not used)
             MPI_Ssend(&message, 1, MPI_INT, status.MPI_SOURCE, 77, mpi::comm_bank);
+        }
+        if (message == CLEAR_BLOCKS) {
+            // clear only blocks whith id less than status.MPI_TAG.
+            std::vector<int> toeraseVec; // it is dangerous to erase an iterator within its own loop
+            for (auto const &block : nodeid2block) {
+                if (block.second == nullptr) toeraseVec.push_back(block.first);
+                if (block.second == nullptr) continue;
+                if (block.first >= status.MPI_TAG and status.MPI_TAG != 0) continue;
+                for (int i = 0; i < block.second->data.size(); i++) {
+                    if (not block.second->deleted[i]) {
+                        this->currentsize -= block.second->N_rows[i] / 128; // converted into kB
+                        delete[] block.second->data[i];
+                    }
+                }
+                this->currentsize -= block.second->BlockData.size() / 128; // converted into kB
+                block.second->BlockData.resize(0, 0); // NB: the matrix does not clear itself otherwise
+                assert(this->currentsize >= 0);
+                this->currentsize = std::max(0ll, this->currentsize);
+                toeraseVec.push_back(block.first);
+            }
+            for (int ierase : toeraseVec) { nodeid2block.erase(ierase); }
+            toeraseVec.clear();
+            std::vector<int> datatoeraseVec;
+            for (auto const &block : orbid2block) {
+                if (block.second == nullptr) toeraseVec.push_back(block.first);
+                if (block.second == nullptr) continue;
+                datatoeraseVec.clear();
+                for (int i = 0; i < block.second->data.size(); i++) {
+                    if (block.second->id[i] < status.MPI_TAG or status.MPI_TAG == 0) datatoeraseVec.push_back(i);
+                    if (block.second->id[i] < status.MPI_TAG or status.MPI_TAG == 0) block.second->data[i] = nullptr;
+                }
+                std::sort(datatoeraseVec.begin(), datatoeraseVec.end());
+                std::reverse(datatoeraseVec.begin(), datatoeraseVec.end());
+                for (int ierase : datatoeraseVec) {
+                    block.second->id.erase(block.second->id.begin() + ierase);
+                    block.second->data.erase(block.second->data.begin() + ierase);
+                    block.second->N_rows.erase(block.second->N_rows.begin() + ierase);
+                }
+                if (block.second->data.size() == 0) toeraseVec.push_back(block.first);
+            }
+            for (int ierase : toeraseVec) { orbid2block.erase(ierase); }
+
+            if (status.MPI_TAG == 0) orbid2block.clear();
+            // could have own clear for data?
+            for (int ix = 1; ix < deposits.size(); ix++) {
+                if (deposits[ix].id >= id_shift) {
+                    if (deposits[ix].hasdata) delete deposits[ix].data;
+                    if (deposits[ix].hasdata) id2ix[deposits[ix].id] = 0; // indicate that it does not exist
+                    deposits[ix].hasdata = false;
+                }
+            }
+            // send message that it is ready (value of message is not used)
+            MPI_Ssend(&message, 1, MPI_INT, status.MPI_SOURCE, 78, mpi::comm_bank);
         }
         if (message == GETMAXTOTDATA) {
             int maxsize_int = maxsize / 1024; // convert into MB
             MPI_Send(&maxsize_int, 1, MPI_INT, status.MPI_SOURCE, 1171, mpi::comm_bank);
         }
         if (message == GETTOTDATA) {
-            int maxsize_int = currentsize/1024; // convert into MB
-            MPI_Send(&maxsize_int, 1, MPI_INTEGER, status.MPI_SOURCE, 1172, mpi::comm_bank);
-	}
+            int maxsize_int = currentsize / 1024; // convert into MB
+            MPI_Send(&maxsize_int, 1, MPI_INT, status.MPI_SOURCE, 1172, mpi::comm_bank);
+        }
+
+        if (message == GET_NODEDATA or message == GET_NODEBLOCK) {
+            // NB: has no queue system yet
+            int nodeid = status.MPI_TAG; // which block to fetch from
+            if (nodeid2block.count(nodeid) and nodeid2block[nodeid] != nullptr) {
+                Blockdata_struct *block = nodeid2block[nodeid];
+                int dataindex = 0; // internal index of the data in the block
+                int size = 0;
+                if (message == GET_NODEDATA) {
+                    // get id of data within block
+                    MPI_Recv(
+                        metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, nodeid + 1, mpi::comm_bank, &status);
+                    int orbid = metadata_block[1];     // which part of the block to fetch
+                    dataindex = block->id2data[orbid]; // column of the data in the block
+                    size = block->N_rows[dataindex];   // number of doubles to fetch
+                    if (metadata_block[2] == 0) {
+                        metadata_block[2] = size;
+                        MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, nodeid, mpi::comm_bank);
+                    }
+                } else {
+                    // send entire block. First make one contiguous superblock
+                    // Prepare the data as one contiguous block
+                    if (block->data.size() == 0)
+                        std::cout << "Zero size blockdata! " << nodeid << " " << block->N_rows.size() << std::endl;
+                    block->BlockData.resize(block->N_rows[0], block->data.size());
+                    size = block->N_rows[0] * block->data.size();
+                    if (printinfo)
+                        std::cout << " rewrite into superblock " << block->data.size() << " " << block->N_rows[0]
+                                  << " tag " << status.MPI_TAG << std::endl;
+                    for (int j = 0; j < block->data.size(); j++) {
+                        for (int i = 0; i < block->N_rows[j]; i++) { block->BlockData(i, j) = block->data[j][i]; }
+                    }
+                    // repoint to the data in BlockData
+                    for (int j = 0; j < block->data.size(); j++) {
+                        if (block->deleted[j] == true) std::cout << "ERROR data already deleted " << std::endl;
+                        assert(block->deleted[j] == false);
+                        delete[] block->data[j];
+                        block->deleted[j] = true;
+                        block->data[j] = block->BlockData.col(j).data();
+                    }
+                    dataindex = 0; // start from first column
+                    // send info about the size of the superblock
+                    metadata_block[0] = status.MPI_TAG;     // nodeid
+                    metadata_block[1] = block->data.size(); // number of columns
+                    metadata_block[2] = size;               // total size = rows*columns
+                    MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, nodeid, mpi::comm_bank);
+                    // send info about the id of each column
+                    MPI_Send(
+                        block->id.data(), metadata_block[1], MPI_INT, status.MPI_SOURCE, nodeid + 1, mpi::comm_bank);
+                }
+                double *data_p = block->data[dataindex];
+                if (size > 0) MPI_Send(data_p, size, MPI_DOUBLE, status.MPI_SOURCE, nodeid + 2, mpi::comm_bank);
+            } else {
+                // Block with this id does not exist.
+                if (message == GET_NODEDATA) {
+                    MPI_Recv(
+                        metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, nodeid + 1, mpi::comm_bank, &status);
+                    int size = metadata_block[2]; // number of doubles to send
+                    if (size == 0) {
+                        metadata_block[2] = size;
+                        MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, nodeid, mpi::comm_bank);
+                    } else {
+                        std::vector<double> zero(size, 0.0); // send zeroes
+                        MPI_Ssend(zero.data(), size, MPI_DOUBLE, status.MPI_SOURCE, nodeid + 2, mpi::comm_bank);
+                    }
+                } else {
+                    metadata_block[0] = status.MPI_TAG; // nodeid
+                    metadata_block[1] = 0;              // number of columns
+                    metadata_block[2] = 0;              // total size = rows*columns
+                    MPI_Send(
+                        metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, metadata_block[0], mpi::comm_bank);
+                }
+            }
+        }
+        if (message == GET_ORBBLOCK) {
+            // NB: BLOCKDATA has no queue system yet
+            int orbid = status.MPI_TAG; // which block to fetch from
+
+            if (orbid2block.count(orbid) and orbid2block[orbid] != nullptr) {
+                Blockdata_struct *block = orbid2block[orbid];
+                int dataindex = 0; // internal index of the data in the block
+                int size = 0;
+                // send entire block. First make one contiguous superblock
+                // Prepare the data as one contiguous block
+                if (block->data.size() == 0)
+                    std::cout << "Zero size blockdata! C " << orbid << " " << block->N_rows.size() << std::endl;
+                size = 0;
+                for (int j = 0; j < block->data.size(); j++) size += block->N_rows[j];
+
+                std::vector<double> coeff(size);
+                int ij = 0;
+                for (int j = 0; j < block->data.size(); j++) {
+                    for (int i = 0; i < block->N_rows[j]; i++) { coeff[ij++] = block->data[j][i]; }
+                }
+                // send info about the size of the superblock
+                metadata_block[0] = orbid;
+                metadata_block[1] = block->data.size(); // number of columns
+                metadata_block[2] = size;               // total size = rows*columns
+                MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, orbid, mpi::comm_bank);
+                MPI_Send(block->id.data(), metadata_block[1], MPI_INT, status.MPI_SOURCE, orbid + 1, mpi::comm_bank);
+                MPI_Send(coeff.data(), size, MPI_DOUBLE, status.MPI_SOURCE, orbid + 2, mpi::comm_bank);
+            } else {
+                // it is possible and allowed that the block has not been written
+                if (printinfo)
+                    std::cout << " block does not exist " << orbid << " " << orbid2block.count(orbid) << std::endl;
+                // Block with this id does not exist.
+                metadata_block[0] = orbid;
+                metadata_block[1] = 0; // number of columns
+                metadata_block[2] = 0; // total size = rows*columns
+                MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, orbid, mpi::comm_bank);
+            }
+        }
+
         if (message == GET_ORBITAL or message == GET_ORBITAL_AND_WAIT or message == GET_ORBITAL_AND_DELETE or
             message == GET_FUNCTION or message == GET_DATA) {
             // withdrawal
@@ -518,10 +806,57 @@ void Bank::open() {
                 }
             }
         }
+        if (message == SAVE_NODEDATA) {
+            // get the extra metadata
+            MPI_Recv(
+                metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, status.MPI_TAG, mpi::comm_bank, &status);
+            int nodeid = metadata_block[0]; // which block to write (should = status.MPI_TAG)
+            int orbid = metadata_block[1];  // which part of the block
+            int size = metadata_block[2];   // number of doubles
+
+            // test if the block exists already
+            if (printinfo)
+                std::cout << mpi::world_rank << " save data nodeid " << nodeid << " size " << size << std::endl;
+            if (nodeid2block.count(nodeid) == 0 or nodeid2block[nodeid] == nullptr) {
+                if (printinfo) std::cout << mpi::world_rank << " block does not exist yet  " << std::endl;
+                // the block does not exist yet, create it
+                Blockdata_struct *block = new Blockdata_struct;
+                nodeid2block[nodeid] = block;
+            }
+            if (orbid2block.count(orbid) == 0 or orbid2block[orbid] == nullptr) {
+                // the block does not exist yet, create it
+                Blockdata_struct *orbblock = new Blockdata_struct;
+                orbid2block[orbid] = orbblock;
+            }
+            // append the incoming data
+            Blockdata_struct *block = nodeid2block[nodeid];
+            block->id2data[orbid] = nodeid2block[nodeid]->data.size(); // internal index of the data in the block
+            double *data_p = new double[size];
+            this->currentsize += size / 128; // converted into kB
+            this->maxsize = std::max(this->currentsize, this->maxsize);
+            block->data.push_back(data_p);
+            block->deleted.push_back(false);
+            block->id.push_back(orbid);
+            block->N_rows.push_back(size);
+
+            Blockdata_struct *orbblock = orbid2block[orbid];
+            orbblock->id2data[nodeid] = orbblock->data.size(); // internal index of the data in the block
+            orbblock->data.push_back(data_p);
+            orbblock->deleted.push_back(false);
+            orbblock->id.push_back(nodeid);
+            orbblock->N_rows.push_back(size);
+
+            MPI_Recv(data_p, size, MPI_DOUBLE, status.MPI_SOURCE, status.MPI_TAG, mpi::comm_bank, &status);
+            if (printinfo)
+                std::cout << " written block " << nodeid << " id " << orbid << " subblocks "
+                          << nodeid2block[nodeid]->data.size() << std::endl;
+        }
         if (message == SAVE_ORBITAL or message == SAVE_FUNCTION or message == SAVE_DATA) {
             // make a new deposit
             int exist_flag = 0;
             if (id2ix[status.MPI_TAG]) {
+                std::cout << "WARNING: id " << status.MPI_TAG << " exists already"
+                          << " " << status.MPI_SOURCE << " " << message << " " << std::endl;
                 ix = id2ix[status.MPI_TAG]; // the deposit exist from before. Will be overwritten
                 exist_flag = 1;
                 if (message == SAVE_DATA and !deposits[ix].hasdata) {
@@ -692,7 +1027,7 @@ int Bank::set_datasize(int datasize) {
 int Bank::put_data(int id, int size, double *data) {
 #ifdef MRCHEM_HAS_MPI
     // for now we distribute according to id
-    id += 2 * id_shift;
+    id += id_shift;
     MPI_Send(&SAVE_DATA, 1, MPI_INT, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
     MPI_Send(data, size, MPI_DOUBLE, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
 #endif
@@ -703,9 +1038,101 @@ int Bank::put_data(int id, int size, double *data) {
 int Bank::get_data(int id, int size, double *data) {
 #ifdef MRCHEM_HAS_MPI
     MPI_Status status;
-    id += 2 * id_shift;
+    id += id_shift;
     MPI_Send(&GET_DATA, 1, MPI_INT, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
     MPI_Recv(data, size, MPI_DOUBLE, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank, &status);
+#endif
+    return 1;
+}
+
+// save data in Bank with identity id as part of block with identity nodeid.
+int Bank::put_nodedata(int id, int nodeid, int size, double *data) {
+#ifdef MRCHEM_HAS_MPI
+    // for now we distribute according to nodeid
+    metadata_block[0] = nodeid; // which block
+    metadata_block[1] = id;     // id within block
+    metadata_block[2] = size;   // size of this data
+    MPI_Send(&SAVE_NODEDATA, 1, MPI_INT, mpi::bankmaster[nodeid % mpi::bank_size], nodeid, mpi::comm_bank);
+    MPI_Send(metadata_block, size_metadata, MPI_INT, mpi::bankmaster[nodeid % mpi::bank_size], nodeid, mpi::comm_bank);
+    MPI_Send(data, size, MPI_DOUBLE, mpi::bankmaster[nodeid % mpi::bank_size], nodeid, mpi::comm_bank);
+#endif
+    return 1;
+}
+
+// get data with identity id
+int Bank::get_nodedata(int id, int nodeid, int size, double *data, std::vector<int> &idVec) {
+#ifdef MRCHEM_HAS_MPI
+    MPI_Status status;
+    // get the column with identity id
+    metadata_block[0] = nodeid; // which block
+    metadata_block[1] = id;     // id within block.
+    metadata_block[2] = size;   // expected size of data
+    MPI_Send(&GET_NODEDATA, 1, MPI_INT, mpi::bankmaster[nodeid % mpi::bank_size], nodeid, mpi::comm_bank);
+    MPI_Send(
+        metadata_block, size_metadata, MPI_INT, mpi::bankmaster[nodeid % mpi::bank_size], nodeid + 1, mpi::comm_bank);
+
+    MPI_Recv(data, size, MPI_DOUBLE, mpi::bankmaster[nodeid % mpi::bank_size], nodeid + 2, mpi::comm_bank, &status);
+#endif
+    return 1;
+}
+
+// get all data for nodeid
+int Bank::get_nodeblock(int nodeid, double *data, std::vector<int> &idVec) {
+#ifdef MRCHEM_HAS_MPI
+    MPI_Status status;
+    // get the entire superblock and also the id of each column
+    MPI_Send(&GET_NODEBLOCK, 1, MPI_INT, mpi::bankmaster[nodeid % mpi::bank_size], nodeid, mpi::comm_bank);
+    MPI_Recv(metadata_block,
+             size_metadata,
+             MPI_INT,
+             mpi::bankmaster[nodeid % mpi::bank_size],
+             nodeid,
+             mpi::comm_bank,
+             &status);
+    idVec.resize(metadata_block[1]);
+    int size = metadata_block[2];
+    if (size > 0)
+        MPI_Recv(idVec.data(),
+                 metadata_block[1],
+                 MPI_INT,
+                 mpi::bankmaster[nodeid % mpi::bank_size],
+                 nodeid + 1,
+                 mpi::comm_bank,
+                 &status);
+    if (size > 0)
+        MPI_Recv(data, size, MPI_DOUBLE, mpi::bankmaster[nodeid % mpi::bank_size], nodeid + 2, mpi::comm_bank, &status);
+#endif
+    return 1;
+}
+
+// get all data with identity orbid
+int Bank::get_orbblock(int orbid, double *&data, std::vector<int> &nodeidVec, int bankstart) {
+#ifdef MRCHEM_HAS_MPI
+    MPI_Status status;
+    int nodeid = mpi::orb_rank + bankstart;
+    // get the entire superblock and also the nodeid of each column
+    MPI_Send(&GET_ORBBLOCK, 1, MPI_INT, mpi::bankmaster[nodeid % mpi::bank_size], orbid, mpi::comm_bank);
+    MPI_Recv(metadata_block,
+             size_metadata,
+             MPI_INT,
+             mpi::bankmaster[nodeid % mpi::bank_size],
+             orbid,
+             mpi::comm_bank,
+             &status);
+    nodeidVec.resize(metadata_block[1]);
+    int totsize = metadata_block[2];
+    if (totsize > 0)
+        MPI_Recv(nodeidVec.data(),
+                 metadata_block[1],
+                 MPI_INT,
+                 mpi::bankmaster[nodeid % mpi::bank_size],
+                 orbid + 1,
+                 mpi::comm_bank,
+                 &status);
+    data = new double[totsize];
+    if (totsize > 0)
+        MPI_Recv(
+            data, totsize, MPI_DOUBLE, mpi::bankmaster[nodeid % mpi::bank_size], orbid + 2, mpi::comm_bank, &status);
 #endif
     return 1;
 }
@@ -733,14 +1160,14 @@ int Bank::get_maxtotalsize() {
     return maxtot;
 }
 
-std::vector<int>  Bank::get_totalsize() {
+std::vector<int> Bank::get_totalsize() {
     std::vector<int> tot;
 #ifdef HAVE_MPI
     MPI_Status status;
     int datasize;
     for (int i = 0; i < mpi::bank_size; i++) {
-        MPI_Send(&GETTOTDATA, 1, MPI_INTEGER, mpi::bankmaster[i], 0, mpi::comm_bank);
-        MPI_Recv(&datasize, 1, MPI_INTEGER, mpi::bankmaster[i], 1172, mpi::comm_bank, &status);
+        MPI_Send(&GETTOTDATA, 1, MPI_INT, mpi::bankmaster[i], 0, mpi::comm_bank);
+        MPI_Recv(&datasize, 1, MPI_INT, mpi::bankmaster[i], 1172, mpi::comm_bank, &status);
         tot.push_back(datasize);
     }
 #endif
@@ -756,6 +1183,7 @@ void Bank::clear_all(int iclient, MPI_Comm comm) {
     // master send signal to bank
     if (iclient == 0) {
         for (int i = 0; i < mpi::bank_size; i++) {
+            // should be made explicitely non-blocking
             MPI_Send(&CLEAR_BANK, 1, MPI_INT, mpi::bankmaster[i], 0, mpi::comm_bank);
         }
         for (int i = 0; i < mpi::bank_size; i++) {
@@ -763,6 +1191,28 @@ void Bank::clear_all(int iclient, MPI_Comm comm) {
             MPI_Status status;
             int message;
             MPI_Recv(&message, 1, MPI_INT, mpi::bankmaster[i], 77, mpi::comm_bank, &status);
+        }
+    }
+    mpi::barrier(comm);
+#endif
+}
+
+// remove all blockdata with nodeid < nodeidmax
+// NB:: collective call. All clients must call this
+void Bank::clear_blockdata(int iclient, int nodeidmax, MPI_Comm comm) {
+#ifdef MRCHEM_HAS_MPI
+    // 1) wait until all clients are ready
+    mpi::barrier(comm);
+    // master send signal to bank
+    if (iclient == 0) {
+        for (int i = 0; i < mpi::bank_size; i++) {
+            MPI_Send(&CLEAR_BLOCKS, 1, MPI_INT, mpi::bankmaster[i], nodeidmax, mpi::comm_bank);
+        }
+        for (int i = 0; i < mpi::bank_size; i++) {
+            // wait until Bank is finished and has sent signal
+            MPI_Status status;
+            int message;
+            MPI_Recv(&message, 1, MPI_INT, mpi::bankmaster[i], 78, mpi::comm_bank, &status);
         }
     }
     mpi::barrier(comm);
@@ -782,8 +1232,8 @@ void Bank::clear_bank() {
 
 void Bank::clear(int ix) {
 #ifdef MRCHEM_HAS_MPI
-    deposits[ix].orb->free(NUMBER::Total);
-    delete deposits[ix].data;
+    if (deposits[ix].orb != nullptr) deposits[ix].orb->free(NUMBER::Total);
+    if (deposits[ix].hasdata) delete deposits[ix].data;
     deposits[ix].hasdata = false;
 #endif
 }

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -112,9 +112,10 @@ void mpi::initialize() {
     if (mpi::world_size < 2) {
         mpi::bank_size = 0;
     } else if (mpi::bank_size < 0) {
-        mpi::bank_size = mpi::world_size / 6 + 1;
+        mpi::bank_size = std::max(mpi::world_size / 4, 1);
     }
     if (mpi::world_size - mpi::bank_size < 1) MSG_ABORT("No MPI ranks left for working!");
+    if (mpi::bank_size < 1 and mpi::world_size > 1) MSG_ABORT("Bank size must be at least one when using MPI!");
 
     mpi::bankmaster.resize(mpi::bank_size);
     for (int i = 0; i < mpi::bank_size; i++) {

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -90,6 +90,10 @@ void share_function(QMFunction &func, int src, int tag, MPI_Comm comm);
 void reduce_function(double prec, QMFunction &func, MPI_Comm comm);
 void broadcast_function(QMFunction &func, MPI_Comm comm);
 
+void reduce_Tree_noCoeff(mrcpp::FunctionTree<3> &tree, MPI_Comm comm);
+void allreduce_Tree_noCoeff(mrcpp::FunctionTree<3> &tree, OrbitalVector &Phi, MPI_Comm comm);
+void broadcast_Tree_noCoeff(mrcpp::FunctionTree<3> &tree, MPI_Comm comm);
+
 void allreduce_vector(IntVector &vec, MPI_Comm comm);
 void allreduce_vector(DoubleVector &vec, MPI_Comm comm);
 void allreduce_vector(ComplexVector &vec, MPI_Comm comm);
@@ -106,8 +110,8 @@ struct deposit {
     double *data; // for pure data arrays
     bool hasdata;
     int datasize;
-    int id;     // to identify what is deposited
-    int source; // mpi rank from the source of the data
+    int id = -1; // to identify what is deposited
+    int source;  // mpi rank from the source of the data
 };
 
 struct queue_struct {
@@ -133,6 +137,11 @@ public:
     int set_datasize(int datasize);
     int put_data(int id, int size, double *data);
     int get_data(int id, int size, double *data);
+    int put_nodedata(int id, int nodeid, int size, double *data);
+    int get_nodedata(int id, int nodeid, int size, double *data, std::vector<int> &idVec);
+    int get_nodeblock(int nodeid, double *data, std::vector<int> &idVec);
+    int get_orbblock(int orbid, double *&data, std::vector<int> &nodeidVec, int bankstart);
+    void clear_blockdata(int i = mpi::orb_rank, int nodeidmax = 0, MPI_Comm comm = mpi::comm_orb);
     int get_maxtotalsize();
     std::vector<int> get_totalsize();
 
@@ -148,8 +157,13 @@ private:
     int const SET_DATASIZE = 9;
     int const GET_DATA = 10;
     int const SAVE_DATA = 11;
-    int const GETMAXTOTDATA = 12;
-    int const GETTOTDATA = 13;
+    int const SAVE_NODEDATA = 12;
+    int const GET_NODEDATA = 13;
+    int const GET_NODEBLOCK = 14;
+    int const GET_ORBBLOCK = 15;
+    int const CLEAR_BLOCKS = 16;
+    int const GETMAXTOTDATA = 17;
+    int const GETTOTDATA = 18;
     std::map<int, int> id2ix;
     std::vector<bank::deposit> deposits;
     std::map<int, int> id2qu;

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -134,6 +134,7 @@ public:
     int put_data(int id, int size, double *data);
     int get_data(int id, int size, double *data);
     int get_maxtotalsize();
+    std::vector<int> get_totalsize();
 
 private:
     int const CLOSE_BANK = 1;
@@ -148,6 +149,7 @@ private:
     int const GET_DATA = 10;
     int const SAVE_DATA = 11;
     int const GETMAXTOTDATA = 12;
+    int const GETTOTDATA = 13;
     std::map<int, int> id2ix;
     std::vector<bank::deposit> deposits;
     std::map<int, int> id2qu;

--- a/src/qmfunctions/orbital_utils.cpp
+++ b/src/qmfunctions/orbital_utils.cpp
@@ -569,6 +569,7 @@ OrbitalVector orbital::rotate(OrbitalVector &Phi, const ComplexMatrix &U, double
                 out[j % N].alloc(NUMBER::Imag);
                 out[j % N].imag().makeTreefromCoeff(refTree, coeffpVec[j], ix2coef[j], priv_prec);
             }
+            if (j >= Neff - N) out[j % N].crop(prec);
         }
 
     } else { // MPI case
@@ -605,6 +606,7 @@ OrbitalVector orbital::rotate(OrbitalVector &Phi, const ComplexMatrix &U, double
                 out[j % N].alloc(NUMBER::Imag);
                 out[j % N].imag().makeTreefromCoeff(refTree, coeffpVec, ix2coef, priv_prec);
             }
+            if (j >= Neff - N) out[j % N].crop(prec);
             for (double *p : pointerstodelete) delete[] p;
             pointerstodelete.clear();
         }

--- a/src/qmfunctions/orbital_utils.cpp
+++ b/src/qmfunctions/orbital_utils.cpp
@@ -1094,6 +1094,8 @@ ComplexMatrix orbital::calc_overlap_matrix(OrbitalVector &Bra, OrbitalVector &Ke
                     node2orbVecBra[ix].push_back(j + N);
                 }
             }
+        }
+        for (int j = 0; j < M; j++) {
             if (Ket[j].hasReal()) {
                 Ket[j].real().makeCoeffVector(coeffVecKet[j], indexVec, parindexVec, scalefac, max_ix, refTree);
                 // make a map that gives j from indexVec

--- a/src/qmfunctions/orbital_utils.cpp
+++ b/src/qmfunctions/orbital_utils.cpp
@@ -25,6 +25,7 @@
 
 #include <MRCPP/Printer>
 #include <MRCPP/Timer>
+#include <MRCPP/trees/FunctionNode.h>
 #include <MRCPP/utils/details.h>
 
 #include "parallel.h"
@@ -37,12 +38,14 @@
 #include "orbital_utils.h"
 #include "qmfunction_utils.h"
 
+using mrcpp::FunctionNode;
 using mrcpp::FunctionTree;
 using mrcpp::FunctionTreeVector;
 using mrcpp::Printer;
 using mrcpp::Timer;
 
 namespace mrchem {
+extern mrcpp::MultiResolutionAnalysis<3> *MRA; // Global MRA
 
 namespace orbital {
 ComplexMatrix localize(double prec, OrbitalVector &Phi, int spin);
@@ -224,35 +227,435 @@ OrbitalVector orbital::add(ComplexDouble a, OrbitalVector &Phi_a, ComplexDouble 
  *
  */
 OrbitalVector orbital::rotate(OrbitalVector &Phi, const ComplexMatrix &U, double prec) {
-    // Get all out orbitals belonging to this MPI
-    auto inter_prec = (mpi::numerically_exact) ? -1.0 : prec;
+
+    // The principle of this routine is that nodes are rotated one by one using matrix multiplication.
+    // The routine does avoid when possible to move data, but uses pointers and indices manipulation.
+    // MPI version does not use OMP yet, Serial version uses OMP
+
+    auto priv_prec = (mpi::numerically_exact) ? -1.0 : prec;
     auto out = orbital::param_copy(Phi);
-    OrbitalIterator iter(Phi);
-    while (iter.next()) {
-        for (auto j = 0; j < out.size(); j++) {
-            if (not mpi::my_orb(out[j])) continue;
-            ComplexVector coef_vec(iter.get_size());
-            QMFunctionVector func_vec;
-            for (auto i = 0; i < iter.get_size(); i++) {
-                auto idx_i = iter.idx(i);
-                auto &recv_i = iter.orbital(i);
-                coef_vec[i] = U(idx_i, j);
-                func_vec.push_back(recv_i);
+    int N = Phi.size();
+
+    mrchem::mpi::orb_bank.clear_blockdata();
+
+    // 1) make union tree without coefficients
+    mrcpp::FunctionTree<3> refTree(*MRA);
+    mpi::allreduce_Tree_noCoeff(refTree, Phi, mpi::comm_orb);
+
+    int sizecoeff = (1 << refTree.getDim()) * refTree.getKp1_d();
+    int sizecoeffW = ((1 << refTree.getDim()) - 1) * refTree.getKp1_d();
+    std::vector<double> scalefac_ref;
+    std::vector<double *> coeffVec_ref; // not used!
+    std::vector<int> indexVec_ref;      // serialIx of the nodes
+    std::vector<int> parindexVec_ref;   // serialIx of the parent nodes
+    int max_ix;
+    // get a list of all nodes in union tree, identified by their serialIx indices
+    refTree.makeCoeffVector(coeffVec_ref, indexVec_ref, parindexVec_ref, scalefac_ref, max_ix, refTree);
+    int max_n = indexVec_ref.size();
+
+    // 2) We work with real numbers only. Make real blocks for U matrix
+    bool UhasReal = false;
+    bool UhasImag = false;
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < N; j++) {
+            if (std::abs(U(i, j).real()) > mrcpp::MachineZero) UhasReal = true;
+            if (std::abs(U(i, j).imag()) > mrcpp::MachineZero) UhasImag = true;
+        }
+    }
+
+    IntVector PsihasReIm(2);
+    for (int i = 0; i < N; i++) {
+        if (!mpi::my_orb(Phi[i])) continue;
+        PsihasReIm[0] = (Phi[i].hasReal()) ? 1 : 0;
+        PsihasReIm[1] = (Phi[i].hasImag()) ? 1 : 0;
+    }
+    mpi::allreduce_vector(PsihasReIm, mpi::comm_orb);
+    if (not PsihasReIm[0] and not PsihasReIm[1]) {
+        println(2, " Rotate, warning: vector has no real and no imaginary parts!");
+        OrbitalVector out = orbital::param_copy(Phi);
+        return out;
+    }
+
+    bool makeReal = (UhasReal and PsihasReIm[0]) or (UhasImag and PsihasReIm[1]);
+    bool makeImag = (UhasReal and PsihasReIm[1]) or (UhasImag and PsihasReIm[0]);
+
+    if (not makeReal and not makeImag) {
+        println(1, " Rotate, warning: vector has no real and no imaginary parts!");
+        OrbitalVector out = orbital::param_copy(Phi);
+        return out;
+    }
+
+    int Neff = N;               // effective number of orbitals
+    if (makeImag) Neff = 2 * N; // Imag and Real treated independently. We always use real part of U
+
+    IntVector conjMat = IntVector::Zero(Neff);
+    for (int i = 0; i < Neff; i++) {
+        if (!mpi::my_orb(Phi[i % N])) continue;
+        conjMat[i] = (Phi[i % N].conjugate()) ? -1 : 1;
+    }
+    mpi::allreduce_vector(conjMat, mpi::comm_orb);
+
+    // we make a real matrix = U,  but organized as one or four real blocks
+    // out_r = U_rr*in_r - U_ir*in_i*conjMat
+    // out_i = U_ri*in_r - U_ii*in_i*conjMat
+    // the first index of U is the one used on input Phi
+    DoubleMatrix Ureal(Neff, Neff); // four blocks, for rr ri ir ii
+    for (int i = 0; i < Neff; i++) {
+        for (int j = 0; j < Neff; j++) {
+            double sign = 1.0;
+            if (i < N and j < N) {
+                // real U applied on real Phi
+                Ureal(i, j) = U.real()(i % N, j % N);
+            } else if (i >= N and j >= N) {
+                // real U applied on imag Phi
+                Ureal(i, j) = conjMat[i] * U.real()(i % N, j % N);
+            } else if (i < N and j >= N) {
+                // imag U applied on real Phi
+                Ureal(i, j) = U.imag()(i % N, j % N);
+            } else {
+                // imag U applied on imag Phi
+                Ureal(i, j) = -1.0 * conjMat[i] * U.imag()(i % N, j % N);
             }
-            auto tmp_j = out[j].paramCopy();
-            qmfunction::linear_combination(tmp_j, coef_vec, func_vec, inter_prec);
-            out[j].add(1.0, tmp_j); // In place addition
-            out[j].crop(inter_prec);
         }
     }
 
-    if (mpi::numerically_exact) {
-        for (auto &phi : out) {
-            if (mpi::my_orb(phi)) phi.crop(prec);
+    // 3) In the serial case we store the coeff pointers in coeffVec. In the mpi case the coeff are stored in the bank
+
+    bool serial = mpi::orb_size == 1; // flag for serial/MPI switch
+
+    // used for serial only:
+    std::vector<std::vector<double *>> coeffVec(Neff);
+    std::vector<std::vector<int>> indexVec(Neff); // serialIx of the nodes
+    std::map<int, std::vector<int>>
+        node2orbVec; // for each node index, gives a vector with the indices of the orbitals using this node
+    std::vector<std::map<int, int>> orb2node(Neff); // for a given orbital and a given node, gives the node index in the
+                                                    // orbital given the node index in the reference tree
+
+    if (serial) {
+
+        // make list of all coefficients (coeffVec), and their reference indices (indexVec)
+        std::vector<int> parindexVec; // serialIx of the parent nodes
+        std::vector<double> scalefac;
+        for (int j = 0; j < N; j++) {
+            // make vector with all coef pointers and their indices in the union grid
+            if (Phi[j].hasReal()) {
+                Phi[j].real().makeCoeffVector(coeffVec[j], indexVec[j], parindexVec, scalefac, max_ix, refTree);
+                // make a map that gives j from indexVec
+                int orb_node_ix = 0;
+                for (int ix : indexVec[j]) {
+                    orb2node[j][ix] = orb_node_ix++;
+                    if (ix < 0) continue;
+                    node2orbVec[ix].push_back(j);
+                }
+            }
+            if (Phi[j].hasImag()) {
+                Phi[j].imag().makeCoeffVector(coeffVec[j + N], indexVec[j + N], parindexVec, scalefac, max_ix, refTree);
+                // make a map that gives j from indexVec
+                int orb_node_ix = 0;
+                for (int ix : indexVec[j + N]) {
+                    orb2node[j + N][ix] = orb_node_ix++;
+                    if (ix < 0) continue;
+                    node2orbVec[ix].push_back(j + N);
+                }
+            }
         }
+
+    } else { // MPI case
+
+        // send own nodes to bank, identifying them through the serialIx of refTree
+        save_nodes(Phi, refTree);
+        mrchem::mpi::barrier(
+            mrchem::mpi::comm_orb); // required for now, as the blockdata functionality has no queue yet.
     }
 
+    // 4) rotate all the nodes
+    IntMatrix split_serial; // in the serial case all split are store in one array
+    std::vector<double> split(
+        Neff, -1.0); // which orbitals need splitting (at a given node). For now double for compatibilty with bank
+    std::vector<double> needsplit(Neff, 1.0);           // which orbitals need splitting
+    std::vector<std::vector<double *>> coeffpVec(Neff); // to put pointers to the rotated coefficient for each orbital
+    std::vector<std::map<int, int>> ix2coef(
+        Neff); // to find the index in for example rotCoeffVec[] corresponding to a serialIx
+    int csize; // size of the current coefficients (different for roots and branches)
+    std::vector<DoubleMatrix>
+        rotatedCoeffVec; // just to ensure that the data from rotatedCoeff is not deleted, since we point to it.
+    // j indices are for unrotated orbitals, i indices are for rotated orbitals
+    if (serial) {
+        std::map<int, int> ix2coef_ref;   // to find the index n corresponding to a serialIx
+        split_serial.resize(Neff, max_n); // not use in the MPI case
+        for (int n = 0; n < max_n; n++) {
+            int node_ix = indexVec_ref[n]; // SerialIx for this node in the reference tree
+            ix2coef_ref[node_ix] = n;
+            for (int i = 0; i < Neff; i++) split_serial(i, n) = 1;
+        }
+
+        std::vector<int> nodeReady(max_n, 0); // To indicate to OMP threads that the parent is ready (for splits)
+
+        // assumes the nodes are ordered such that parent are treated before children. BFS or DFS ok.
+        // NB: the n must be traversed approximately in right order: Thread n may have to wait until som other preceding
+        // n is finished.
+#pragma omp parallel for schedule(dynamic)
+        for (int n = 0; n < max_n; n++) {
+            int csize;
+            int node_ix = indexVec_ref[n]; // SerialIx for this node in the reference tree
+            // 4a) make a dense contiguous matrix with the coefficient from all the orbitals using node n
+            std::vector<int> orbjVec; // to remember which orbital correspond to each orbVec.size();
+            if (node2orbVec[node_ix].size() <= 0) continue;
+            csize = sizecoeffW;
+            if (parindexVec_ref[n] < 0) csize = sizecoeff; // for root nodes we include scaling coeff
+
+            int shift = sizecoeff - sizecoeffW; // to copy only wavelet part
+            if (parindexVec_ref[n] < 0) shift = 0;
+            DoubleMatrix coeffBlock(csize, node2orbVec[node_ix].size());
+            for (int j : node2orbVec[node_ix]) { // loop over indices of the orbitals using this node
+                int orb_node_ix = orb2node[j][node_ix];
+                for (int k = 0; k < csize; k++) coeffBlock(k, orbjVec.size()) = coeffVec[j][orb_node_ix][k + shift];
+                orbjVec.push_back(j);
+            }
+
+            // 4b) make a list of rotated orbitals needed for this node
+            // OMP must wait until parent is ready
+            while (parindexVec_ref[n] >= 0 and nodeReady[ix2coef_ref[parindexVec_ref[n]]] == 0) {
+#pragma omp flush
+            };
+
+            std::vector<int> orbiVec;
+            for (int i = 0; i < Neff; i++) { // loop over all rotated orbitals
+                if (not makeReal and i < N) continue;
+                if (not makeImag and i >= N) continue;
+                if (parindexVec_ref[n] >= 0 and split_serial(i, ix2coef_ref[parindexVec_ref[n]]) == 0)
+                    continue; // parent node has too small wavelets
+                orbiVec.push_back(i);
+            }
+
+            // 4c) rotate this node
+            DoubleMatrix Un(orbjVec.size(), orbiVec.size()); // chunk of U, with reorganized indices
+            for (int i = 0; i < orbiVec.size(); i++) {       // loop over rotated orbitals
+                for (int j = 0; j < orbjVec.size(); j++) { Un(j, i) = Ureal(orbjVec[j], orbiVec[i]); }
+            }
+            DoubleMatrix rotatedCoeff(csize, orbiVec.size());
+            // HERE IT HAPPENS!
+            rotatedCoeff.noalias() = coeffBlock * Un; // Matrix mutiplication
+
+            // 4d) store and make rotated node pointers
+            // for now we allocate in buffer, in future could be directly allocated in the final trees
+            double thres = priv_prec * priv_prec * scalefac_ref[n] * scalefac_ref[n];
+            // make all norms:
+            for (int i = 0; i < orbiVec.size(); i++) {
+                // check if parent must be split
+                if (parindexVec_ref[n] == -1 or split_serial(orbiVec[i], ix2coef_ref[parindexVec_ref[n]])) {
+                    // mark this node for this orbital for later split
+#pragma omp critical
+                    {
+                        ix2coef[orbiVec[i]][node_ix] = coeffpVec[orbiVec[i]].size();
+                        coeffpVec[orbiVec[i]].push_back(&(rotatedCoeff(0, i))); // list of coefficient pointers
+                    }
+                    // check norms for split
+                    double wnorm = 0.0; // rotatedCoeff(k, i) is already in cache here
+                    int kstart = 0;
+                    if (parindexVec_ref[n] < 0)
+                        kstart = sizecoeff - sizecoeffW; // do not include scaling, even for roots
+                    for (int k = kstart; k < csize; k++) wnorm += rotatedCoeff(k, i) * rotatedCoeff(k, i);
+                    if (thres < wnorm or priv_prec < 0.0)
+                        split_serial(orbiVec[i], n) = 1;
+                    else
+                        split_serial(orbiVec[i], n) = 0;
+                } else {
+                    ix2coef[orbiVec[i]][node_ix] = max_n + 1; // should not be used
+                    split_serial(orbiVec[i], n) = 0;          // do not split if parent does not need to be split
+                }
+            }
+            nodeReady[n] = 1;
+#pragma omp critical
+            {
+                rotatedCoeffVec.push_back(std::move(
+                    rotatedCoeff)); // this ensures that rotatedCoeff is not deleted, when getting out of scope
+            }
+        }
+
+    } else { // MPI case
+
+        // TODO? rotate in bank, so that we do not get and put. Requires clever handling of splits.
+        std::vector<double> split(
+            Neff, -1.0); // which orbitals need splitting (at a given node). For now double for compatibilty with bank
+        std::vector<double> needsplit(Neff, 1.0); // which orbitals need splitting
+        if (mpi::orb_rank == 0) mrchem::mpi::orb_bank.set_datasize(Neff);
+        mrchem::mpi::barrier(
+            mrchem::mpi::comm_orb); // required for now, as the blockdata functionality has no queue yet.
+
+        DoubleMatrix coeffBlock(sizecoeff, Neff);
+        max_ix++; // largest node index + 1. to store rotated orbitals with different id
+        for (int n = 0; n < max_n; n++) {
+            if (n % mpi::orb_size != mpi::orb_rank) continue; // could use any partitioning
+            double thres = priv_prec * priv_prec * scalefac_ref[n] * scalefac_ref[n];
+
+            // 4a) make list of orbitals that should split the parent node, i.e. include this node
+            int parentid = parindexVec_ref[n];
+            if (parentid == -1) {
+                // root node, split if output needed
+                for (int i = 0; i < N; i++) {
+                    if (makeReal)
+                        split[i] = 1.0;
+                    else
+                        split[i] = -1.0;
+                }
+                for (int i = N; i < Neff; i++) {
+                    if (makeImag)
+                        split[i] = 1.0;
+                    else
+                        split[i] = -1.0;
+                }
+                csize = sizecoeff;
+            } else {
+                // note that it will wait until data is available
+                mrchem::mpi::orb_bank.get_data(parentid, Neff, split.data());
+                csize = sizecoeffW;
+            }
+            std::vector<int> orbiVec;
+            std::vector<int> orbjVec;
+            for (int i = 0; i < Neff; i++) {  // loop over rotated orbitals
+                if (split[i] < 0.0) continue; // parent node has too small wavelets
+                orbiVec.push_back(i);
+            }
+
+            // 4b) rotate this node
+            DoubleMatrix coeffBlock(csize, Neff); // largest possible used size
+            mrchem::mpi::orb_bank.get_nodeblock(indexVec_ref[n], coeffBlock.data(), orbjVec);
+            coeffBlock.conservativeResize(Eigen::NoChange, orbjVec.size()); // keep only used part
+
+            // chunk of U, with reorganized indices and separate blocks for real and imag:
+            DoubleMatrix Un(orbjVec.size(), orbiVec.size());
+            DoubleMatrix rotatedCoeff(csize, orbiVec.size());
+
+            for (int i = 0; i < orbiVec.size(); i++) {     // loop over included rotated real and imag part of orbitals
+                for (int j = 0; j < orbjVec.size(); j++) { // loop over input orbital, possibly imaginary parts
+                    Un(j, i) = Ureal(orbjVec[j], orbiVec[i]);
+                }
+            }
+
+            // HERE IT HAPPENS
+            rotatedCoeff.noalias() = coeffBlock * Un; // Matrix mutiplication
+
+            // 3c) find which orbitals need to further refine this node, and store rotated node (after each other while
+            // in cache).
+            for (int i = 0; i < orbiVec.size(); i++) { // loop over rotated orbitals
+                needsplit[orbiVec[i]] = -1.0;          // default, do not split
+                // check if this node/orbital needs further refinement
+                double wnorm = 0.0;
+                int kwstart = csize - sizecoeffW; // do not include scaling
+                for (int k = kwstart; k < csize; k++) wnorm += rotatedCoeff.col(i)[k] * rotatedCoeff.col(i)[k];
+                if (thres < wnorm or priv_prec < 0.0) needsplit[orbiVec[i]] = 1.0;
+                mrchem::mpi::orb_bank.put_nodedata(
+                    orbiVec[i], indexVec_ref[n] + max_ix, csize, rotatedCoeff.col(i).data());
+            }
+            mrchem::mpi::orb_bank.put_data(indexVec_ref[n], Neff, needsplit.data());
+        }
+        mrchem::mpi::orb_bank.clear_blockdata(mpi::orb_rank, max_ix, mpi::comm_orb);
+    }
+
+    // 5) reconstruct trees using rotated nodes.
+
+    // only serial case can use OMP, because MPI cannot be used by threads
+    if (serial) {
+        // OMP parallelized, but does not scale well, because the total memory bandwidth is a bottleneck. (the main
+        // operation is writing the coefficient into the tree)
+
+#pragma omp parallel for schedule(static)
+        for (int j = 0; j < Neff; j++) {
+            if (j < N) {
+                out[j].alloc(NUMBER::Real);
+                out[j].real().makeTreefromCoeff(refTree, coeffpVec[j], ix2coef[j], priv_prec);
+            } else {
+                out[j % N].alloc(NUMBER::Imag);
+                out[j % N].imag().makeTreefromCoeff(refTree, coeffpVec[j], ix2coef[j], priv_prec);
+            }
+        }
+
+    } else { // MPI case
+
+        for (int j = 0; j < Neff; j++) {
+            if (not mpi::my_orb(out[j % N])) continue;
+            // traverse possible nodes, and stop descending when norm is zero (leaf in out[j])
+            std::vector<double *> coeffpVec; //
+            std::map<int, int> ix2coef;      // to find the index in coeffVec[] corresponding to a serialIx
+            int ix = 0;
+            std::vector<double *> pointerstodelete; // list of temporary arrays to clean up
+            for (int ibank = 0; ibank < mpi::bank_size; ibank++) {
+                std::vector<int> nodeidVec;
+                double *dataVec; // will be allocated by bank
+                mrchem::mpi::orb_bank.get_orbblock(j, dataVec, nodeidVec, ibank);
+                if (nodeidVec.size() > 0) pointerstodelete.push_back(dataVec);
+                int shift = 0;
+                for (int n = 0; n < nodeidVec.size(); n++) {
+                    assert(nodeidVec[n] - max_ix >= 0);                // unrotated nodes have been deleted
+                    assert(ix2coef.count(nodeidVec[n] - max_ix) == 0); // each nodeid treated once
+                    ix2coef[nodeidVec[n] - max_ix] = ix++;
+                    csize = sizecoeffW;
+                    if (parindexVec_ref[nodeidVec[n] - max_ix] < 0) csize = sizecoeff;
+                    coeffpVec.push_back(&dataVec[shift]); // list of coeff pointers
+                    shift += csize;
+                }
+            }
+            if (j < N) {
+                // Real part
+                out[j].alloc(NUMBER::Real);
+                out[j].real().makeTreefromCoeff(refTree, coeffpVec, ix2coef, priv_prec);
+            } else {
+                // Imag part
+                out[j % N].alloc(NUMBER::Imag);
+                out[j % N].imag().makeTreefromCoeff(refTree, coeffpVec, ix2coef, priv_prec);
+            }
+            for (double *p : pointerstodelete) delete[] p;
+            pointerstodelete.clear();
+        }
+        mrchem::mpi::orb_bank.clear_blockdata();
+    }
     return out;
+}
+
+/** @brief Save all nodes in bank; identify them using serialIx from refTree
+ * shift is a shift applied in the id
+ */
+void orbital::save_nodes(OrbitalVector Phi, mrcpp::FunctionTree<3> &refTree, int shift) {
+    int sizecoeff = (1 << refTree.getDim()) * refTree.getKp1_d();
+    int sizecoeffW = ((1 << refTree.getDim()) - 1) * refTree.getKp1_d();
+    int max_nNodes = refTree.getNNodes();
+    std::vector<double *> coeffVec;
+    std::vector<double> scalefac;
+    std::vector<int> indexVec;    // SerialIx of the node in refOrb
+    std::vector<int> parindexVec; // SerialIx of the parent node
+    int N = Phi.size();
+    int max_ix;
+    for (int j = 0; j < N; j++) {
+        if (not mpi::my_orb(Phi[j])) continue;
+        // make vector with all coef address and their index in the union grid
+        if (Phi[j].hasReal()) {
+            Phi[j].real().makeCoeffVector(coeffVec, indexVec, parindexVec, scalefac, max_ix, refTree);
+            int max_n = indexVec.size();
+            // send node coefs from Phi[j] to bank
+            // except for the root nodes, only wavelets are sent
+            for (int i = 0; i < max_n; i++) {
+                if (indexVec[i] < 0) continue; // nodes that are not in refOrb
+                int csize = sizecoeffW;
+                if (parindexVec[i] < 0) csize = sizecoeff;
+                mrchem::mpi::orb_bank.put_nodedata(j, indexVec[i] + shift, csize, &(coeffVec[i][sizecoeff - csize]));
+            }
+        }
+        // Imaginary parts are considered as orbitals with an orbid shifted by N
+        if (Phi[j].hasImag()) {
+            Phi[j].imag().makeCoeffVector(coeffVec, indexVec, parindexVec, scalefac, max_ix, refTree);
+            int max_n = indexVec.size();
+            // send node coefs from Phi[j] to bank
+            for (int i = 0; i < max_n; i++) {
+                if (indexVec[i] < 0) continue; // nodes that are not in refOrb
+                // NB: the identifier (indexVec[i]) must be shifted for not colliding with the nodes from the real part
+                int csize = sizecoeffW;
+                if (parindexVec[i] < 0) csize = sizecoeff;
+                mrchem::mpi::orb_bank.put_nodedata(
+                    j + N, indexVec[i] + shift, csize, &(coeffVec[i][sizecoeff - csize]));
+            }
+        }
+    }
 }
 
 /** @brief Deep copy
@@ -455,73 +858,352 @@ void orbital::orthogonalize(double prec, OrbitalVector &Phi, OrbitalVector &Psi)
     }
 }
 
-/** @brief Compute the overlap matrix S_ij = <bra_i|ket_j>
+/** @brief Orbital transformation out_j = sum_i inp_i*U_ij
+ *
+ * NOTE: OrbitalVector is considered a ROW vector, so rotation
+ *       means matrix multiplication from the right
+ *
+ * MPI: Rank distribution of output vector is the same as input vector
+ *
  */
 ComplexMatrix orbital::calc_overlap_matrix(OrbitalVector &BraKet) {
-    ComplexMatrix S = ComplexMatrix::Zero(BraKet.size(), BraKet.size());
 
-    // Get all ket orbitals belonging to this MPI
-    OrbitalChunk myKet = mpi::get_my_chunk(BraKet);
+    mrchem::mpi::barrier(mrchem::mpi::comm_orb); // for the timings
+    int N = BraKet.size();
+    ComplexMatrix S = ComplexMatrix::Zero(N, N);
+    DoubleMatrix Sreal = DoubleMatrix::Zero(2 * N, 2 * N); // same as S, but stored as 4 blocks, rr,ri,ir,ii
 
-    // Receive ALL orbitals on the bra side, use only MY orbitals on the ket side
-    // Computes the FULL columns associated with MY orbitals on the ket side
-    OrbitalIterator iter(BraKet, true); // use symmetry
-    Timer timer;
-    while (iter.next()) {
-        for (int i = 0; i < iter.get_size(); i++) {
-            int idx_i = iter.idx(i);
-            Orbital &bra_i = iter.orbital(i);
-            for (auto &j : myKet) {
-                int idx_j = std::get<0>(j);
-                Orbital &ket_j = std::get<1>(j);
-                if (mpi::my_orb(bra_i) and idx_j > idx_i) continue;
-                if (mpi::my_unique_orb(ket_j) or mpi::orb_rank == 0) {
-                    S(idx_i, idx_j) = orbital::dot(bra_i, ket_j);
-                    S(idx_j, idx_i) = std::conj(S(idx_i, idx_j));
+    // 1) make union tree without coefficients
+    mrcpp::FunctionTree<3> refTree(*MRA);
+    mpi::allreduce_Tree_noCoeff(refTree, BraKet, mpi::comm_orb);
+
+    int sizecoeff = (1 << refTree.getDim()) * refTree.getKp1_d();
+    int sizecoeffW = ((1 << refTree.getDim()) - 1) * refTree.getKp1_d();
+
+    // get a list of all nodes in union grid, as defined by their indices
+    std::vector<double> scalefac;
+    std::vector<double *> coeffVec_ref;
+    std::vector<int> indexVec_ref;    // serialIx of the nodes
+    std::vector<int> parindexVec_ref; // serialIx of the parent nodes
+    int max_ix;                       // largest index value (not used here)
+
+    refTree.makeCoeffVector(coeffVec_ref, indexVec_ref, parindexVec_ref, scalefac, max_ix, refTree);
+    int max_n = indexVec_ref.size();
+
+    // only used for serial case:
+    std::vector<std::vector<double *>> coeffVec(2 * N);
+    std::map<int, std::vector<int>>
+        node2orbVec; // for each node index, gives a vector with the indices of the orbitals using this node
+    std::vector<std::map<int, int>> orb2node(2 * N); // for a given orbital and a given node, gives the node index in
+                                                     // the orbital given the node index in the reference tree
+
+    bool serial = mpi::orb_size == 1; // flag for serial/MPI switch
+
+    // In the serial case we store the coeff pointers in coeffVec. In the mpi case the coeff are stored in the bank
+    if (serial) {
+        // 2) make list of all coefficients, and their reference indices
+        // for different orbitals, indexVec will give the same index for the same node in space
+        std::vector<int> parindexVec; // serialIx of the parent nodes
+        std::vector<int> indexVec;    // serialIx of the nodes
+        for (int j = 0; j < N; j++) {
+            // make vector with all coef pointers and their indices in the union grid
+            if (BraKet[j].hasReal()) {
+                BraKet[j].real().makeCoeffVector(coeffVec[j], indexVec, parindexVec, scalefac, max_ix, refTree);
+                // make a map that gives j from indexVec
+                int orb_node_ix = 0;
+                for (int ix : indexVec) {
+                    orb2node[j][ix] = orb_node_ix++;
+                    if (ix < 0) continue;
+                    node2orbVec[ix].push_back(j);
+                }
+            }
+            if (BraKet[j].hasImag()) {
+                BraKet[j].imag().makeCoeffVector(coeffVec[j + N], indexVec, parindexVec, scalefac, max_ix, refTree);
+                // make a map that gives j from indexVec
+                int orb_node_ix = 0;
+                for (int ix : indexVec) {
+                    orb2node[j + N][ix] = orb_node_ix++;
+                    if (ix < 0) continue;
+                    node2orbVec[ix].push_back(j + N);
                 }
             }
         }
-        timer.start();
+    } else { // MPI case
+        // 2) send own nodes to bank, identifying them through the serialIx of refTree
+        save_nodes(BraKet, refTree);
+        mrchem::mpi::barrier(mrchem::mpi::comm_orb); // wait until everything is stored before fetching!
     }
-    // Assumes all MPIs have (only) computed their own columns of the matrix
+
+    // 3) make dot product for all the nodes and accumulate into S
+
+    int ibank = 0;
+#pragma omp parallel for schedule(dynamic) if (serial)
+    for (int n = 0; n < max_n; n++) {
+        int csize;
+        if (n % mpi::orb_size != mpi::orb_rank) continue;
+        int node_ix = indexVec_ref[n]; // SerialIx for this node in the reference tree
+        std::vector<int> orbVec;       // identifies which orbitals use this node
+        if (serial and node2orbVec[node_ix].size() <= 0) continue;
+        if (parindexVec_ref[n] < 0)
+            csize = sizecoeff;
+        else
+            csize = sizecoeffW;
+        // In the serial case we copy the coeff coeffBlock. In the mpi case coeffBlock is provided by the bank
+        if (serial) {
+            int shift = sizecoeff - sizecoeffW; // to copy only wavelet part
+            if (parindexVec_ref[n] < 0) shift = 0;
+            DoubleMatrix coeffBlock(csize, node2orbVec[node_ix].size());
+            for (int j : node2orbVec[node_ix]) { // loop over indices of the orbitals using this node
+                int orb_node_ix = orb2node[j][node_ix];
+                for (int k = 0; k < csize; k++) coeffBlock(k, orbVec.size()) = coeffVec[j][orb_node_ix][k + shift];
+                orbVec.push_back(j);
+            }
+            if (orbVec.size() > 0) {
+                DoubleMatrix S_temp(orbVec.size(), orbVec.size());
+                S_temp.noalias() = coeffBlock.transpose() * coeffBlock;
+                for (int i = 0; i < orbVec.size(); i++) {
+                    for (int j = 0; j < orbVec.size(); j++) {
+                        // must ensure that threads are not competing
+                        double &Srealij = Sreal(orbVec[i], orbVec[j]);
+                        double &Stempij = S_temp(i, j);
+#pragma omp atomic
+                        Srealij += Stempij;
+                    }
+                }
+            }
+        } else { // MPI case
+            DoubleMatrix coeffBlock(csize, 2 * N);
+            mrchem::mpi::orb_bank.get_nodeblock(indexVec_ref[n], coeffBlock.data(), orbVec);
+
+            if (orbVec.size() > 0) {
+                DoubleMatrix S_temp(orbVec.size(), orbVec.size());
+                coeffBlock.conservativeResize(Eigen::NoChange, orbVec.size());
+                S_temp.noalias() = coeffBlock.transpose() * coeffBlock;
+                for (int i = 0; i < orbVec.size(); i++) {
+                    for (int j = 0; j < orbVec.size(); j++) { Sreal(orbVec[i], orbVec[j]) += S_temp(i, j); }
+                }
+            }
+        }
+    }
+
+    mrchem::mpi::orb_bank.clear_blockdata();
+
+    IntVector conjMat = IntVector::Zero(N);
+    for (int i = 0; i < N; i++) {
+        if (!mpi::my_orb(BraKet[i])) continue;
+        conjMat[i] = (BraKet[i].conjugate()) ? -1 : 1;
+    }
+    mpi::allreduce_vector(conjMat, mpi::comm_orb);
+
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j <= i; j++) {
+            S.real()(i, j) = Sreal(i, j) + conjMat[i] * conjMat[j] * Sreal(i + N, j + N);
+            S.imag()(i, j) = conjMat[j] * Sreal(i, j + N) - conjMat[i] * Sreal(i + N, j);
+            if (i != j) S(j, i) = std::conj(S(i, j)); // ensure exact symmetri
+        }
+    }
+
+    // Assumes linearity: result is sum of all nodes contributions
     mpi::allreduce_matrix(S, mpi::comm_orb);
+
     return S;
 }
 
 /** @brief Compute the overlap matrix S_ij = <bra_i|ket_j>
  *
- * MPI: Each rank will compute the full columns related to their
- *      orbitals in the ket vector. The bra orbitals are communicated
- *      one rank at the time (all orbitals belonging to a given rank
- *      is communicated at the same time). This algorithm sets NO
- *      restrictions on the distributions of the bra or ket orbitals
- *      among the available ranks. After the columns have been computed,
- *      the full matrix is allreduced, e.i. all MPIs will have the full
- *      matrix at exit.
- *
  */
 ComplexMatrix orbital::calc_overlap_matrix(OrbitalVector &Bra, OrbitalVector &Ket) {
-    ComplexMatrix S = ComplexMatrix::Zero(Bra.size(), Ket.size());
 
-    // Get all ket orbitals belonging to this MPI
-    OrbitalChunk myKet = mpi::get_my_chunk(Ket);
+    int N = Bra.size();
+    int M = Ket.size();
+    ComplexMatrix S = ComplexMatrix::Zero(N, M);
+    DoubleMatrix Sreal = DoubleMatrix::Zero(2 * N, 2 * M); // same as S, but stored as 4 blocks, rr,ri,ir,ii
 
-    // Receive ALL orbitals on the bra side, use only MY orbitals on the ket side
-    // Computes the FULL columns associated with MY orbitals on the ket side
-    OrbitalIterator iter(Bra);
-    while (iter.next()) {
-        for (int i = 0; i < iter.get_size(); i++) {
-            int idx_i = iter.idx(i);
-            Orbital &bra_i = iter.orbital(i);
-            for (auto &j : myKet) {
-                int idx_j = std::get<0>(j);
-                Orbital &ket_j = std::get<1>(j);
-                if (mpi::my_unique_orb(ket_j) or mpi::grand_master()) S(idx_i, idx_j) = orbital::dot(bra_i, ket_j);
+    // 1) make union tree without coefficients for Bra (supposed smallest)
+    mrcpp::FunctionTree<3> refTree(*MRA);
+    mpi::allreduce_Tree_noCoeff(refTree, Bra, mpi::comm_orb);
+    // note that Ket is not part of union grid: if a node is in ket but not in Bra, the dot product is zero.
+
+    int sizecoeff = (1 << refTree.getDim()) * refTree.getKp1_d();
+    int sizecoeffW = ((1 << refTree.getDim()) - 1) * refTree.getKp1_d();
+
+    // get a list of all nodes in union grid, as defined by their indices
+    std::vector<double *> coeffVec_ref;
+    std::vector<int> indexVec_ref;    // serialIx of the nodes
+    std::vector<int> parindexVec_ref; // serialIx of the parent nodes
+    std::vector<double> scalefac;
+    int max_ix;
+
+    refTree.makeCoeffVector(coeffVec_ref, indexVec_ref, parindexVec_ref, scalefac, max_ix, refTree);
+    int max_n = indexVec_ref.size();
+    max_ix++;
+
+    bool serial = mpi::orb_size == 1; // flag for serial/MPI switch
+
+    // only used for serial case:
+    std::vector<std::vector<double *>> coeffVecBra(2 * N);
+    std::map<int, std::vector<int>>
+        node2orbVecBra; // for each node index, gives a vector with the indices of the orbitals using this node
+    std::vector<std::map<int, int>> orb2nodeBra(2 * N); // for a given orbital and a given node, gives the node index in
+                                                        // the orbital given the node index in the reference tree
+    std::vector<std::vector<double *>> coeffVecKet(2 * M);
+    std::map<int, std::vector<int>>
+        node2orbVecKet; // for each node index, gives a vector with the indices of the orbitals using this node
+    std::vector<std::map<int, int>> orb2nodeKet(2 * M); // for a given orbital and a given node, gives the node index in
+                                                        // the orbital given the node index in the reference tree
+
+    // In the serial case we store the coeff pointers in coeffVec. In the mpi case the coeff are stored in the bank
+    if (serial) {
+        // 2) make list of all coefficients, and their reference indices
+        // for different orbitals, indexVec will give the same index for the same node in space
+        // TODO? : do not copy coefficients, but use directly the pointers
+        // could OMP parallelize, but is fast anyway
+        std::vector<int> parindexVec; // serialIx of the parent nodes
+        std::vector<int> indexVec;    // serialIx of the nodes
+        for (int j = 0; j < N; j++) {
+            // make vector with all coef pointers and their indices in the union grid
+            if (Bra[j].hasReal()) {
+                Bra[j].real().makeCoeffVector(coeffVecBra[j], indexVec, parindexVec, scalefac, max_ix, refTree);
+                // make a map that gives j from indexVec
+                int orb_node_ix = 0;
+                for (int ix : indexVec) {
+                    orb2nodeBra[j][ix] = orb_node_ix++;
+                    if (ix < 0) continue;
+                    node2orbVecBra[ix].push_back(j);
+                }
+            }
+            if (Bra[j].hasImag()) {
+                Bra[j].imag().makeCoeffVector(coeffVecBra[j + N], indexVec, parindexVec, scalefac, max_ix, refTree);
+                // make a map that gives j from indexVec
+                int orb_node_ix = 0;
+                for (int ix : indexVec) {
+                    orb2nodeBra[j + N][ix] = orb_node_ix++;
+                    if (ix < 0) continue;
+                    node2orbVecBra[ix].push_back(j + N);
+                }
+            }
+            if (Ket[j].hasReal()) {
+                Ket[j].real().makeCoeffVector(coeffVecKet[j], indexVec, parindexVec, scalefac, max_ix, refTree);
+                // make a map that gives j from indexVec
+                int orb_node_ix = 0;
+                for (int ix : indexVec) {
+                    orb2nodeKet[j][ix] = orb_node_ix++;
+                    if (ix < 0) continue;
+                    node2orbVecKet[ix].push_back(j);
+                }
+            }
+            if (Ket[j].hasImag()) {
+                Ket[j].imag().makeCoeffVector(coeffVecKet[j + M], indexVec, parindexVec, scalefac, max_ix, refTree);
+                // make a map that gives j from indexVec
+                int orb_node_ix = 0;
+                for (int ix : indexVec) {
+                    orb2nodeKet[j + M][ix] = orb_node_ix++;
+                    if (ix < 0) continue;
+                    node2orbVecKet[ix].push_back(j + M);
+                }
+            }
+        }
+
+    } else { // MPI case
+
+        // 2) send own nodes to bank, identifying them through the serialIx of refTree
+        save_nodes(Bra, refTree);
+        save_nodes(Ket, refTree, max_ix); // Save using a shift for serialIx. Only nodes present in refTree are stored.
+        mrchem::mpi::barrier(mrchem::mpi::comm_orb); // wait until everything is stored before fetching!
+    }
+
+    // 3) make dot product for all the nodes and accumulate into S
+
+#pragma omp parallel for schedule(dynamic) if (serial)
+    for (int n = 0; n < max_n; n++) {
+        if (n % mpi::orb_size != mpi::orb_rank) continue;
+        int csize;
+        std::vector<int> orbVecBra; // identifies which Bra orbitals use this node
+        std::vector<int> orbVecKet; // identifies which Ket orbitals use this node
+        if (parindexVec_ref[n] < 0)
+            csize = sizecoeff;
+        else
+            csize = sizecoeffW;
+        if (serial) {
+            int node_ix = indexVec_ref[n];      // SerialIx for this node in the reference tree
+            int shift = sizecoeff - sizecoeffW; // to copy only wavelet part
+            DoubleMatrix coeffBlockBra(csize, node2orbVecBra[node_ix].size());
+            DoubleMatrix coeffBlockKet(csize, node2orbVecKet[node_ix].size());
+            if (parindexVec_ref[n] < 0) shift = 0;
+
+            for (int j : node2orbVecBra[node_ix]) { // loop over indices of the orbitals using this node
+                int orb_node_ix = orb2nodeBra[j][node_ix];
+                for (int k = 0; k < csize; k++)
+                    coeffBlockBra(k, orbVecBra.size()) = coeffVecBra[j][orb_node_ix][k + shift];
+                orbVecBra.push_back(j);
+            }
+            for (int j : node2orbVecKet[node_ix]) { // loop over indices of the orbitals using this node
+                int orb_node_ix = orb2nodeKet[j][node_ix];
+                for (int k = 0; k < csize; k++)
+                    coeffBlockKet(k, orbVecKet.size()) = coeffVecKet[j][orb_node_ix][k + shift];
+                orbVecKet.push_back(j);
+            }
+
+            if (orbVecBra.size() > 0 and orbVecKet.size() > 0) {
+                DoubleMatrix S_temp(orbVecBra.size(), orbVecKet.size());
+                S_temp.noalias() = coeffBlockBra.transpose() * coeffBlockKet;
+                for (int i = 0; i < orbVecBra.size(); i++) {
+                    for (int j = 0; j < orbVecKet.size(); j++) {
+                        // must ensure that threads are not competing
+                        double &Srealij = Sreal(orbVecBra[i], orbVecKet[j]);
+                        double &Stempij = S_temp(i, j);
+#pragma omp atomic
+                        Srealij += Stempij;
+                        // Sreal(orbVecBra[i], orbVecKet[j]) += S_temp(i,j);
+                    }
+                }
+            }
+
+        } else {
+            DoubleMatrix coeffBlockBra(csize, 2 * N);
+            DoubleMatrix coeffBlockKet(csize, 2 * M);
+            mrchem::mpi::orb_bank.get_nodeblock(indexVec_ref[n], coeffBlockBra.data(), orbVecBra); // get Bra parts
+            mrchem::mpi::orb_bank.get_nodeblock(
+                indexVec_ref[n] + max_ix, coeffBlockKet.data(), orbVecKet); // get Ket parts
+
+            if (orbVecBra.size() > 0 and orbVecKet.size() > 0) {
+                DoubleMatrix S_temp(orbVecBra.size(), orbVecKet.size());
+                coeffBlockBra.conservativeResize(Eigen::NoChange, orbVecBra.size());
+                coeffBlockKet.conservativeResize(Eigen::NoChange, orbVecKet.size());
+                S_temp.noalias() = coeffBlockBra.transpose() * coeffBlockKet;
+                for (int i = 0; i < orbVecBra.size(); i++) {
+                    for (int j = 0; j < orbVecKet.size(); j++) { Sreal(orbVecBra[i], orbVecKet[j]) += S_temp(i, j); }
+                }
             }
         }
     }
-    // Assumes all MPIs have (only) computed their own columns of the matrix
+
+    mrchem::mpi::orb_bank.clear_blockdata();
+
+    IntVector conjMatBra = IntVector::Zero(N);
+    for (int i = 0; i < N; i++) {
+        if (!mpi::my_orb(Bra[i])) continue;
+        conjMatBra[i] = (Bra[i].conjugate()) ? -1 : 1;
+    }
+    mpi::allreduce_vector(conjMatBra, mpi::comm_orb);
+    IntVector conjMatKet = IntVector::Zero(M);
+    for (int i = 0; i < M; i++) {
+        if (!mpi::my_orb(Ket[i])) continue;
+        conjMatKet[i] = (Ket[i].conjugate()) ? -1 : 1;
+    }
+    mpi::allreduce_vector(conjMatKet, mpi::comm_orb);
+
+    for (int i = 0; i < N; i++) {
+        for (int j = 0; j < M; j++) {
+            S.real()(i, j) = Sreal(i, j) + conjMatBra[i] * conjMatKet[j] * Sreal(i + N, j + M);
+            S.imag()(i, j) = conjMatKet[j] * Sreal(i, j + M) - conjMatBra[i] * Sreal(i + N, j);
+        }
+    }
+
+    // 4) collect results from all MPI. Linearity: result is sum of all node contributions
+
     mpi::allreduce_matrix(S, mpi::comm_orb);
+
     return S;
 }
 
@@ -674,11 +1356,12 @@ ComplexMatrix orbital::calc_localization_matrix(double prec, OrbitalVector &Phi)
             U = rr.getTotalU().cast<ComplexDouble>();
         } else {
             println(2, " Foster-Boys localization did not converge!");
+            U = rr.getTotalU().cast<ComplexDouble>();
         }
     } else {
         println(2, " Cannot localize less than two orbitals");
     }
-    if (n_it <= 0) {
+    if (n_it == 0) {
         Timer orth_t;
         U = orbital::calc_lowdin_matrix(Phi);
         mrcpp::print::time(2, "Computing Lowdin matrix", orth_t);

--- a/src/qmfunctions/orbital_utils.h
+++ b/src/qmfunctions/orbital_utils.h
@@ -55,6 +55,8 @@ OrbitalVector disjoin(OrbitalVector &Phi, int spin);
 void save_orbitals(OrbitalVector &Phi, const std::string &file, int spin = -1);
 OrbitalVector load_orbitals(const std::string &file, int n_orbs = -1);
 
+void save_nodes(OrbitalVector Phi, mrcpp::FunctionTree<3> &refTree, int shift = 0);
+
 void normalize(OrbitalVector &Phi);
 void orthogonalize(double prec, OrbitalVector &Phi);
 void orthogonalize(double prec, OrbitalVector &Phi, OrbitalVector &Psi);


### PR DESCRIPTION
New faster method for rotation and dot product of orbital vectors. Those are the parts that scale as 0(N²)
The idea is to rotate one nodes at a time; this can be done as a matrix multiplication which is extremely fast.
For Valinomycine (300 orbitals), rotation is up to 50 times faster. Overall 5 times faster LDA calculation.
The benefit is largest for large molecules.

Could still relatively easily be further optimized, as the mpi version does not even use omp (!) for example. However other parts are now the bottleneck (XC and Exchange) and should be optimized first.

The functions that have been replaced are "rotate" and "overlap". Unfortunately those have become "monolithic" and heavy, since they are written for efficiency (avoid data copying and use pointer and indices manipulation).

Other: faster localization, and accept U matrix also when it is not converged (that simply mean it is not the optimal localization, but very close to it).

Requires updated mrcpp library.