### PR TITLE
Bank upgrade

### DIFF
--- a/doc/users/Betzy_example.job
+++ b/doc/users/Betzy_example.job
@@ -1,0 +1,8 @@
+#!/bin/bash -l
+#SBATCH --nodes=4
+#SBATCH --tasks-per-node=8
+
+export UCX_LOG_LEVEL=ERROR
+export OMP_NUM_THREADS=16
+
+~/my_path/to/mrchem --launcher='mpirun --rank-by node --map-by socket --bind-to numa' mw6

--- a/doc/users/running.rst
+++ b/doc/users/running.rst
@@ -150,14 +150,17 @@ library on Betzy.
   Tells the system to place the first MPI rank on the first node, the second MPI
   rank on the second node, until the last node, then start at the first node again.
 
-``--map-by numa``
-  Tells the system to map MPI ranks according to NUMA (Non Uniform Memory Access).
+``--map-by socket``
+  Tells the system to map (group) MPI ranks according to socket before distribution
+  between nodes. This will ensure that for example two bank cores will access
+  different parts of memory.
+
+``--bind-to numa``
+  Tells the system to bind cores to one NUMA (Non Uniform Memory Access) group.
   On Betzy memory configuration groups cores by groups of 16, with cores in the same
   group having the same access to memory (other cores will have access to that part
   of the memory too, but slower).
-
-``--bind-to numa``
-  Tells the system to bind cores to one NUMA group. That means that a process will
+  That means that a process will
   only be allowed to use one of the 16 cores of the group. (The operating system may
   change the core assigned to a thread/process and, without precautions, it may be
   assigned to any other core, which would result in much reduced performance). The 16

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -767,7 +767,6 @@ json driver::rsp::run(const json &json_rsp, Molecule &mol) {
     }
     F_0.clear();
     mpi::barrier(mpi::comm_orb);
-    if (mpi::bank_size > 0) mpi::orb_bank.clear_all(mpi::orb_rank, mpi::comm_orb);
     mol.getOrbitalsX_p().reset(); // Release shared_ptr
     mol.getOrbitalsY_p().reset(); // Release shared_ptr
 

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -30,6 +30,7 @@
 #include "qmfunctions/ComplexFunction.h"
 #include "qmfunctions/Density.h"
 #include "qmfunctions/Orbital.h"
+#include "utils/Bank.h"
 
 #ifdef MRCHEM_HAS_OMP
 #ifndef MRCPP_HAS_OMP
@@ -58,6 +59,8 @@ int n_threads = mrchem_get_max_threads();
 
 using namespace Eigen;
 
+CentralBank dataBank;
+
 namespace mpi {
 
 bool numerically_exact = false;
@@ -71,9 +74,11 @@ int share_size = 1;
 int share_rank = 0;
 int sh_group_rank = 0;
 int is_bank = 0;
+int is_centralbank = 0;
 int is_bankclient = 1;
 int is_bankmaster = 0; // only one bankmaster is_bankmaster
 int bank_size = -1;
+int max_tag = 0; // max value allowed by MPI. Set by initialize()
 std::vector<int> bankmaster;
 
 MPI_Comm comm_orb;
@@ -81,14 +86,12 @@ MPI_Comm comm_share;
 MPI_Comm comm_sh_group;
 MPI_Comm comm_bank;
 
-Bank orb_bank;
-
 } // namespace mpi
 
 int id_shift; // to ensure that nodes, orbitals and functions do not collide
 
-int metadata_block[3]; // can add more metadata in future
-int const size_metadata = 3;
+extern int metadata_block[3]; // can add more metadata in future
+extern int const size_metadata = 3;
 
 void mpi::initialize() {
     Eigen::setNbThreads(1);
@@ -124,10 +127,12 @@ void mpi::initialize() {
     if (mpi::world_rank < mpi::world_size - mpi::bank_size) {
         // everything which is left
         mpi::is_bank = 0;
+        mpi::is_centralbank = 0;
         mpi::is_bankclient = 1;
     } else {
-        // special group of bankmasters
+        // special group of centralbankmasters
         mpi::is_bank = 1;
+        mpi::is_centralbank = 1;
         mpi::is_bankclient = 0;
         if (mpi::world_rank == mpi::world_size - mpi::bank_size) mpi::is_bankmaster = 1;
     }
@@ -160,11 +165,12 @@ void mpi::initialize() {
     void *val;
     int flag;
     MPI_Comm_get_attr(MPI_COMM_WORLD, MPI_TAG_UB, &val, &flag); // max value allowed by MPI for tags
-    id_shift = *(int *)val / 2;                                 // half is reserved for non orbital.
+    max_tag = *(int *)val / 2;
+    id_shift = max_tag / 2; // half is reserved for non orbital.
 
     if (mpi::is_bank) {
         // bank is open until end of program
-        mpi::orb_bank.open();
+        if (mpi::is_centralbank) { dataBank.open(); }
         mpi::finalize();
         exit(EXIT_SUCCESS);
     }
@@ -176,8 +182,8 @@ void mpi::initialize() {
 void mpi::finalize() {
 #ifdef MRCHEM_HAS_MPI
     if (mpi::bank_size > 0 and mpi::grand_master()) {
-        println(3, " max data in bank " << mpi::orb_bank.get_maxtotalsize() << " MB ");
-        mpi::orb_bank.close();
+        println(3, " max data in bank " << dataBank.get_maxtotalsize() << " MB ");
+        dataBank.close();
     }
     MPI_Barrier(MPI_COMM_WORLD); // to ensure everybody got here
     MPI_Finalize();
@@ -520,722 +526,6 @@ void mpi::broadcast_Tree_noCoeff(mrcpp::FunctionTree<3> &tree, MPI_Comm comm) {
         fac /= 2;
     }
     MPI_Barrier(comm);
-#endif
-}
-
-/**************************
- * Bank related functions *
- **************************/
-
-Bank::~Bank() {
-    for (int ix = 1; ix < this->deposits.size(); ix++) this->clear(ix);
-}
-
-void Bank::open() {
-#ifdef MRCHEM_HAS_MPI
-    MPI_Status status;
-    char safe_data1;
-    int deposit_size = sizeof(bank::deposit);
-    int n_chunks, ix;
-    int message;
-    int datasize = -1;
-    struct Blockdata_struct {
-        std::vector<double *> data; // to store the incoming data
-        std::vector<bool> deleted;  // to indicate if it has been deleted already
-        MatrixXd BlockData;         // to put the final block
-        // eigen matrix are per default stored column-major (one can add columns at the end)
-        std::vector<int> N_rows;
-        std::map<int, int> id2data; // internal index of the data in the block
-        std::vector<int> id;        // the id of each column. Either nodeid, or orbid
-    };
-    std::map<int, Blockdata_struct *> nodeid2block; // to get block from its nodeid (all coeff for one node)
-    std::map<int, Blockdata_struct *> orbid2block;  // to get block from its orbid
-
-    deposits.resize(1); // we reserve 0, since it is the value returned for undefined key
-    queue.resize(1);    // we reserve 0, since it is the value returned for undefined key
-
-    bool printinfo = false;
-
-    // The bank never goes out of this loop until it receives a close message!
-    while (true) {
-        MPI_Recv(&message, 1, MPI_INT, MPI_ANY_SOURCE, MPI_ANY_TAG, mpi::comm_bank, &status);
-        if (printinfo)
-            std::cout << mpi::world_rank << " got message " << message << " from " << status.MPI_SOURCE << std::endl;
-        if (message == CLOSE_BANK) {
-            if (mpi::is_bankmaster and printinfo) std::cout << "Bank is closing" << std::endl;
-            this->clear_bank();
-            break; // close bank, i.e stop listening for incoming messages
-        }
-        if (message == CLEAR_BANK) {
-            this->clear_bank();
-            for (auto const &block : nodeid2block) {
-                if (block.second == nullptr) continue;
-                for (int i = 0; i < block.second->data.size(); i++) {
-                    if (not block.second->deleted[i]) {
-                        this->currentsize -= block.second->N_rows[i] / 128; // converted into kB
-                        delete[] block.second->data[i];
-                    }
-                }
-                delete block.second;
-            }
-            nodeid2block.clear();
-            orbid2block.clear();
-            // send message that it is ready (value of message is not used)
-            MPI_Ssend(&message, 1, MPI_INT, status.MPI_SOURCE, 77, mpi::comm_bank);
-        }
-        if (message == CLEAR_BLOCKS) {
-            // clear only blocks whith id less than status.MPI_TAG.
-            std::vector<int> toeraseVec; // it is dangerous to erase an iterator within its own loop
-            for (auto const &block : nodeid2block) {
-                if (block.second == nullptr) toeraseVec.push_back(block.first);
-                if (block.second == nullptr) continue;
-                if (block.first >= status.MPI_TAG and status.MPI_TAG != 0) continue;
-                for (int i = 0; i < block.second->data.size(); i++) {
-                    if (not block.second->deleted[i]) {
-                        this->currentsize -= block.second->N_rows[i] / 128; // converted into kB
-                        delete[] block.second->data[i];
-                    }
-                }
-                this->currentsize -= block.second->BlockData.size() / 128; // converted into kB
-                block.second->BlockData.resize(0, 0); // NB: the matrix does not clear itself otherwise
-                assert(this->currentsize >= 0);
-                this->currentsize = std::max(0ll, this->currentsize);
-                toeraseVec.push_back(block.first);
-            }
-            for (int ierase : toeraseVec) { nodeid2block.erase(ierase); }
-            toeraseVec.clear();
-            std::vector<int> datatoeraseVec;
-            for (auto const &block : orbid2block) {
-                if (block.second == nullptr) toeraseVec.push_back(block.first);
-                if (block.second == nullptr) continue;
-                datatoeraseVec.clear();
-                for (int i = 0; i < block.second->data.size(); i++) {
-                    if (block.second->id[i] < status.MPI_TAG or status.MPI_TAG == 0) datatoeraseVec.push_back(i);
-                    if (block.second->id[i] < status.MPI_TAG or status.MPI_TAG == 0) block.second->data[i] = nullptr;
-                }
-                std::sort(datatoeraseVec.begin(), datatoeraseVec.end());
-                std::reverse(datatoeraseVec.begin(), datatoeraseVec.end());
-                for (int ierase : datatoeraseVec) {
-                    block.second->id.erase(block.second->id.begin() + ierase);
-                    block.second->data.erase(block.second->data.begin() + ierase);
-                    block.second->N_rows.erase(block.second->N_rows.begin() + ierase);
-                }
-                if (block.second->data.size() == 0) toeraseVec.push_back(block.first);
-            }
-            for (int ierase : toeraseVec) { orbid2block.erase(ierase); }
-
-            if (status.MPI_TAG == 0) orbid2block.clear();
-            // could have own clear for data?
-            for (int ix = 1; ix < deposits.size(); ix++) {
-                if (deposits[ix].id >= id_shift) {
-                    if (deposits[ix].hasdata) delete deposits[ix].data;
-                    if (deposits[ix].hasdata) id2ix[deposits[ix].id] = 0; // indicate that it does not exist
-                    deposits[ix].hasdata = false;
-                }
-            }
-            // send message that it is ready (value of message is not used)
-            MPI_Ssend(&message, 1, MPI_INT, status.MPI_SOURCE, 78, mpi::comm_bank);
-        }
-        if (message == GETMAXTOTDATA) {
-            int maxsize_int = maxsize / 1024; // convert into MB
-            MPI_Send(&maxsize_int, 1, MPI_INT, status.MPI_SOURCE, 1171, mpi::comm_bank);
-        }
-        if (message == GETTOTDATA) {
-            int maxsize_int = currentsize / 1024; // convert into MB
-            MPI_Send(&maxsize_int, 1, MPI_INT, status.MPI_SOURCE, 1172, mpi::comm_bank);
-        }
-
-        if (message == GET_NODEDATA or message == GET_NODEBLOCK) {
-            // NB: has no queue system yet
-            int nodeid = status.MPI_TAG; // which block to fetch from
-            if (nodeid2block.count(nodeid) and nodeid2block[nodeid] != nullptr) {
-                Blockdata_struct *block = nodeid2block[nodeid];
-                int dataindex = 0; // internal index of the data in the block
-                int size = 0;
-                if (message == GET_NODEDATA) {
-                    // get id of data within block
-                    MPI_Recv(
-                        metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, nodeid + 1, mpi::comm_bank, &status);
-                    int orbid = metadata_block[1];     // which part of the block to fetch
-                    dataindex = block->id2data[orbid]; // column of the data in the block
-                    size = block->N_rows[dataindex];   // number of doubles to fetch
-                    if (metadata_block[2] == 0) {
-                        metadata_block[2] = size;
-                        MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, nodeid, mpi::comm_bank);
-                    }
-                } else {
-                    // send entire block. First make one contiguous superblock
-                    // Prepare the data as one contiguous block
-                    if (block->data.size() == 0)
-                        std::cout << "Zero size blockdata! " << nodeid << " " << block->N_rows.size() << std::endl;
-                    block->BlockData.resize(block->N_rows[0], block->data.size());
-                    size = block->N_rows[0] * block->data.size();
-                    if (printinfo)
-                        std::cout << " rewrite into superblock " << block->data.size() << " " << block->N_rows[0]
-                                  << " tag " << status.MPI_TAG << std::endl;
-                    for (int j = 0; j < block->data.size(); j++) {
-                        for (int i = 0; i < block->N_rows[j]; i++) { block->BlockData(i, j) = block->data[j][i]; }
-                    }
-                    // repoint to the data in BlockData
-                    for (int j = 0; j < block->data.size(); j++) {
-                        if (block->deleted[j] == true) std::cout << "ERROR data already deleted " << std::endl;
-                        assert(block->deleted[j] == false);
-                        delete[] block->data[j];
-                        block->deleted[j] = true;
-                        block->data[j] = block->BlockData.col(j).data();
-                    }
-                    dataindex = 0; // start from first column
-                    // send info about the size of the superblock
-                    metadata_block[0] = status.MPI_TAG;     // nodeid
-                    metadata_block[1] = block->data.size(); // number of columns
-                    metadata_block[2] = size;               // total size = rows*columns
-                    MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, nodeid, mpi::comm_bank);
-                    // send info about the id of each column
-                    MPI_Send(
-                        block->id.data(), metadata_block[1], MPI_INT, status.MPI_SOURCE, nodeid + 1, mpi::comm_bank);
-                }
-                double *data_p = block->data[dataindex];
-                if (size > 0) MPI_Send(data_p, size, MPI_DOUBLE, status.MPI_SOURCE, nodeid + 2, mpi::comm_bank);
-            } else {
-                // Block with this id does not exist.
-                if (message == GET_NODEDATA) {
-                    MPI_Recv(
-                        metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, nodeid + 1, mpi::comm_bank, &status);
-                    int size = metadata_block[2]; // number of doubles to send
-                    if (size == 0) {
-                        metadata_block[2] = size;
-                        MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, nodeid, mpi::comm_bank);
-                    } else {
-                        std::vector<double> zero(size, 0.0); // send zeroes
-                        MPI_Ssend(zero.data(), size, MPI_DOUBLE, status.MPI_SOURCE, nodeid + 2, mpi::comm_bank);
-                    }
-                } else {
-                    metadata_block[0] = status.MPI_TAG; // nodeid
-                    metadata_block[1] = 0;              // number of columns
-                    metadata_block[2] = 0;              // total size = rows*columns
-                    MPI_Send(
-                        metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, metadata_block[0], mpi::comm_bank);
-                }
-            }
-        }
-        if (message == GET_ORBBLOCK) {
-            // NB: BLOCKDATA has no queue system yet
-            int orbid = status.MPI_TAG; // which block to fetch from
-
-            if (orbid2block.count(orbid) and orbid2block[orbid] != nullptr) {
-                Blockdata_struct *block = orbid2block[orbid];
-                int dataindex = 0; // internal index of the data in the block
-                int size = 0;
-                // send entire block. First make one contiguous superblock
-                // Prepare the data as one contiguous block
-                if (block->data.size() == 0)
-                    std::cout << "Zero size blockdata! C " << orbid << " " << block->N_rows.size() << std::endl;
-                size = 0;
-                for (int j = 0; j < block->data.size(); j++) size += block->N_rows[j];
-
-                std::vector<double> coeff(size);
-                int ij = 0;
-                for (int j = 0; j < block->data.size(); j++) {
-                    for (int i = 0; i < block->N_rows[j]; i++) { coeff[ij++] = block->data[j][i]; }
-                }
-                // send info about the size of the superblock
-                metadata_block[0] = orbid;
-                metadata_block[1] = block->data.size(); // number of columns
-                metadata_block[2] = size;               // total size = rows*columns
-                MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, orbid, mpi::comm_bank);
-                MPI_Send(block->id.data(), metadata_block[1], MPI_INT, status.MPI_SOURCE, orbid + 1, mpi::comm_bank);
-                MPI_Send(coeff.data(), size, MPI_DOUBLE, status.MPI_SOURCE, orbid + 2, mpi::comm_bank);
-            } else {
-                // it is possible and allowed that the block has not been written
-                if (printinfo)
-                    std::cout << " block does not exist " << orbid << " " << orbid2block.count(orbid) << std::endl;
-                // Block with this id does not exist.
-                metadata_block[0] = orbid;
-                metadata_block[1] = 0; // number of columns
-                metadata_block[2] = 0; // total size = rows*columns
-                MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, orbid, mpi::comm_bank);
-            }
-        }
-
-        if (message == GET_ORBITAL or message == GET_ORBITAL_AND_WAIT or message == GET_ORBITAL_AND_DELETE or
-            message == GET_FUNCTION or message == GET_DATA) {
-            // withdrawal
-            int ix = id2ix[status.MPI_TAG];
-            if (ix == 0) {
-                if (printinfo) std::cout << mpi::world_rank << " not found " << status.MPI_TAG << std::endl;
-                if (message == GET_ORBITAL or message == GET_ORBITAL_AND_DELETE) {
-                    // do not wait for the orbital to arrive
-                    int found = 0;
-                    if (printinfo)
-                        std::cout << mpi::world_rank << " sending found 0 to " << status.MPI_SOURCE << std::endl;
-                    MPI_Send(&found, 1, MPI_INT, status.MPI_SOURCE, 117, mpi::comm_bank);
-                } else {
-                    // the id does not exist. Put in queue and Wait until it is defined
-                    if (printinfo) std::cout << mpi::world_rank << " queuing " << status.MPI_TAG << std::endl;
-                    if (id2qu[status.MPI_TAG] == 0) {
-                        queue.push_back({status.MPI_TAG, {status.MPI_SOURCE}});
-                        id2qu[status.MPI_TAG] = queue.size() - 1;
-                    } else {
-                        // somebody is already waiting for this id. queue in queue
-                        queue[id2qu[status.MPI_TAG]].clients.push_back(status.MPI_SOURCE);
-                    }
-                }
-            } else {
-                if (deposits[ix].id != status.MPI_TAG) std::cout << ix << " Bank accounting error " << std::endl;
-                if (message == GET_ORBITAL or message == GET_ORBITAL_AND_WAIT or message == GET_ORBITAL_AND_DELETE) {
-                    if (message == GET_ORBITAL or message == GET_ORBITAL_AND_DELETE) {
-                        int found = 1;
-                        MPI_Send(&found, 1, MPI_INT, status.MPI_SOURCE, 117, mpi::comm_bank);
-                    }
-                    mpi::send_orbital(*deposits[ix].orb, status.MPI_SOURCE, deposits[ix].id, mpi::comm_bank);
-                    if (message == GET_ORBITAL_AND_DELETE) {
-                        this->currentsize -= deposits[ix].orb->getSizeNodes(NUMBER::Total);
-                        deposits[ix].orb->free(NUMBER::Total);
-                        id2ix[status.MPI_TAG] = 0;
-                    }
-                }
-                if (message == GET_FUNCTION) {
-                    mpi::send_function(*deposits[ix].orb, status.MPI_SOURCE, deposits[ix].id, mpi::comm_bank);
-                }
-                if (message == GET_DATA) {
-                    MPI_Send(deposits[ix].data,
-                             deposits[ix].datasize,
-                             MPI_DOUBLE,
-                             status.MPI_SOURCE,
-                             deposits[ix].id,
-                             mpi::comm_bank);
-                }
-            }
-        }
-        if (message == SAVE_NODEDATA) {
-            // get the extra metadata
-            MPI_Recv(
-                metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, status.MPI_TAG, mpi::comm_bank, &status);
-            int nodeid = metadata_block[0]; // which block to write (should = status.MPI_TAG)
-            int orbid = metadata_block[1];  // which part of the block
-            int size = metadata_block[2];   // number of doubles
-
-            // test if the block exists already
-            if (printinfo)
-                std::cout << mpi::world_rank << " save data nodeid " << nodeid << " size " << size << std::endl;
-            if (nodeid2block.count(nodeid) == 0 or nodeid2block[nodeid] == nullptr) {
-                if (printinfo) std::cout << mpi::world_rank << " block does not exist yet  " << std::endl;
-                // the block does not exist yet, create it
-                Blockdata_struct *block = new Blockdata_struct;
-                nodeid2block[nodeid] = block;
-            }
-            if (orbid2block.count(orbid) == 0 or orbid2block[orbid] == nullptr) {
-                // the block does not exist yet, create it
-                Blockdata_struct *orbblock = new Blockdata_struct;
-                orbid2block[orbid] = orbblock;
-            }
-            // append the incoming data
-            Blockdata_struct *block = nodeid2block[nodeid];
-            block->id2data[orbid] = nodeid2block[nodeid]->data.size(); // internal index of the data in the block
-            double *data_p = new double[size];
-            this->currentsize += size / 128; // converted into kB
-            this->maxsize = std::max(this->currentsize, this->maxsize);
-            block->data.push_back(data_p);
-            block->deleted.push_back(false);
-            block->id.push_back(orbid);
-            block->N_rows.push_back(size);
-
-            Blockdata_struct *orbblock = orbid2block[orbid];
-            orbblock->id2data[nodeid] = orbblock->data.size(); // internal index of the data in the block
-            orbblock->data.push_back(data_p);
-            orbblock->deleted.push_back(false);
-            orbblock->id.push_back(nodeid);
-            orbblock->N_rows.push_back(size);
-
-            MPI_Recv(data_p, size, MPI_DOUBLE, status.MPI_SOURCE, status.MPI_TAG, mpi::comm_bank, &status);
-            if (printinfo)
-                std::cout << " written block " << nodeid << " id " << orbid << " subblocks "
-                          << nodeid2block[nodeid]->data.size() << std::endl;
-        }
-        if (message == SAVE_ORBITAL or message == SAVE_FUNCTION or message == SAVE_DATA) {
-            // make a new deposit
-            int exist_flag = 0;
-            if (id2ix[status.MPI_TAG]) {
-                std::cout << "WARNING: id " << status.MPI_TAG << " exists already"
-                          << " " << status.MPI_SOURCE << " " << message << " " << std::endl;
-                ix = id2ix[status.MPI_TAG]; // the deposit exist from before. Will be overwritten
-                exist_flag = 1;
-                if (message == SAVE_DATA and !deposits[ix].hasdata) {
-                    exist_flag = 0;
-                    deposits[ix].data = new double[datasize];
-                    deposits[ix].hasdata = true;
-                }
-            } else {
-                ix = deposits.size(); // NB: ix is now index of last element + 1
-                deposits.resize(ix + 1);
-                if (message == SAVE_ORBITAL or message == SAVE_FUNCTION) deposits[ix].orb = new Orbital(0);
-                if (message == SAVE_DATA) {
-                    deposits[ix].data = new double[datasize];
-                    deposits[ix].hasdata = true;
-                }
-            }
-            deposits[ix].id = status.MPI_TAG;
-            id2ix[deposits[ix].id] = ix;
-            deposits[ix].source = status.MPI_SOURCE;
-            if (message == SAVE_ORBITAL) {
-                mpi::recv_orbital(*deposits[ix].orb, deposits[ix].source, deposits[ix].id, mpi::comm_bank);
-                if (exist_flag == 0) {
-                    this->currentsize += deposits[ix].orb->getSizeNodes(NUMBER::Total);
-                    this->maxsize = std::max(this->currentsize, this->maxsize);
-                }
-            }
-            if (message == SAVE_FUNCTION) {
-                mpi::recv_function(*deposits[ix].orb, deposits[ix].source, deposits[ix].id, mpi::comm_bank);
-            }
-            if (message == SAVE_DATA) {
-                deposits[ix].datasize = datasize;
-                MPI_Recv(deposits[ix].data,
-                         datasize,
-                         MPI_DOUBLE,
-                         deposits[ix].source,
-                         deposits[ix].id,
-                         mpi::comm_bank,
-                         &status);
-                this->currentsize += datasize / 128; // converted into kB
-                this->maxsize = std::max(this->currentsize, this->maxsize);
-            }
-            if (id2qu[deposits[ix].id] != 0) {
-                // someone is waiting for those data. Send to them
-                int iq = id2qu[deposits[ix].id];
-                if (deposits[ix].id != queue[iq].id) std::cout << ix << " Bank queue accounting error " << std::endl;
-                for (int iqq : queue[iq].clients) {
-                    if (message == SAVE_ORBITAL) {
-                        mpi::send_orbital(*deposits[ix].orb, iqq, queue[iq].id, mpi::comm_bank);
-                    }
-                    if (message == SAVE_FUNCTION) {
-                        mpi::send_function(*deposits[ix].orb, iqq, queue[iq].id, mpi::comm_bank);
-                    }
-                    if (message == SAVE_DATA) {
-                        MPI_Send(deposits[ix].data, datasize, MPI_DOUBLE, iqq, queue[iq].id, mpi::comm_bank);
-                    }
-                }
-                queue[iq].clients.clear(); // cannot erase entire queue[iq], because that would require to shift all the
-                                           // id2qu value larger than iq
-                queue[iq].id = -1;
-                id2qu.erase(deposits[ix].id);
-            }
-        }
-        if (message == SET_DATASIZE) {
-            int datasize_new;
-            MPI_Recv(&datasize_new, 1, MPI_INT, status.MPI_SOURCE, status.MPI_TAG, mpi::comm_bank, &status);
-            if (datasize_new != datasize) {
-                // make sure that all old data arrays are deleted
-                for (int ix = 1; ix < deposits.size(); ix++) {
-                    if (deposits[ix].hasdata) {
-                        delete deposits[ix].data;
-                        deposits[ix].hasdata = false;
-                    }
-                }
-            }
-            datasize = datasize_new;
-        }
-    }
-#endif
-}
-
-// save orbital in Bank with identity id
-int Bank::put_orb(int id, Orbital &orb) {
-#ifdef MRCHEM_HAS_MPI
-    // for now we distribute according to id
-    if (id > id_shift) MSG_ABORT("Bank id must be less than max allowed tag / 2 ");
-    MPI_Send(&SAVE_ORBITAL, 1, MPI_INT, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-    mpi::send_orbital(orb, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-#endif
-    return 1;
-}
-
-// get orbital with identity id.
-// If wait=0, return immediately with value zero if not available (default)
-// else, wait until available
-int Bank::get_orb(int id, Orbital &orb, int wait) {
-#ifdef MRCHEM_HAS_MPI
-    MPI_Status status;
-    if (wait == 0) {
-        MPI_Send(&GET_ORBITAL, 1, MPI_INT, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-        int found;
-        MPI_Recv(&found, 1, MPI_INT, mpi::bankmaster[id % mpi::bank_size], 117, mpi::comm_bank, &status);
-        if (found != 0) {
-            mpi::recv_orbital(orb, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-            return 1;
-        } else {
-            return 0;
-        }
-    } else {
-        MPI_Send(&GET_ORBITAL_AND_WAIT, 1, MPI_INT, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-        mpi::recv_orbital(orb, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-    }
-#endif
-    return 1;
-}
-
-// get orbital with identity id, and delete from bank.
-// return immediately with value zero if not available
-int Bank::get_orb_del(int id, Orbital &orb) {
-#ifdef MRCHEM_HAS_MPI
-    MPI_Status status;
-    MPI_Send(&GET_ORBITAL_AND_DELETE, 1, MPI_INT, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-    int found;
-    MPI_Recv(&found, 1, MPI_INT, mpi::bankmaster[id % mpi::bank_size], 117, mpi::comm_bank, &status);
-    if (found != 0) {
-        mpi::recv_orbital(orb, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-        return 1;
-    } else {
-        return 0;
-    }
-#endif
-    return 1;
-}
-
-// save function in Bank with identity id
-int Bank::put_func(int id, QMFunction &func) {
-#ifdef MRCHEM_HAS_MPI
-    // for now we distribute according to id
-    id += id_shift;
-    MPI_Send(&SAVE_FUNCTION, 1, MPI_INT, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-    mpi::send_function(func, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-#endif
-    return 1;
-}
-
-// get function with identity id
-int Bank::get_func(int id, QMFunction &func) {
-#ifdef MRCHEM_HAS_MPI
-    MPI_Status status;
-    id += id_shift;
-    MPI_Send(&GET_FUNCTION, 1, MPI_INT, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-    mpi::recv_function(func, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-#endif
-    return 1;
-}
-
-// set the size of the data arrays (in size of doubles) to be sent/received later
-int Bank::set_datasize(int datasize) {
-#ifdef MRCHEM_HAS_MPI
-    for (int i = 0; i < mpi::bank_size; i++) {
-        MPI_Send(&SET_DATASIZE, 1, MPI_INT, mpi::bankmaster[i], 0, mpi::comm_bank);
-        MPI_Send(&datasize, 1, MPI_INT, mpi::bankmaster[i], 0, mpi::comm_bank);
-    }
-#endif
-    return 1;
-}
-
-// save data in Bank with identity id . datasize MUST have been set already. NB:not tested
-int Bank::put_data(int id, int size, double *data) {
-#ifdef MRCHEM_HAS_MPI
-    // for now we distribute according to id
-    id += id_shift;
-    MPI_Send(&SAVE_DATA, 1, MPI_INT, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-    MPI_Send(data, size, MPI_DOUBLE, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-#endif
-    return 1;
-}
-
-// get data with identity id
-int Bank::get_data(int id, int size, double *data) {
-#ifdef MRCHEM_HAS_MPI
-    MPI_Status status;
-    id += id_shift;
-    MPI_Send(&GET_DATA, 1, MPI_INT, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank);
-    MPI_Recv(data, size, MPI_DOUBLE, mpi::bankmaster[id % mpi::bank_size], id, mpi::comm_bank, &status);
-#endif
-    return 1;
-}
-
-// save data in Bank with identity id as part of block with identity nodeid.
-int Bank::put_nodedata(int id, int nodeid, int size, double *data) {
-#ifdef MRCHEM_HAS_MPI
-    // for now we distribute according to nodeid
-    metadata_block[0] = nodeid; // which block
-    metadata_block[1] = id;     // id within block
-    metadata_block[2] = size;   // size of this data
-    MPI_Send(&SAVE_NODEDATA, 1, MPI_INT, mpi::bankmaster[nodeid % mpi::bank_size], nodeid, mpi::comm_bank);
-    MPI_Send(metadata_block, size_metadata, MPI_INT, mpi::bankmaster[nodeid % mpi::bank_size], nodeid, mpi::comm_bank);
-    MPI_Send(data, size, MPI_DOUBLE, mpi::bankmaster[nodeid % mpi::bank_size], nodeid, mpi::comm_bank);
-#endif
-    return 1;
-}
-
-// get data with identity id
-int Bank::get_nodedata(int id, int nodeid, int size, double *data, std::vector<int> &idVec) {
-#ifdef MRCHEM_HAS_MPI
-    MPI_Status status;
-    // get the column with identity id
-    metadata_block[0] = nodeid; // which block
-    metadata_block[1] = id;     // id within block.
-    metadata_block[2] = size;   // expected size of data
-    MPI_Send(&GET_NODEDATA, 1, MPI_INT, mpi::bankmaster[nodeid % mpi::bank_size], nodeid, mpi::comm_bank);
-    MPI_Send(
-        metadata_block, size_metadata, MPI_INT, mpi::bankmaster[nodeid % mpi::bank_size], nodeid + 1, mpi::comm_bank);
-
-    MPI_Recv(data, size, MPI_DOUBLE, mpi::bankmaster[nodeid % mpi::bank_size], nodeid + 2, mpi::comm_bank, &status);
-#endif
-    return 1;
-}
-
-// get all data for nodeid
-int Bank::get_nodeblock(int nodeid, double *data, std::vector<int> &idVec) {
-#ifdef MRCHEM_HAS_MPI
-    MPI_Status status;
-    // get the entire superblock and also the id of each column
-    MPI_Send(&GET_NODEBLOCK, 1, MPI_INT, mpi::bankmaster[nodeid % mpi::bank_size], nodeid, mpi::comm_bank);
-    MPI_Recv(metadata_block,
-             size_metadata,
-             MPI_INT,
-             mpi::bankmaster[nodeid % mpi::bank_size],
-             nodeid,
-             mpi::comm_bank,
-             &status);
-    idVec.resize(metadata_block[1]);
-    int size = metadata_block[2];
-    if (size > 0)
-        MPI_Recv(idVec.data(),
-                 metadata_block[1],
-                 MPI_INT,
-                 mpi::bankmaster[nodeid % mpi::bank_size],
-                 nodeid + 1,
-                 mpi::comm_bank,
-                 &status);
-    if (size > 0)
-        MPI_Recv(data, size, MPI_DOUBLE, mpi::bankmaster[nodeid % mpi::bank_size], nodeid + 2, mpi::comm_bank, &status);
-#endif
-    return 1;
-}
-
-// get all data with identity orbid
-int Bank::get_orbblock(int orbid, double *&data, std::vector<int> &nodeidVec, int bankstart) {
-#ifdef MRCHEM_HAS_MPI
-    MPI_Status status;
-    int nodeid = mpi::orb_rank + bankstart;
-    // get the entire superblock and also the nodeid of each column
-    MPI_Send(&GET_ORBBLOCK, 1, MPI_INT, mpi::bankmaster[nodeid % mpi::bank_size], orbid, mpi::comm_bank);
-    MPI_Recv(metadata_block,
-             size_metadata,
-             MPI_INT,
-             mpi::bankmaster[nodeid % mpi::bank_size],
-             orbid,
-             mpi::comm_bank,
-             &status);
-    nodeidVec.resize(metadata_block[1]);
-    int totsize = metadata_block[2];
-    if (totsize > 0)
-        MPI_Recv(nodeidVec.data(),
-                 metadata_block[1],
-                 MPI_INT,
-                 mpi::bankmaster[nodeid % mpi::bank_size],
-                 orbid + 1,
-                 mpi::comm_bank,
-                 &status);
-    data = new double[totsize];
-    if (totsize > 0)
-        MPI_Recv(
-            data, totsize, MPI_DOUBLE, mpi::bankmaster[nodeid % mpi::bank_size], orbid + 2, mpi::comm_bank, &status);
-#endif
-    return 1;
-}
-
-// Ask to close the Bank
-void Bank::close() {
-#ifdef MRCHEM_HAS_MPI
-    for (int i = 0; i < mpi::bank_size; i++) {
-        MPI_Send(&CLOSE_BANK, 1, MPI_INT, mpi::bankmaster[i], 0, mpi::comm_bank);
-    }
-#endif
-}
-
-int Bank::get_maxtotalsize() {
-    int maxtot = 0;
-#ifdef MRCHEM_HAS_MPI
-    MPI_Status status;
-    int datasize;
-    for (int i = 0; i < mpi::bank_size; i++) {
-        MPI_Send(&GETMAXTOTDATA, 1, MPI_INT, mpi::bankmaster[i], 0, mpi::comm_bank);
-        MPI_Recv(&datasize, 1, MPI_INT, mpi::bankmaster[i], 1171, mpi::comm_bank, &status);
-        maxtot = std::max(maxtot, datasize);
-    }
-#endif
-    return maxtot;
-}
-
-std::vector<int> Bank::get_totalsize() {
-    std::vector<int> tot;
-#ifdef HAVE_MPI
-    MPI_Status status;
-    int datasize;
-    for (int i = 0; i < mpi::bank_size; i++) {
-        MPI_Send(&GETTOTDATA, 1, MPI_INT, mpi::bankmaster[i], 0, mpi::comm_bank);
-        MPI_Recv(&datasize, 1, MPI_INT, mpi::bankmaster[i], 1172, mpi::comm_bank, &status);
-        tot.push_back(datasize);
-    }
-#endif
-    return tot;
-}
-
-// remove all deposits
-// NB:: collective call. All clients must call this
-void Bank::clear_all(int iclient, MPI_Comm comm) {
-#ifdef MRCHEM_HAS_MPI
-    // 1) wait until all clients are ready
-    mpi::barrier(comm);
-    // master send signal to bank
-    if (iclient == 0) {
-        for (int i = 0; i < mpi::bank_size; i++) {
-            // should be made explicitely non-blocking
-            MPI_Send(&CLEAR_BANK, 1, MPI_INT, mpi::bankmaster[i], 0, mpi::comm_bank);
-        }
-        for (int i = 0; i < mpi::bank_size; i++) {
-            // wait until Bank is finished and has sent signal
-            MPI_Status status;
-            int message;
-            MPI_Recv(&message, 1, MPI_INT, mpi::bankmaster[i], 77, mpi::comm_bank, &status);
-        }
-    }
-    mpi::barrier(comm);
-#endif
-}
-
-// remove all blockdata with nodeid < nodeidmax
-// NB:: collective call. All clients must call this
-void Bank::clear_blockdata(int iclient, int nodeidmax, MPI_Comm comm) {
-#ifdef MRCHEM_HAS_MPI
-    // 1) wait until all clients are ready
-    mpi::barrier(comm);
-    // master send signal to bank
-    if (iclient == 0) {
-        for (int i = 0; i < mpi::bank_size; i++) {
-            MPI_Send(&CLEAR_BLOCKS, 1, MPI_INT, mpi::bankmaster[i], nodeidmax, mpi::comm_bank);
-        }
-        for (int i = 0; i < mpi::bank_size; i++) {
-            // wait until Bank is finished and has sent signal
-            MPI_Status status;
-            int message;
-            MPI_Recv(&message, 1, MPI_INT, mpi::bankmaster[i], 78, mpi::comm_bank, &status);
-        }
-    }
-    mpi::barrier(comm);
-#endif
-}
-
-void Bank::clear_bank() {
-#ifdef MRCHEM_HAS_MPI
-    for (int ix = 1; ix < this->deposits.size(); ix++) this->clear(ix);
-    this->deposits.resize(1);
-    this->queue.resize(1);
-    this->id2ix.clear();
-    this->id2qu.clear();
-    this->currentsize = 0;
-#endif
-}
-
-void Bank::clear(int ix) {
-#ifdef MRCHEM_HAS_MPI
-    if (deposits[ix].orb != nullptr) deposits[ix].orb->free(NUMBER::Total);
-    if (deposits[ix].hasdata) delete deposits[ix].data;
-    deposits[ix].hasdata = false;
 #endif
 }
 

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -47,7 +47,11 @@ namespace omp {
 extern int n_threads;
 } // namespace omp
 
+class CentralBank;
+extern CentralBank dataBank;
+
 namespace mpi {
+
 extern bool numerically_exact;
 extern int shared_memory_size;
 
@@ -61,6 +65,7 @@ extern int sh_group_rank;
 extern int is_bank;
 extern int is_bankclient;
 extern int bank_size;
+extern int max_tag;
 extern std::vector<int> bankmaster;
 
 extern MPI_Comm comm_orb;
@@ -101,81 +106,6 @@ void allreduce_matrix(IntMatrix &vec, MPI_Comm comm);
 void allreduce_matrix(DoubleMatrix &mat, MPI_Comm comm);
 void allreduce_matrix(ComplexMatrix &mat, MPI_Comm comm);
 
-} // namespace mpi
-
-namespace bank {
-
-struct deposit {
-    Orbital *orb;
-    double *data; // for pure data arrays
-    bool hasdata;
-    int datasize;
-    int id = -1; // to identify what is deposited
-    int source;  // mpi rank from the source of the data
-};
-
-struct queue_struct {
-    int id;
-    std::vector<int> clients;
-};
-
-} // namespace bank
-
-class Bank {
-public:
-    Bank() = default;
-    ~Bank();
-    void open();
-    void close();
-    void clear_all(int i = mpi::orb_rank, MPI_Comm comm = mpi::comm_orb);
-    void clear(int ix);
-    int put_orb(int id, Orbital &orb);
-    int get_orb(int id, Orbital &orb, int wait = 0);
-    int get_orb_del(int id, Orbital &orb);
-    int put_func(int id, QMFunction &func);
-    int get_func(int id, QMFunction &func);
-    int set_datasize(int datasize);
-    int put_data(int id, int size, double *data);
-    int get_data(int id, int size, double *data);
-    int put_nodedata(int id, int nodeid, int size, double *data);
-    int get_nodedata(int id, int nodeid, int size, double *data, std::vector<int> &idVec);
-    int get_nodeblock(int nodeid, double *data, std::vector<int> &idVec);
-    int get_orbblock(int orbid, double *&data, std::vector<int> &nodeidVec, int bankstart);
-    void clear_blockdata(int i = mpi::orb_rank, int nodeidmax = 0, MPI_Comm comm = mpi::comm_orb);
-    int get_maxtotalsize();
-    std::vector<int> get_totalsize();
-
-private:
-    int const CLOSE_BANK = 1;
-    int const CLEAR_BANK = 2;
-    int const GET_ORBITAL = 3;
-    int const GET_ORBITAL_AND_WAIT = 4;
-    int const GET_ORBITAL_AND_DELETE = 5;
-    int const SAVE_ORBITAL = 6;
-    int const GET_FUNCTION = 7;
-    int const SAVE_FUNCTION = 8;
-    int const SET_DATASIZE = 9;
-    int const GET_DATA = 10;
-    int const SAVE_DATA = 11;
-    int const SAVE_NODEDATA = 12;
-    int const GET_NODEDATA = 13;
-    int const GET_NODEBLOCK = 14;
-    int const GET_ORBBLOCK = 15;
-    int const CLEAR_BLOCKS = 16;
-    int const GETMAXTOTDATA = 17;
-    int const GETTOTDATA = 18;
-    std::map<int, int> id2ix;
-    std::vector<bank::deposit> deposits;
-    std::map<int, int> id2qu;
-    std::vector<bank::queue_struct> queue;
-    long long currentsize = 0; // total deposited data size (without containers)
-    long long maxsize = 0;     // max total deposited data size (without containers)
-
-    void clear_bank();
-};
-
-namespace mpi {
-extern Bank orb_bank;
 } // namespace mpi
 
 } // namespace mrchem

--- a/src/qmfunctions/OrbitalIterator.cpp
+++ b/src/qmfunctions/OrbitalIterator.cpp
@@ -1,5 +1,5 @@
 /*
- * MRChem, a numerical real-space code for molecular electronic structure
+ * Mrchem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
  * Copyright (C) 2020 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
@@ -28,6 +28,7 @@
 #include "Orbital.h"
 #include "OrbitalIterator.h"
 #include "parallel.h"
+#include "utils/Bank.h"
 
 namespace mrchem {
 
@@ -220,7 +221,7 @@ bool OrbitalIterator::bank_next(int max_recv) {
         for (int i = 0; i < this->orbitals->size(); i++) {
             Orbital &phi_i = (*this->orbitals)[i];
             if (not mpi::my_orb(phi_i)) continue;
-            mpi::orb_bank.put_orb(i, phi_i);
+            orbBank.put_orb(i, phi_i);
         }
     }
 
@@ -229,7 +230,7 @@ bool OrbitalIterator::bank_next(int max_recv) {
         int tag = i;
         int orb_ix = this->received_counter;
         Orbital &phi_i = (*this->orbitals)[orb_ix];
-        mpi::orb_bank.get_orb(orb_ix, phi_i);
+        orbBank.get_orb(orb_ix, phi_i);
         this->received_orbital_index.push_back(orb_ix);
         this->received_orbitals.push_back(phi_i);
         this->received_counter++; // total

--- a/src/qmfunctions/OrbitalIterator.h
+++ b/src/qmfunctions/OrbitalIterator.h
@@ -33,6 +33,7 @@ class OrbitalIterator final {
 public:
     OrbitalIterator(OrbitalVector &Phi, bool sym = false);
 
+    BankAccount orbBank;
     bool next(int max_recv = -1);
     bool bank_next(int max_recv = 1);
 

--- a/src/qmfunctions/orbital_utils.h
+++ b/src/qmfunctions/orbital_utils.h
@@ -27,6 +27,7 @@
 
 #include "mrchem.h"
 #include "qmfunction_fwd.h"
+#include "utils/Bank.h"
 
 namespace mrchem {
 namespace orbital {
@@ -55,7 +56,7 @@ OrbitalVector disjoin(OrbitalVector &Phi, int spin);
 void save_orbitals(OrbitalVector &Phi, const std::string &file, int spin = -1);
 OrbitalVector load_orbitals(const std::string &file, int n_orbs = -1);
 
-void save_nodes(OrbitalVector Phi, mrcpp::FunctionTree<3> &refTree, int shift = 0);
+void save_nodes(OrbitalVector Phi, mrcpp::FunctionTree<3> &refTree, BankAccount &nodes);
 
 void normalize(OrbitalVector &Phi);
 void orthogonalize(double prec, OrbitalVector &Phi);

--- a/src/qmoperators/two_electron/ExchangePotential.cpp
+++ b/src/qmoperators/two_electron/ExchangePotential.cpp
@@ -105,13 +105,8 @@ void ExchangePotential::setup(double prec) {
  */
 void ExchangePotential::clear() {
     clearInternal();
-    // clearBank();
+    clearBank();
     clearApplyPrec();
-}
-
-void ExchangePotential::clearBank() {
-    mpi::barrier(mpi::comm_orb);
-    if (mpi::bank_size > 0) mpi::orb_bank.clear_all(mpi::orb_rank, mpi::comm_orb);
 }
 
 /** @brief computes phi_k*Int(phi_i^dag*phi_j/|r-r'|)

--- a/src/qmoperators/two_electron/ExchangePotential.h
+++ b/src/qmoperators/two_electron/ExchangePotential.h
@@ -5,6 +5,7 @@
 #include "qmfunctions/Orbital.h"
 #include "qmfunctions/qmfunction_fwd.h"
 #include "qmoperators/QMOperator.h"
+#include "utils/Bank.h"
 
 namespace mrchem {
 
@@ -46,7 +47,7 @@ protected:
     void clear() override;
 
     virtual void setupBank() = 0;
-    void clearBank();
+    virtual void clearBank() {}
 
     virtual int testInternal(Orbital phi_p) const { return -1; }
     virtual void setupInternal(double prec) {}

--- a/src/qmoperators/two_electron/ExchangePotentialD1.h
+++ b/src/qmoperators/two_electron/ExchangePotentialD1.h
@@ -29,7 +29,9 @@ public:
     friend class ExchangeOperator;
 
 private:
+    BankAccount PhiBank; // to put the Orbitals
     void setupBank() override;
+    void clearBank();
     int testInternal(Orbital phi_p) const override;
     void setupInternal(double prec) override;
     Orbital calcExchange(Orbital phi_p);

--- a/src/qmoperators/two_electron/ExchangePotentialD2.cpp
+++ b/src/qmoperators/two_electron/ExchangePotentialD2.cpp
@@ -39,24 +39,32 @@ ExchangePotentialD2::ExchangePotentialD2(PoissonOperator_p P,
 void ExchangePotentialD2::setupBank() {
     if (mpi::bank_size < 1) return;
 
-    int id_shift = 10000;
-
     Timer timer;
     mpi::barrier(mpi::comm_orb);
     OrbitalVector &Phi = *this->orbitals;
     for (int i = 0; i < Phi.size(); i++) {
-        if (mpi::my_orb(Phi[i])) mpi::orb_bank.put_orb(i + id_shift, Phi[i]);
+        if (mpi::my_orb(Phi[i])) PhiBank.put_orb(i, Phi[i]);
     }
     OrbitalVector &X = *this->orbitals_x;
     for (int i = 0; i < X.size(); i++) {
-        if (mpi::my_orb(X[i])) mpi::orb_bank.put_orb(i + 2 * id_shift, X[i]);
+        if (mpi::my_orb(X[i])) XBank.put_orb(i, X[i]);
     }
     OrbitalVector &Y = *this->orbitals_y;
     for (int i = 0; i < Y.size(); i++) {
-        if (mpi::my_orb(Y[i])) mpi::orb_bank.put_orb(i + 3 * id_shift, Y[i]);
+        if (mpi::my_orb(Y[i])) YBank.put_orb(i, Y[i]);
     }
     mpi::barrier(mpi::comm_orb);
     mrcpp::print::time(4, "Setting up exchange bank", timer);
+}
+
+/** @brief Clears the Exchange Operator
+ *
+ *  Clears the orbital bank accounts.
+ */
+void ExchangePotentialD2::clearBank() {
+    PhiBank.clear();
+    XBank.clear();
+    YBank.clear();
 }
 
 /** @brief Apply exchange operator to given orbital
@@ -92,9 +100,9 @@ Orbital ExchangePotentialD2::apply(Orbital phi_p) {
         Orbital &x_i = X[i];
         Orbital &y_i = Y[i];
 
-        if (not mpi::my_orb(phi_i)) mpi::orb_bank.get_orb(i + id_shift, phi_i, 1);
-        if (not mpi::my_orb(x_i)) mpi::orb_bank.get_orb(i + 2 * id_shift, x_i, 1);
-        if (not mpi::my_orb(y_i)) mpi::orb_bank.get_orb(i + 3 * id_shift, y_i, 1);
+        if (not mpi::my_orb(phi_i)) PhiBank.get_orb(i + id_shift, phi_i, 1);
+        if (not mpi::my_orb(x_i)) PhiBank.get_orb(i + 2 * id_shift, x_i, 1);
+        if (not mpi::my_orb(y_i)) PhiBank.get_orb(i + 3 * id_shift, y_i, 1);
 
         double spin_fac = getSpinFactor(phi_i, phi_p);
         if (std::abs(spin_fac) >= mrcpp::MachineZero) {
@@ -153,9 +161,9 @@ Orbital ExchangePotentialD2::dagger(Orbital phi_p) {
         Orbital &x_i = X[i];
         Orbital &y_i = Y[i];
 
-        if (not mpi::my_orb(phi_i)) mpi::orb_bank.get_orb(i + id_shift, phi_i, 1);
-        if (not mpi::my_orb(x_i)) mpi::orb_bank.get_orb(i + 2 * id_shift, x_i, 1);
-        if (not mpi::my_orb(y_i)) mpi::orb_bank.get_orb(i + 3 * id_shift, y_i, 1);
+        if (not mpi::my_orb(phi_i)) PhiBank.get_orb(i + id_shift, phi_i, 1);
+        if (not mpi::my_orb(x_i)) PhiBank.get_orb(i + 2 * id_shift, x_i, 1);
+        if (not mpi::my_orb(y_i)) PhiBank.get_orb(i + 3 * id_shift, y_i, 1);
 
         double spin_fac = getSpinFactor(phi_i, phi_p);
         if (std::abs(spin_fac) >= mrcpp::MachineZero) {

--- a/src/qmoperators/two_electron/ExchangePotentialD2.h
+++ b/src/qmoperators/two_electron/ExchangePotentialD2.h
@@ -5,6 +5,7 @@
 #include "ExchangePotential.h"
 #include "qmfunctions/qmfunction_fwd.h"
 #include "qmoperators/QMOperator.h"
+#include "utils/Bank.h"
 
 namespace mrchem {
 
@@ -36,11 +37,15 @@ public:
     friend class ExchangeOperator;
 
 private:
+    BankAccount PhiBank; // to put the Orbitals
+    BankAccount XBank;
+    BankAccount YBank;
     bool useOnlyX;                             ///< true if X and Y are the same set of orbitals
     std::shared_ptr<OrbitalVector> orbitals_x; ///< first set of perturbed orbitals defining the exchange operator
     std::shared_ptr<OrbitalVector> orbitals_y; ///< second set of perturbed orbitals defining the exchange operator
 
     void setupBank() override;
+    void clearBank();
 
     Orbital apply(Orbital phi_p) override;
     Orbital dagger(Orbital phi_p) override;

--- a/src/scf_solver/GroundStateSolver.cpp
+++ b/src/scf_solver/GroundStateSolver.cpp
@@ -344,7 +344,6 @@ json GroundStateSolver::optimize(Molecule &mol, FockOperator &F) {
 
     F.clear();
     mpi::barrier(mpi::comm_orb);
-    if (mpi::bank_size > 0) mpi::orb_bank.clear_all(mpi::orb_rank, mpi::comm_orb);
 
     printConvergence(converged, "Total energy");
     reset();

--- a/src/scf_solver/SCFSolver.cpp
+++ b/src/scf_solver/SCFSolver.cpp
@@ -315,9 +315,9 @@ void SCFSolver::printMemory() const {
     if (mpi::bank_size > 0 and mpi::grand_master()) {
         if (mem_unit == "(GB)") {
             mrcpp::print::value(
-                1, "Maximum data in bank", (double)mpi::orb_bank.get_maxtotalsize() / 1024, mem_unit, 2, false);
+                1, "Maximum data in bank", (double)dataBank.get_maxtotalsize() / 1024, mem_unit, 2, false);
         } else {
-            mrcpp::print::value(1, "Maximum data in bank", (double)mpi::orb_bank.get_maxtotalsize(), "(MB)", 2, false);
+            mrcpp::print::value(1, "Maximum data in bank", (double)dataBank.get_maxtotalsize(), "(MB)", 2, false);
         }
     }
     mrcpp::print::separator(2, '=', 2);

--- a/src/utils/Bank.cpp
+++ b/src/utils/Bank.cpp
@@ -1,0 +1,879 @@
+#include <MRCPP/Printer>
+#include <MRCPP/Timer>
+
+#include "Bank.h"
+#include "qmfunctions/Orbital.h"
+
+namespace mrchem {
+
+using namespace Eigen;
+
+int metadata_block[3]; // can add more metadata in future
+int const size_metadata = 3;
+
+CentralBank::~CentralBank() {
+    // delete all data and accounts
+}
+
+struct Blockdata_struct {
+    std::vector<double *> data; // to store the incoming data
+    std::vector<bool> deleted;  // to indicate if it has been deleted already
+    MatrixXd BlockData;         // to put the final block
+    // eigen matrix are per default stored column-major (one can add columns at the end)
+    std::vector<int> N_rows;
+    std::map<int, int> id2data; // internal index of the data in the block
+    std::vector<int> id;        // the id of each column. Either nodeid, or orbid
+};
+std::map<int, std::map<int, Blockdata_struct *> *>
+    get_nodeid2block; // to get block from its nodeid (all coeff for one node)
+std::map<int, std::map<int, Blockdata_struct *> *> get_orbid2block; // to get block from its orbid
+
+void CentralBank::open() {
+#ifdef MRCHEM_HAS_MPI
+    MPI_Status status;
+    char safe_data1;
+    int deposit_size = sizeof(deposit);
+    int n_chunks, ix;
+    int messages[message_size];
+    int datasize = -1;
+    std::map<int, int> get_numberofclients;
+
+    bool printinfo = false;
+    int id_shift = max_tag / 2; // to ensure that nodes, orbitals and functions do not collide
+    int max_account_id = -1;
+    // The bank never goes out of this loop until it receives a close message!
+    while (true) {
+        MPI_Recv(&messages, message_size, MPI_INT, MPI_ANY_SOURCE, MPI_ANY_TAG, comm_bank, &status);
+        if (printinfo)
+            std::cout << world_rank << " got message " << messages[0] << " from " << status.MPI_SOURCE << " account "
+                      << messages[1] << std::endl;
+        int message = messages[0];
+        int account = messages[1];
+        if (message == NEW_ACCOUNT) {
+            // we just have to pick out a number that is not already assigned
+            account = (max_account_id + 1) % 1000000000;
+            while (get_deposits.count(account)) account = (account + 1) % 1000000000; // improbable this is used
+            max_account_id = account;
+            // create default content
+            get_deposits[account] = new std::vector<deposit>;
+            get_deposits[account]->resize(1);
+            get_id2ix[account] = new std::map<int, int>;
+            get_id2qu[account] = new std::map<int, int>;
+            get_queue[account] = new std::vector<queue_struct>;
+            get_queue[account]->resize(1);
+            get_orbid2block[account] = new std::map<int, Blockdata_struct *>;
+            get_nodeid2block[account] = new std::map<int, Blockdata_struct *>;
+            get_numberofclients[account] = messages[1];
+            currentsize[account] = 0;
+            MPI_Send(&account, 1, MPI_INT, status.MPI_SOURCE, 1, comm_bank);
+        }
+        std::vector<deposit> &deposits = *get_deposits[account];
+        std::map<int, int> &id2ix = *get_id2ix[account]; // gives zero if id is not defined
+        std::map<int, int> &id2qu = *get_id2qu[account];
+        std::vector<queue_struct> &queue = *get_queue[account];
+        std::map<int, Blockdata_struct *> &orbid2block = *get_orbid2block[account];
+        std::map<int, Blockdata_struct *> &nodeid2block = *get_nodeid2block[account];
+
+        if (message == CLOSE_ACCOUNT) {
+            get_numberofclients[account]--;
+            if (get_numberofclients[account] == 0) {
+                // all clients have closed the account. We remove the account.
+                totcurrentsize -= currentsize[account];
+                clear_account(account);
+            }
+        }
+
+        if (message == CLOSE_BANK) {
+            if (is_bank and printinfo) std::cout << "Bank is closing" << std::endl;
+            this->clear_bank();
+            break; // close bank, i.e stop listening for incoming messages
+        }
+        if (message == CLEAR_BANK) {
+            this->clear_bank();
+            for (auto const &block : nodeid2block) {
+                if (block.second == nullptr) continue;
+                for (int i = 0; i < block.second->data.size(); i++) {
+                    if (not block.second->deleted[i]) {
+                        currentsize[account] -= block.second->N_rows[i] / 128; // converted into kB
+                        totcurrentsize -= block.second->N_rows[i] / 128;       // converted into kB
+                        delete[] block.second->data[i];
+                    }
+                }
+                delete block.second;
+            }
+            nodeid2block.clear();
+            orbid2block.clear();
+            // send message that it is ready (value of message is not used)
+            MPI_Ssend(&message, 1, MPI_INT, status.MPI_SOURCE, 77, comm_bank);
+        }
+        if (message == CLEAR_BLOCKS) {
+            // clear only blocks whith id less than status.MPI_TAG.
+            std::vector<int> toeraseVec; // it is dangerous to erase an iterator within its own loop
+            for (auto const &block : nodeid2block) {
+                if (block.second == nullptr) toeraseVec.push_back(block.first);
+                if (block.second == nullptr) continue;
+                if (block.first >= status.MPI_TAG and status.MPI_TAG != 0) continue;
+                for (int i = 0; i < block.second->data.size(); i++) {
+                    if (not block.second->deleted[i]) {
+                        currentsize[account] -= block.second->N_rows[i] / 128; // converted into kB
+                        totcurrentsize -= block.second->N_rows[i] / 128;       // converted into kB
+                        delete[] block.second->data[i];
+                    }
+                }
+                currentsize[account] -= block.second->BlockData.size() / 128; // converted into kB
+                totcurrentsize -= block.second->BlockData.size() / 128;       // converted into kB
+                block.second->BlockData.resize(0, 0); // NB: the matrix does not clear itself otherwise
+                assert(currentsize[account] >= 0);
+                this->currentsize[account] = std::max(0ll, currentsize[account]);
+                toeraseVec.push_back(block.first);
+            }
+            for (int ierase : toeraseVec) { nodeid2block.erase(ierase); }
+            toeraseVec.clear();
+            std::vector<int> datatoeraseVec;
+            for (auto const &block : orbid2block) {
+                if (block.second == nullptr) toeraseVec.push_back(block.first);
+                if (block.second == nullptr) continue;
+                datatoeraseVec.clear();
+                for (int i = 0; i < block.second->data.size(); i++) {
+                    if (block.second->id[i] < status.MPI_TAG or status.MPI_TAG == 0) datatoeraseVec.push_back(i);
+                    if (block.second->id[i] < status.MPI_TAG or status.MPI_TAG == 0) block.second->data[i] = nullptr;
+                }
+                std::sort(datatoeraseVec.begin(), datatoeraseVec.end());
+                std::reverse(datatoeraseVec.begin(), datatoeraseVec.end());
+                for (int ierase : datatoeraseVec) {
+                    block.second->id.erase(block.second->id.begin() + ierase);
+                    block.second->data.erase(block.second->data.begin() + ierase);
+                    block.second->N_rows.erase(block.second->N_rows.begin() + ierase);
+                }
+                if (block.second->data.size() == 0) toeraseVec.push_back(block.first);
+            }
+            for (int ierase : toeraseVec) { orbid2block.erase(ierase); }
+
+            if (status.MPI_TAG == 0) orbid2block.clear();
+            // could have own clear for data?
+            for (int ix = 1; ix < deposits.size(); ix++) {
+                if (deposits[ix].id >= id_shift) {
+                    if (deposits[ix].hasdata) delete deposits[ix].data;
+                    if (deposits[ix].hasdata) id2ix[deposits[ix].id] = 0; // indicate that it does not exist
+                    deposits[ix].hasdata = false;
+                }
+            }
+            // send message that it is ready (value of message is not used)
+            MPI_Ssend(&message, 1, MPI_INT, status.MPI_SOURCE, 78, comm_bank);
+        }
+        if (message == GETMAXTOTDATA) {
+            int maxsize_int = maxsize / 1024; // convert into MB
+            MPI_Send(&maxsize_int, 1, MPI_INT, status.MPI_SOURCE, 1171, comm_bank);
+        }
+        if (message == GETTOTDATA) {
+            int maxsize_int = totcurrentsize / 1024; // convert into MB
+            MPI_Send(&maxsize_int, 1, MPI_INT, status.MPI_SOURCE, 1172, comm_bank);
+        }
+
+        if (message == GET_NODEDATA or message == GET_NODEBLOCK) {
+            // NB: has no queue system yet
+            int nodeid = status.MPI_TAG; // which block to fetch from
+            if (nodeid2block.count(nodeid) and nodeid2block[nodeid] != nullptr) {
+                Blockdata_struct *block = nodeid2block[nodeid];
+                int dataindex = 0; // internal index of the data in the block
+                int size = 0;
+                if (message == GET_NODEDATA) {
+                    int orbid = messages[3];           // which part of the block to fetch
+                    dataindex = block->id2data[orbid]; // column of the data in the block
+                    size = block->N_rows[dataindex];   // number of doubles to fetch
+                    if (size != messages[4]) std::cout << "ERROR nodedata has wrong size" << std::endl;
+                } else {
+                    // send entire block. First make one contiguous superblock
+                    // Prepare the data as one contiguous block
+                    if (block->data.size() == 0)
+                        std::cout << "Zero size blockdata! " << nodeid << " " << block->N_rows.size() << std::endl;
+                    block->BlockData.resize(block->N_rows[0], block->data.size());
+                    size = block->N_rows[0] * block->data.size();
+                    if (printinfo)
+                        std::cout << " rewrite into superblock " << block->data.size() << " " << block->N_rows[0]
+                                  << " tag " << status.MPI_TAG << std::endl;
+                    for (int j = 0; j < block->data.size(); j++) {
+                        for (int i = 0; i < block->N_rows[j]; i++) { block->BlockData(i, j) = block->data[j][i]; }
+                    }
+                    // repoint to the data in BlockData
+                    for (int j = 0; j < block->data.size(); j++) {
+                        if (block->deleted[j] == true) std::cout << "ERROR data already deleted " << std::endl;
+                        assert(block->deleted[j] == false);
+                        delete[] block->data[j];
+                        block->deleted[j] = true;
+                        block->data[j] = block->BlockData.col(j).data();
+                    }
+                    dataindex = 0; // start from first column
+                    // send info about the size of the superblock
+                    metadata_block[0] = status.MPI_TAG;     // nodeid
+                    metadata_block[1] = block->data.size(); // number of columns
+                    metadata_block[2] = size;               // total size = rows*columns
+                    MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, nodeid, comm_bank);
+                    // send info about the id of each column
+                    MPI_Send(block->id.data(), metadata_block[1], MPI_INT, status.MPI_SOURCE, nodeid + 1, comm_bank);
+                }
+                double *data_p = block->data[dataindex];
+                if (size > 0) MPI_Send(data_p, size, MPI_DOUBLE, status.MPI_SOURCE, nodeid + 2, comm_bank);
+            } else {
+                if (printinfo) std::cout << " block " << nodeid << " does not exist " << std::endl;
+                // Block with this id does not exist.
+                if (message == GET_NODEDATA) {
+                    int size = messages[4]; // number of doubles to send
+                    if (size == 0) {
+                        std::cout << "WARNING: GET_NODEDATA asks for zero size data" << std::endl;
+                        metadata_block[2] = size;
+                        MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, nodeid, comm_bank);
+                    } else {
+                        std::vector<double> zero(size, 0.0); // send zeroes
+                        MPI_Ssend(zero.data(), size, MPI_DOUBLE, status.MPI_SOURCE, nodeid + 2, comm_bank);
+                    }
+                } else {
+                    metadata_block[0] = status.MPI_TAG; // nodeid
+                    metadata_block[1] = 0;              // number of columns
+                    metadata_block[2] = 0;              // total size = rows*columns
+                    MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, metadata_block[0], comm_bank);
+                }
+            }
+        }
+        if (message == GET_ORBBLOCK) {
+            // NB: BLOCKDATA has no queue system yet
+            int orbid = status.MPI_TAG; // which block to fetch from
+
+            if (orbid2block.count(orbid) and orbid2block[orbid] != nullptr) {
+                Blockdata_struct *block = orbid2block[orbid];
+                int dataindex = 0; // internal index of the data in the block
+                int size = 0;
+                // send entire block. First make one contiguous superblock
+                // Prepare the data as one contiguous block
+                if (block->data.size() == 0)
+                    std::cout << "Zero size blockdata! C " << orbid << " " << block->N_rows.size() << std::endl;
+                size = 0;
+                for (int j = 0; j < block->data.size(); j++) size += block->N_rows[j];
+
+                std::vector<double> coeff(size);
+                int ij = 0;
+                for (int j = 0; j < block->data.size(); j++) {
+                    for (int i = 0; i < block->N_rows[j]; i++) { coeff[ij++] = block->data[j][i]; }
+                }
+                // send info about the size of the superblock
+                metadata_block[0] = orbid;
+                metadata_block[1] = block->data.size(); // number of columns
+                metadata_block[2] = size;               // total size = rows*columns
+                MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, orbid, comm_bank);
+                MPI_Send(block->id.data(), metadata_block[1], MPI_INT, status.MPI_SOURCE, orbid + 1, comm_bank);
+                MPI_Send(coeff.data(), size, MPI_DOUBLE, status.MPI_SOURCE, orbid + 2, comm_bank);
+            } else {
+                // it is possible and allowed that the block has not been written
+                if (printinfo)
+                    std::cout << " block does not exist " << orbid << " " << orbid2block.count(orbid) << std::endl;
+                // Block with this id does not exist.
+                metadata_block[0] = orbid;
+                metadata_block[1] = 0; // number of columns
+                metadata_block[2] = 0; // total size = rows*columns
+                MPI_Send(metadata_block, size_metadata, MPI_INT, status.MPI_SOURCE, orbid, comm_bank);
+            }
+        }
+
+        if (message == GET_ORBITAL or message == GET_ORBITAL_AND_WAIT or message == GET_ORBITAL_AND_DELETE or
+            message == GET_FUNCTION or message == GET_DATA) {
+            // withdrawal
+            int ix = id2ix[status.MPI_TAG];
+            if (id2ix.count(status.MPI_TAG) == 0 or ix == 0) {
+                if (printinfo)
+                    std::cout << world_rank << " not found " << status.MPI_TAG << " " << message << std::endl;
+                if (message == GET_ORBITAL or message == GET_ORBITAL_AND_DELETE) {
+                    // do not wait for the orbital to arrive
+                    int found = 0;
+                    if (printinfo) std::cout << world_rank << " sending found 0 to " << status.MPI_SOURCE << std::endl;
+                    MPI_Send(&found, 1, MPI_INT, status.MPI_SOURCE, 117, comm_bank);
+                } else {
+                    // the id does not exist. Put in queue and Wait until it is defined
+                    if (printinfo) std::cout << world_rank << " queuing " << status.MPI_TAG << std::endl;
+                    if (id2qu[status.MPI_TAG] == 0) {
+                        queue.push_back({status.MPI_TAG, {status.MPI_SOURCE}});
+                        id2qu[status.MPI_TAG] = queue.size() - 1;
+                    } else {
+                        // somebody is already waiting for this id. queue in queue
+                        queue[id2qu[status.MPI_TAG]].clients.push_back(status.MPI_SOURCE);
+                    }
+                }
+            } else {
+                int ix = id2ix[status.MPI_TAG];
+                if (deposits[ix].id != status.MPI_TAG) std::cout << ix << " Bank accounting error " << std::endl;
+                if (message == GET_ORBITAL or message == GET_ORBITAL_AND_WAIT or message == GET_ORBITAL_AND_DELETE) {
+                    if (message == GET_ORBITAL or message == GET_ORBITAL_AND_DELETE) {
+                        int found = 1;
+                        MPI_Send(&found, 1, MPI_INT, status.MPI_SOURCE, 117, comm_bank);
+                    }
+                    send_orbital(*deposits[ix].orb, status.MPI_SOURCE, deposits[ix].id, comm_bank);
+                    if (message == GET_ORBITAL_AND_DELETE) {
+                        currentsize[account] -= deposits[ix].orb->getSizeNodes(NUMBER::Total);
+                        totcurrentsize -= deposits[ix].orb->getSizeNodes(NUMBER::Total);
+                        deposits[ix].orb->free(NUMBER::Total);
+                        id2ix[status.MPI_TAG] = 0;
+                    }
+                }
+                if (message == GET_FUNCTION) {
+                    send_function(*deposits[ix].orb, status.MPI_SOURCE, deposits[ix].id, comm_bank);
+                }
+                if (message == GET_DATA) {
+                    MPI_Send(deposits[ix].data,
+                             deposits[ix].datasize,
+                             MPI_DOUBLE,
+                             status.MPI_SOURCE,
+                             deposits[ix].id,
+                             comm_bank);
+                }
+            }
+        }
+        if (message == SAVE_NODEDATA) {
+            int nodeid = messages[2]; // which block to write (should = status.MPI_TAG)
+            int orbid = messages[3];  // which part of the block
+            int size = messages[4];   // number of doubles
+
+            // test if the block exists already
+            if (printinfo) std::cout << world_rank << " save data nodeid " << nodeid << " size " << size << std::endl;
+            if (nodeid2block.count(nodeid) == 0 or nodeid2block[nodeid] == nullptr) {
+                if (printinfo) std::cout << world_rank << " block does not exist yet  " << std::endl;
+                // the block does not exist yet, create it
+                Blockdata_struct *block = new Blockdata_struct;
+                nodeid2block[nodeid] = block;
+            }
+            if (orbid2block.count(orbid) == 0 or orbid2block[orbid] == nullptr) {
+                // the block does not exist yet, create it
+                Blockdata_struct *orbblock = new Blockdata_struct;
+                orbid2block[orbid] = orbblock;
+            }
+            // append the incoming data
+            Blockdata_struct *block = nodeid2block[nodeid];
+            block->id2data[orbid] = nodeid2block[nodeid]->data.size(); // internal index of the data in the block
+            double *data_p = new double[size];
+            currentsize[account] += size / 128; // converted into kB
+            totcurrentsize += size / 128;       // converted into kB
+            this->maxsize = std::max(totcurrentsize, this->maxsize);
+            block->data.push_back(data_p);
+            block->deleted.push_back(false);
+            block->id.push_back(orbid);
+            block->N_rows.push_back(size);
+
+            Blockdata_struct *orbblock = orbid2block[orbid];
+            orbblock->id2data[nodeid] = orbblock->data.size(); // internal index of the data in the block
+            orbblock->data.push_back(data_p);
+            orbblock->deleted.push_back(false);
+            orbblock->id.push_back(nodeid);
+            orbblock->N_rows.push_back(size);
+
+            MPI_Recv(data_p, size, MPI_DOUBLE, status.MPI_SOURCE, status.MPI_TAG, comm_bank, &status);
+            if (printinfo)
+                std::cout << " written block " << nodeid << " id " << orbid << " subblocks "
+                          << nodeid2block[nodeid]->data.size() << std::endl;
+        }
+        if (message == SAVE_ORBITAL or message == SAVE_FUNCTION or message == SAVE_DATA) {
+            // make a new deposit
+            int exist_flag = 0;
+            if (id2ix[status.MPI_TAG]) {
+                std::cout << "WARNING: id " << status.MPI_TAG << " exists already"
+                          << " " << status.MPI_SOURCE << " " << message << " " << std::endl;
+                ix = id2ix[status.MPI_TAG]; // the deposit exist from before. Will be overwritten
+                exist_flag = 1;
+                if (message == SAVE_DATA and !deposits[ix].hasdata) {
+                    exist_flag = 0;
+                    deposits[ix].data = new double[datasize];
+                    deposits[ix].hasdata = true;
+                }
+            } else {
+                ix = deposits.size(); // NB: ix is now index of last element + 1
+                deposits.resize(ix + 1);
+                if (message == SAVE_ORBITAL or message == SAVE_FUNCTION) deposits[ix].orb = new Orbital(0);
+                if (message == SAVE_DATA) {
+                    deposits[ix].data = new double[datasize];
+                    deposits[ix].hasdata = true;
+                }
+            }
+            deposits[ix].id = status.MPI_TAG;
+            id2ix[deposits[ix].id] = ix;
+            deposits[ix].source = status.MPI_SOURCE;
+            if (message == SAVE_ORBITAL) {
+                recv_orbital(*deposits[ix].orb, deposits[ix].source, deposits[ix].id, comm_bank);
+                if (exist_flag == 0) {
+                    currentsize[account] += deposits[ix].orb->getSizeNodes(NUMBER::Total);
+                    totcurrentsize += deposits[ix].orb->getSizeNodes(NUMBER::Total);
+                    this->maxsize = std::max(totcurrentsize, this->maxsize);
+                }
+            }
+            if (message == SAVE_FUNCTION) {
+                recv_function(*deposits[ix].orb, deposits[ix].source, deposits[ix].id, comm_bank);
+            }
+            if (message == SAVE_DATA) {
+                deposits[ix].datasize = datasize;
+                MPI_Recv(
+                    deposits[ix].data, datasize, MPI_DOUBLE, deposits[ix].source, deposits[ix].id, comm_bank, &status);
+                currentsize[account] += datasize / 128; // converted into kB
+                totcurrentsize += datasize / 128;       // converted into kB
+                this->maxsize = std::max(totcurrentsize, this->maxsize);
+            }
+            if (id2qu[deposits[ix].id] != 0) {
+                // someone is waiting for those data. Send to them
+                int iq = id2qu[deposits[ix].id];
+                if (deposits[ix].id != queue[iq].id) std::cout << ix << " Bank queue accounting error " << std::endl;
+                for (int iqq : queue[iq].clients) {
+                    if (message == SAVE_ORBITAL) { send_orbital(*deposits[ix].orb, iqq, queue[iq].id, comm_bank); }
+                    if (message == SAVE_FUNCTION) { send_function(*deposits[ix].orb, iqq, queue[iq].id, comm_bank); }
+                    if (message == SAVE_DATA) {
+                        MPI_Send(deposits[ix].data, datasize, MPI_DOUBLE, iqq, queue[iq].id, comm_bank);
+                    }
+                }
+                queue[iq].clients.clear(); // cannot erase entire queue[iq], because that would require to shift all the
+                                           // id2qu value larger than iq
+                queue[iq].id = -1;
+                id2qu.erase(deposits[ix].id);
+            }
+        }
+        if (message == SET_DATASIZE) {
+            int datasize_new = messages[2];
+            if (datasize_new != datasize) {
+                // make sure that all old data arrays are deleted
+                for (int ix = 1; ix < deposits.size(); ix++) {
+                    if (deposits[ix].hasdata) {
+                        delete deposits[ix].data;
+                        deposits[ix].hasdata = false;
+                    }
+                }
+            }
+            datasize = datasize_new;
+        }
+    }
+#endif
+}
+
+// Ask to close the Bank
+void CentralBank::close() {
+#ifdef MRCHEM_HAS_MPI
+    for (int i = 0; i < bank_size; i++) { MPI_Send(&CLOSE_BANK, 1, MPI_INT, bankmaster[i], 0, comm_bank); }
+#endif
+}
+
+void CentralBank::clear_bank() {
+#ifdef MRCHEM_HAS_MPI
+    for (auto account : accounts) { clear_account(account); }
+#endif
+}
+
+int CentralBank::clearAccount(int account, int iclient, MPI_Comm comm) {
+#ifdef MRCHEM_HAS_MPI
+    closeAccount(account);
+    return openAccount(iclient, comm);
+#else
+    return 1;
+#endif
+}
+void CentralBank::clear_account(int account) {
+#ifdef MRCHEM_HAS_MPI
+    std::vector<deposit> &deposits = *get_deposits[account];
+    for (int ix = 1; ix < deposits.size(); ix++) {
+        if (deposits[ix].orb != nullptr) deposits[ix].orb->free(NUMBER::Total);
+        if (deposits[ix].hasdata) delete deposits[ix].data;
+        deposits[ix].hasdata = false;
+    }
+    deposits.clear();
+    delete get_queue[account];
+    get_queue.erase(account);
+    delete get_id2ix[account];
+    delete get_id2qu[account];
+    get_id2ix.erase(account);
+    get_id2qu.erase(account);
+    get_deposits.erase(account);
+    currentsize.erase(account);
+
+    std::map<int, Blockdata_struct *> &nodeid2block = *get_nodeid2block[account];
+    std::map<int, Blockdata_struct *> &orbid2block = *get_orbid2block[account];
+
+    std::vector<int> toeraseVec; // it is dangerous to erase an iterator within its own loop
+    for (auto const &block : nodeid2block) {
+        if (block.second == nullptr) toeraseVec.push_back(block.first);
+        if (block.second == nullptr) continue;
+        for (int i = 0; i < block.second->data.size(); i++) {
+            if (not block.second->deleted[i]) {
+                currentsize[account] -= block.second->N_rows[i] / 128; // converted into kB
+                totcurrentsize -= block.second->N_rows[i] / 128;       // converted into kB
+                delete[] block.second->data[i];
+            }
+        }
+        currentsize[account] -= block.second->BlockData.size() / 128; // converted into kB
+        totcurrentsize -= block.second->BlockData.size() / 128;       // converted into kB
+        block.second->BlockData.resize(0, 0);                         // NB: the matrix does not clear itself otherwise
+        assert(currentsize[account] >= 0);
+        toeraseVec.push_back(block.first);
+    }
+    for (int ierase : toeraseVec) { nodeid2block.erase(ierase); }
+    toeraseVec.clear();
+    std::vector<int> datatoeraseVec; // it is dangerous to erase an iterator within its own loop
+    for (auto const &block : orbid2block) {
+        if (block.second == nullptr) toeraseVec.push_back(block.first);
+        if (block.second == nullptr) continue;
+        datatoeraseVec.clear();
+        for (int i = 0; i < block.second->data.size(); i++) {
+            datatoeraseVec.push_back(i);
+            block.second->data[i] = nullptr;
+        }
+        std::sort(datatoeraseVec.begin(), datatoeraseVec.end());
+        std::reverse(datatoeraseVec.begin(), datatoeraseVec.end());
+        for (int ierase : datatoeraseVec) {
+            block.second->id.erase(block.second->id.begin() + ierase);
+            block.second->data.erase(block.second->data.begin() + ierase);
+            block.second->N_rows.erase(block.second->N_rows.begin() + ierase);
+        }
+        if (block.second->data.size() == 0) toeraseVec.push_back(block.first);
+    }
+    for (int ierase : toeraseVec) { orbid2block.erase(ierase); }
+
+    orbid2block.clear();
+    for (int ix = 1; ix < deposits.size(); ix++) {
+        if (deposits[ix].id >= max_tag / 2) {
+            if (deposits[ix].hasdata) delete deposits[ix].data;
+            if (deposits[ix].hasdata) (*get_id2ix[account])[deposits[ix].id] = 0; // indicate that it does not exist
+            deposits[ix].hasdata = false;
+        }
+    }
+    delete get_nodeid2block[account];
+    delete get_orbid2block[account];
+    get_nodeid2block.erase(account);
+    get_orbid2block.erase(account);
+
+#endif
+}
+
+int CentralBank::openAccount(int iclient, MPI_Comm comm) {
+// NB: this is a collective call, since we need all the accounts to be synchronized
+    int account_id = -1;
+#ifdef MRCHEM_HAS_MPI
+    MPI_Status status;
+    int messages[message_size];
+    messages[0] = NEW_ACCOUNT;
+    int size;
+    MPI_Comm_size(comm, &size);
+    messages[1] = size;
+    if (iclient == 0) {
+        for (int i = 0; i < bank_size; i++) {
+            int account_id_i;
+            MPI_Send(messages, message_size, MPI_INT, bankmaster[i], 0, comm_bank);
+            MPI_Recv(&account_id_i, 1, MPI_INT, bankmaster[i], 1, comm_bank, &status);
+            if (i > 0 and account_id_i != account_id) MSG_ABORT("Account id mismatch!");
+            account_id = account_id_i;
+        }
+        MPI_Bcast(&account_id, 1, MPI_INT, 0, comm);
+    } else {
+        MPI_Bcast(&account_id, 1, MPI_INT, 0, comm);
+    }
+#endif
+    return account_id;
+}
+
+void CentralBank::closeAccount(int account_id) {
+// The account will in reality not be removed before everybody has sent a close message
+#ifdef MRCHEM_HAS_MPI
+    MPI_Status status;
+    int messages[message_size];
+    messages[0] = CLOSE_ACCOUNT;
+    messages[1] = account_id;
+    for (int i = 0; i < bank_size; i++) { MPI_Send(messages, message_size, MPI_INT, bankmaster[i], 0, comm_bank); }
+#endif
+}
+
+int CentralBank::get_maxtotalsize() {
+    int maxtot = 0;
+#ifdef MRCHEM_HAS_MPI
+    MPI_Status status;
+    int datasize;
+    for (int i = 0; i < bank_size; i++) {
+        MPI_Send(&GETMAXTOTDATA, 1, MPI_INT, bankmaster[i], 0, comm_bank);
+        MPI_Recv(&datasize, 1, MPI_INT, bankmaster[i], 1171, comm_bank, &status);
+        maxtot = std::max(maxtot, datasize);
+    }
+#endif
+    return maxtot;
+}
+
+std::vector<int> CentralBank::get_totalsize() {
+    std::vector<int> tot;
+#ifdef HAVE_MPI
+    MPI_Status status;
+    int datasize;
+    for (int i = 0; i < bank_size; i++) {
+        MPI_Send(&GETTOTDATA, 1, MPI_INT, bankmaster[i], 0, comm_bank);
+        MPI_Recv(&datasize, 1, MPI_INT, bankmaster[i], 1172, comm_bank, &status);
+        tot.push_back(datasize);
+    }
+#endif
+    return tot;
+}
+
+// Accounts: (clients)
+
+// save orbital in Bank with identity id
+int BankAccount::put_orb(int id, Orbital &orb) {
+#ifdef MRCHEM_HAS_MPI
+    // for now we distribute according to id
+    if (id > max_tag) MSG_ABORT("Bank id must be less than max allowed tag ");
+    int messages[message_size];
+    messages[0] = SAVE_ORBITAL;
+    messages[1] = account_id;
+    MPI_Send(messages, message_size, MPI_INT, bankmaster[id % bank_size], id, comm_bank);
+    send_orbital(orb, bankmaster[id % bank_size], id, comm_bank);
+#endif
+    return 1;
+}
+
+// get orbital with identity id.
+// If wait=0, return immediately with value zero if not available (default)
+// else, wait until available
+int BankAccount::get_orb(int id, Orbital &orb, int wait) {
+#ifdef MRCHEM_HAS_MPI
+    MPI_Status status;
+    int messages[message_size];
+    messages[1] = account_id;
+    if (wait == 0) {
+        messages[0] = GET_ORBITAL;
+        MPI_Send(messages, message_size, MPI_INT, bankmaster[id % bank_size], id, comm_bank);
+        int found;
+        MPI_Recv(&found, 1, MPI_INT, bankmaster[id % bank_size], 117, comm_bank, &status);
+        if (found != 0) {
+            recv_orbital(orb, bankmaster[id % bank_size], id, comm_bank);
+            return 1;
+        } else {
+            return 0;
+        }
+    } else {
+        messages[0] = GET_ORBITAL_AND_WAIT;
+        MPI_Send(messages, message_size, MPI_INT, bankmaster[id % bank_size], id, comm_bank);
+        recv_orbital(orb, bankmaster[id % bank_size], id, comm_bank);
+    }
+#endif
+    return 1;
+}
+
+// get orbital with identity id, and delete from bank.
+// return immediately with value zero if not available
+int BankAccount::get_orb_del(int id, Orbital &orb) {
+#ifdef MRCHEM_HAS_MPI
+    MPI_Status status;
+    int messages[message_size];
+    messages[0] = GET_ORBITAL_AND_DELETE;
+    messages[1] = account_id;
+    MPI_Send(messages, message_size, MPI_INT, bankmaster[id % bank_size], id, comm_bank);
+    int found;
+    MPI_Recv(&found, 1, MPI_INT, bankmaster[id % bank_size], 117, comm_bank, &status);
+    if (found != 0) {
+        recv_orbital(orb, bankmaster[id % bank_size], id, comm_bank);
+        return 1;
+    } else {
+        return 0;
+    }
+#endif
+    return 1;
+}
+
+// save function in Bank with identity id
+int BankAccount::put_func(int id, QMFunction &func) {
+#ifdef MRCHEM_HAS_MPI
+    // for now we distribute according to id
+    if (id > max_tag / 2) MSG_ABORT("Bank id must be less than max allowed tag / 2");
+    id += max_tag / 2;
+    int messages[message_size];
+    messages[0] = SAVE_FUNCTION;
+    messages[1] = account_id;
+    MPI_Send(messages, message_size, MPI_INT, bankmaster[id % bank_size], id, comm_bank);
+    send_function(func, bankmaster[id % bank_size], id, comm_bank);
+#endif
+    return 1;
+}
+
+// get function with identity id
+int BankAccount::get_func(int id, QMFunction &func) {
+#ifdef MRCHEM_HAS_MPI
+    MPI_Status status;
+    id += max_tag / 2;
+    int messages[message_size];
+    messages[0] = GET_FUNCTION;
+    messages[1] = account_id;
+    MPI_Send(messages, message_size, MPI_INT, bankmaster[id % bank_size], id, comm_bank);
+    recv_function(func, bankmaster[id % bank_size], id, comm_bank);
+#endif
+    return 1;
+}
+
+// set the size of the data arrays (in size of doubles) to be sent/received later
+void BankAccount::set_datasize(int datasize, int iclient, MPI_Comm comm) {
+#ifdef MRCHEM_HAS_MPI
+    if (iclient == 0) {
+        for (int i = 0; i < bank_size; i++) {
+            int messages[message_size];
+            messages[0] = SET_DATASIZE;
+            messages[1] = account_id;
+            messages[2] = datasize;
+            MPI_Send(messages, message_size, MPI_INT, bankmaster[i], 0, comm_bank);
+        }
+    }
+    MPI_Barrier(comm);
+#endif
+}
+
+// save data in Bank with identity id . datasize MUST have been set already. NB:not tested
+int BankAccount::put_data(int id, int size, double *data) {
+#ifdef MRCHEM_HAS_MPI
+    // for now we distribute according to id
+    if (id > max_tag) MSG_ABORT("Bank id must be less than max allowed tag");
+    int messages[message_size];
+    messages[0] = SAVE_DATA;
+    messages[1] = account_id;
+    MPI_Send(messages, message_size, MPI_INT, bankmaster[id % bank_size], id, comm_bank);
+    MPI_Send(data, size, MPI_DOUBLE, bankmaster[id % bank_size], id, comm_bank);
+#endif
+    return 1;
+}
+
+// get data with identity id
+int BankAccount::get_data(int id, int size, double *data) {
+#ifdef MRCHEM_HAS_MPI
+    MPI_Status status;
+    int messages[message_size];
+    messages[0] = GET_DATA;
+    messages[1] = account_id;
+    MPI_Send(messages, message_size, MPI_INT, bankmaster[id % bank_size], id, comm_bank);
+    MPI_Recv(data, size, MPI_DOUBLE, bankmaster[id % bank_size], id, comm_bank, &status);
+#endif
+    return 1;
+}
+
+// save data in Bank with identity id as part of block with identity nodeid.
+int BankAccount::put_nodedata(int id, int nodeid, int size, double *data) {
+#ifdef MRCHEM_HAS_MPI
+    // for now we distribute according to nodeid
+    if (id > max_tag) MSG_ABORT("Bank id must be less than max allowed tag");
+    metadata_block[0] = nodeid; // which block
+    metadata_block[1] = id;     // id within block
+    metadata_block[2] = size;   // size of this data
+    int messages[message_size];
+    messages[0] = SAVE_NODEDATA;
+    messages[1] = account_id;
+    messages[2] = nodeid; // which block
+    messages[3] = id;     // id within block
+    messages[4] = size;   // size of this data
+    MPI_Send(messages, message_size, MPI_INT, bankmaster[nodeid % bank_size], nodeid, comm_bank);
+    MPI_Send(data, size, MPI_DOUBLE, bankmaster[nodeid % bank_size], nodeid, comm_bank);
+#endif
+    return 1;
+}
+
+// get data with identity id
+int BankAccount::get_nodedata(int id, int nodeid, int size, double *data, std::vector<int> &idVec) {
+#ifdef MRCHEM_HAS_MPI
+    MPI_Status status;
+    // get the column with identity id
+    metadata_block[0] = nodeid; // which block
+    metadata_block[1] = id;     // id within block.
+    metadata_block[2] = size;   // expected size of data
+    int messages[message_size];
+    messages[0] = GET_NODEDATA;
+    messages[1] = account_id;
+    messages[2] = nodeid; // which block
+    messages[3] = id;     // id within block.
+    messages[4] = size;   // expected size of data
+    MPI_Send(messages, message_size, MPI_INT, bankmaster[nodeid % bank_size], nodeid, comm_bank);
+    MPI_Recv(data, size, MPI_DOUBLE, bankmaster[nodeid % bank_size], nodeid + 2, comm_bank, &status);
+#endif
+    return 1;
+}
+
+// get all data for nodeid
+int BankAccount::get_nodeblock(int nodeid, double *data, std::vector<int> &idVec) {
+#ifdef MRCHEM_HAS_MPI
+    MPI_Status status;
+    // get the entire superblock and also the id of each column
+    int messages[message_size];
+    messages[0] = GET_NODEBLOCK;
+    messages[1] = account_id;
+    MPI_Send(messages, message_size, MPI_INT, bankmaster[nodeid % bank_size], nodeid, comm_bank);
+    MPI_Recv(metadata_block, size_metadata, MPI_INT, bankmaster[nodeid % bank_size], nodeid, comm_bank, &status);
+    idVec.resize(metadata_block[1]);
+    int size = metadata_block[2];
+    if (size > 0)
+        MPI_Recv(
+            idVec.data(), metadata_block[1], MPI_INT, bankmaster[nodeid % bank_size], nodeid + 1, comm_bank, &status);
+    if (size > 0) MPI_Recv(data, size, MPI_DOUBLE, bankmaster[nodeid % bank_size], nodeid + 2, comm_bank, &status);
+#endif
+    return 1;
+}
+
+// get all data with identity orbid
+int BankAccount::get_orbblock(int orbid, double *&data, std::vector<int> &nodeidVec, int bankstart) {
+#ifdef MRCHEM_HAS_MPI
+    MPI_Status status;
+    int nodeid = orb_rank + bankstart;
+    // get the entire superblock and also the nodeid of each column
+    int messages[message_size];
+    messages[0] = GET_ORBBLOCK;
+    messages[1] = account_id;
+    MPI_Send(messages, message_size, MPI_INT, bankmaster[nodeid % bank_size], orbid, comm_bank);
+    MPI_Recv(metadata_block, size_metadata, MPI_INT, bankmaster[nodeid % bank_size], orbid, comm_bank, &status);
+    nodeidVec.resize(metadata_block[1]);
+    int totsize = metadata_block[2];
+    if (totsize > 0)
+        MPI_Recv(nodeidVec.data(),
+                 metadata_block[1],
+                 MPI_INT,
+                 bankmaster[nodeid % bank_size],
+                 orbid + 1,
+                 comm_bank,
+                 &status);
+    data = new double[totsize];
+    if (totsize > 0) MPI_Recv(data, totsize, MPI_DOUBLE, bankmaster[nodeid % bank_size], orbid + 2, comm_bank, &status);
+#endif
+    return 1;
+}
+
+// remove all blockdata with nodeid < nodeidmax
+// NB:: collective call. All clients must call this
+void BankAccount::clear_blockdata(int iclient, int nodeidmax, MPI_Comm comm) {
+#ifdef MRCHEM_HAS_MPI
+    // 1) wait until all clients are ready
+    MPI_Barrier(comm);
+    // master send signal to bank
+    if (iclient == 0) {
+        int messages[message_size];
+        messages[1] = account_id;
+        messages[0] = CLEAR_BLOCKS;
+        for (int i = 0; i < bank_size; i++) {
+            MPI_Send(messages, message_size, MPI_INT, bankmaster[i], nodeidmax, comm_bank);
+        }
+        for (int i = 0; i < bank_size; i++) {
+            // wait until Bank is finished and has sent signal
+            MPI_Status status;
+            int message;
+            MPI_Recv(&message, 1, MPI_INT, bankmaster[i], 78, comm_bank, &status);
+        }
+    }
+    MPI_Barrier(comm);
+#endif
+}
+
+// creator. NB: collective
+BankAccount::BankAccount(int iclient, MPI_Comm comm) {
+    this->account_id = dataBank.openAccount(iclient, comm);
+#ifdef MRCHEM_HAS_MPI
+    MPI_Barrier(comm);
+#endif
+}
+
+// destructor
+BankAccount::~BankAccount() {
+    // The account will in reality not be removed before everybody has sent a delete message
+    dataBank.closeAccount(this->account_id);
+}
+
+// closes account and reopen a new empty account. NB: account_id will change
+void BankAccount::clear(int iclient, MPI_Comm comm) {
+    this->account_id = dataBank.clearAccount(this->account_id, iclient, comm);
+}
+
+} // namespace mrchem

--- a/src/utils/Bank.h
+++ b/src/utils/Bank.h
@@ -1,0 +1,95 @@
+#pragma once
+
+#include "MRCPP/Parallel"
+
+#include "mrchem.h"
+#include "parallel.h"
+#include "qmfunctions/qmfunction_fwd.h"
+
+namespace mrchem {
+
+using namespace mpi;
+
+struct deposit {
+    Orbital *orb;
+    double *data; // for pure data arrays
+    bool hasdata;
+    int datasize;
+    int id = -1; // to identify what is deposited
+    int source;  // mpi rank from the source of the data
+};
+
+struct queue_struct {
+    int id;
+    std::vector<int> clients;
+};
+int const CLOSE_BANK = 1;
+int const CLEAR_BANK = 2;
+int const NEW_ACCOUNT = 3;
+int const CLOSE_ACCOUNT = 4;
+int const GET_ORBITAL = 5;
+int const GET_ORBITAL_AND_WAIT = 6;
+int const GET_ORBITAL_AND_DELETE = 7;
+int const SAVE_ORBITAL = 8;
+int const GET_FUNCTION = 9;
+int const SAVE_FUNCTION = 10;
+int const SET_DATASIZE = 11;
+int const GET_DATA = 12;
+int const SAVE_DATA = 13;
+int const SAVE_NODEDATA = 14;
+int const GET_NODEDATA = 15;
+int const GET_NODEBLOCK = 16;
+int const GET_ORBBLOCK = 17;
+int const CLEAR_BLOCKS = 18;
+int const GETMAXTOTDATA = 19;
+int const GETTOTDATA = 20;
+
+class CentralBank {
+public:
+    CentralBank() = default;
+    ~CentralBank();
+    void open();
+    void close();
+    int openAccount(int iclient, MPI_Comm comm);
+    int clearAccount(int account, int iclient, MPI_Comm comm); // closes and open fresh account
+    void closeAccount(int account_id);                         // remove the account
+    long long totcurrentsize = 0ll;                            // number of kB used by all accounts
+    int get_maxtotalsize();
+
+private:
+    std::vector<int> accounts;                          // open bank accounts
+    std::map<int, std::vector<deposit> *> get_deposits; // gives deposits of an account
+    std::map<int, std::map<int, int> *> get_id2ix;
+    std::map<int, std::map<int, int> *> get_id2qu;
+    std::map<int, std::vector<queue_struct> *> get_queue; // gives deposits of an account
+    std::map<int, long long> currentsize;                 // total deposited data size (without containers)
+    long long maxsize = 0;                                // max total deposited data size (without containers)
+    void clear_bank();
+    void clear_account(int account); // remove the content of the account
+    std::vector<int> get_totalsize();
+};
+
+class BankAccount {
+public:
+    BankAccount(int iclient = orb_rank, MPI_Comm comm = comm_orb);
+    ~BankAccount();
+    int account_id = -1;
+    void clear(int i = orb_rank, MPI_Comm comm = comm_orb);
+    int put_orb(int id, Orbital &orb);
+    int get_orb(int id, Orbital &orb, int wait = 0);
+    int get_orb_del(int id, Orbital &orb);
+    int put_func(int id, QMFunction &func);
+    int get_func(int id, QMFunction &func);
+    void set_datasize(int datasize, int iclient = orb_rank, MPI_Comm comm = comm_orb);
+    int put_data(int id, int size, double *data);
+    int get_data(int id, int size, double *data);
+    int put_nodedata(int id, int nodeid, int size, double *data);
+    int get_nodedata(int id, int nodeid, int size, double *data, std::vector<int> &idVec);
+    int get_nodeblock(int nodeid, double *data, std::vector<int> &idVec);
+    int get_orbblock(int orbid, double *&data, std::vector<int> &nodeidVec, int bankstart);
+    void clear_blockdata(int i = orb_rank, int nodeidmax = 0, MPI_Comm comm = comm_orb);
+};
+
+int const message_size = 5;
+
+} // namespace mrchem

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(mrchem
     ${CMAKE_CURRENT_SOURCE_DIR}/math_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/NonlinearMaximizer.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RRMaximizer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/Bank.cpp
   )
 
 add_subdirectory(gto_utils)


### PR DESCRIPTION
Refactoring of Bank. Main changes:

- Moved all Bank related to own files utils/Bank.cpp
- The usage of the Bank is now through the `BankAccount` class. Once a type `BankAccount` is defined, it can be used similarly to an array (or rather a std::map) to put and get orbitals or data. 
- The `BankAccount` are private, so no interference between different parts of the code. 
- One can open several `BankAccounts` (for Bra and Ket orbitals for example). 
- They are cleaned up automatically (destructor) when getting out of scope.
- Note that `BankAccount` class declaration (creator) is collective, i.e. it must be declared by all MPI at once.  
- Slightly faster
