### PR TITLE
MPI tests

### DIFF
--- a/src/qmfunctions/ComplexFunction.h
+++ b/src/qmfunctions/ComplexFunction.h
@@ -47,20 +47,23 @@ struct FunctionData {
 class ComplexFunction final {
 public:
     explicit ComplexFunction(bool share)
-            : shared_mem(nullptr)
+            : shared_mem_re(nullptr)
+            , shared_mem_im(nullptr)
             , re(nullptr)
             , im(nullptr) {
         this->func_data.is_shared = share;
         if (this->func_data.is_shared and mpi::share_size > 1) {
             // Memory size in MB defined in input. Virtual memory, does not cost anything if not used.
 #ifdef MRCPP_HAS_MPI
-            this->shared_mem = new mrcpp::SharedMemory(mpi::comm_share, mpi::shared_memory_size);
+            this->shared_mem_re = new mrcpp::SharedMemory(mpi::comm_share, mpi::shared_memory_size);
+            this->shared_mem_im = new mrcpp::SharedMemory(mpi::comm_share, mpi::shared_memory_size);
 #endif
         }
     }
 
     ~ComplexFunction() {
-        if (this->shared_mem != nullptr) delete this->shared_mem;
+        if (this->shared_mem_re != nullptr) delete this->shared_mem_re;
+        if (this->shared_mem_im != nullptr) delete this->shared_mem_im;
         if (this->re != nullptr) delete this->re;
         if (this->im != nullptr) delete this->im;
     }
@@ -69,7 +72,8 @@ public:
 
 private:
     FunctionData func_data;
-    mrcpp::SharedMemory *shared_mem;
+    mrcpp::SharedMemory *shared_mem_re;
+    mrcpp::SharedMemory *shared_mem_im;
     mrcpp::FunctionTree<3> *re; ///< Real part of function
     mrcpp::FunctionTree<3> *im; ///< Imaginary part of function
 

--- a/src/qmfunctions/QMFunction.cpp
+++ b/src/qmfunctions/QMFunction.cpp
@@ -68,11 +68,11 @@ void QMFunction::alloc(int type, mrcpp::MultiResolutionAnalysis<3> *mra) {
     if (mra == nullptr) MSG_ABORT("Invalid argument");
     if (type == NUMBER::Real or type == NUMBER::Total) {
         if (hasReal()) MSG_ABORT("Real part already allocated");
-        this->func_ptr->re = new mrcpp::FunctionTree<3>(*mra, this->func_ptr->shared_mem);
+        this->func_ptr->re = new mrcpp::FunctionTree<3>(*mra, this->func_ptr->shared_mem_re);
     }
     if (type == NUMBER::Imag or type == NUMBER::Total) {
         if (hasImag()) MSG_ABORT("Imaginary part already allocated");
-        this->func_ptr->im = new mrcpp::FunctionTree<3>(*mra, this->func_ptr->shared_mem);
+        this->func_ptr->im = new mrcpp::FunctionTree<3>(*mra, this->func_ptr->shared_mem_im);
     }
 }
 
@@ -80,12 +80,13 @@ void QMFunction::free(int type) {
     if (type == NUMBER::Real or type == NUMBER::Total) {
         if (hasReal()) delete this->func_ptr->re;
         this->func_ptr->re = nullptr;
+        if (this->func_ptr->shared_mem_re) this->func_ptr->shared_mem_re->clear();
     }
     if (type == NUMBER::Imag or type == NUMBER::Total) {
         if (hasImag()) delete this->func_ptr->im;
         this->func_ptr->im = nullptr;
+        if (this->func_ptr->shared_mem_im) this->func_ptr->shared_mem_im->clear();
     }
-    if (this->func_ptr->shared_mem and !hasImag() and !hasReal()) this->func_ptr->shared_mem->clear();
 }
 
 /** @brief Returns the orbital meta data

--- a/src/qmoperators/two_electron/ExchangePotentialD2.cpp
+++ b/src/qmoperators/two_electron/ExchangePotentialD2.cpp
@@ -38,21 +38,20 @@ ExchangePotentialD2::ExchangePotentialD2(PoissonOperator_p P,
 /** @brief Save all orbitals in Bank, so that they can be accessed asynchronously */
 void ExchangePotentialD2::setupBank() {
     if (mpi::bank_size < 1) return;
-    int id_shift = 10000;
 
     Timer timer;
     mpi::barrier(mpi::comm_orb);
     OrbitalVector &Phi = *this->orbitals;
     for (int i = 0; i < Phi.size(); i++) {
-        if (mpi::my_orb(Phi[i])) PhiBank.put_orb(i + id_shift, Phi[i]);
+        if (mpi::my_orb(Phi[i])) PhiBank.put_orb(i, Phi[i]);
     }
     OrbitalVector &X = *this->orbitals_x;
     for (int i = 0; i < X.size(); i++) {
-        if (mpi::my_orb(X[i])) XBank.put_orb(i + 2 * id_shift, X[i]);
+        if (mpi::my_orb(X[i])) XBank.put_orb(i, X[i]);
     }
     OrbitalVector &Y = *this->orbitals_y;
     for (int i = 0; i < Y.size(); i++) {
-        if (mpi::my_orb(Y[i])) YBank.put_orb(i + 3 * id_shift, Y[i]);
+        if (mpi::my_orb(Y[i])) YBank.put_orb(i, Y[i]);
     }
     mpi::barrier(mpi::comm_orb);
     mrcpp::print::time(4, "Setting up exchange bank", timer);
@@ -81,8 +80,6 @@ Orbital ExchangePotentialD2::apply(Orbital phi_p) {
         return phi_p.paramCopy();
     }
 
-    int id_shift = 10000;
-
     Timer timer;
     OrbitalVector &Phi = *this->orbitals;
     OrbitalVector &X = *this->orbitals_x;
@@ -101,9 +98,9 @@ Orbital ExchangePotentialD2::apply(Orbital phi_p) {
         Orbital &x_i = X[i];
         Orbital &y_i = Y[i];
 
-        if (not mpi::my_orb(phi_i)) PhiBank.get_orb(i + id_shift, phi_i, 1);
-        if (not mpi::my_orb(x_i)) XBank.get_orb(i + 2 * id_shift, x_i, 1);
-        if (not mpi::my_orb(y_i)) YBank.get_orb(i + 3 * id_shift, y_i, 1);
+        if (not mpi::my_orb(phi_i)) PhiBank.get_orb(i, phi_i, 1);
+        if (not mpi::my_orb(x_i)) XBank.get_orb(i, x_i, 1);
+        if (not mpi::my_orb(y_i)) YBank.get_orb(i, y_i, 1);
 
         double spin_fac = getSpinFactor(phi_i, phi_p);
         if (std::abs(spin_fac) >= mrcpp::MachineZero) {
@@ -142,8 +139,6 @@ Orbital ExchangePotentialD2::dagger(Orbital phi_p) {
         return phi_p.paramCopy();
     }
 
-    int id_shift = 10000;
-
     Timer timer;
     OrbitalVector &Phi = *this->orbitals;
     OrbitalVector &X = *this->orbitals_x;
@@ -162,9 +157,9 @@ Orbital ExchangePotentialD2::dagger(Orbital phi_p) {
         Orbital &x_i = X[i];
         Orbital &y_i = Y[i];
 
-        if (not mpi::my_orb(phi_i)) PhiBank.get_orb(i + id_shift, phi_i, 1);
-        if (not mpi::my_orb(x_i)) XBank.get_orb(i + 2 * id_shift, x_i, 1);
-        if (not mpi::my_orb(y_i)) YBank.get_orb(i + 3 * id_shift, y_i, 1);
+        if (not mpi::my_orb(phi_i)) PhiBank.get_orb(i, phi_i, 1);
+        if (not mpi::my_orb(x_i)) XBank.get_orb(i, x_i, 1);
+        if (not mpi::my_orb(y_i)) YBank.get_orb(i, y_i, 1);
 
         double spin_fac = getSpinFactor(phi_i, phi_p);
         if (std::abs(spin_fac) >= mrcpp::MachineZero) {

--- a/src/qmoperators/two_electron/ExchangePotentialD2.cpp
+++ b/src/qmoperators/two_electron/ExchangePotentialD2.cpp
@@ -38,20 +38,21 @@ ExchangePotentialD2::ExchangePotentialD2(PoissonOperator_p P,
 /** @brief Save all orbitals in Bank, so that they can be accessed asynchronously */
 void ExchangePotentialD2::setupBank() {
     if (mpi::bank_size < 1) return;
+    int id_shift = 10000;
 
     Timer timer;
     mpi::barrier(mpi::comm_orb);
     OrbitalVector &Phi = *this->orbitals;
     for (int i = 0; i < Phi.size(); i++) {
-        if (mpi::my_orb(Phi[i])) PhiBank.put_orb(i, Phi[i]);
+        if (mpi::my_orb(Phi[i])) PhiBank.put_orb(i + id_shift, Phi[i]);
     }
     OrbitalVector &X = *this->orbitals_x;
     for (int i = 0; i < X.size(); i++) {
-        if (mpi::my_orb(X[i])) XBank.put_orb(i, X[i]);
+        if (mpi::my_orb(X[i])) XBank.put_orb(i + 2 * id_shift, X[i]);
     }
     OrbitalVector &Y = *this->orbitals_y;
     for (int i = 0; i < Y.size(); i++) {
-        if (mpi::my_orb(Y[i])) YBank.put_orb(i, Y[i]);
+        if (mpi::my_orb(Y[i])) YBank.put_orb(i + 3 * id_shift, Y[i]);
     }
     mpi::barrier(mpi::comm_orb);
     mrcpp::print::time(4, "Setting up exchange bank", timer);
@@ -101,8 +102,8 @@ Orbital ExchangePotentialD2::apply(Orbital phi_p) {
         Orbital &y_i = Y[i];
 
         if (not mpi::my_orb(phi_i)) PhiBank.get_orb(i + id_shift, phi_i, 1);
-        if (not mpi::my_orb(x_i)) PhiBank.get_orb(i + 2 * id_shift, x_i, 1);
-        if (not mpi::my_orb(y_i)) PhiBank.get_orb(i + 3 * id_shift, y_i, 1);
+        if (not mpi::my_orb(x_i)) XBank.get_orb(i + 2 * id_shift, x_i, 1);
+        if (not mpi::my_orb(y_i)) YBank.get_orb(i + 3 * id_shift, y_i, 1);
 
         double spin_fac = getSpinFactor(phi_i, phi_p);
         if (std::abs(spin_fac) >= mrcpp::MachineZero) {
@@ -162,8 +163,8 @@ Orbital ExchangePotentialD2::dagger(Orbital phi_p) {
         Orbital &y_i = Y[i];
 
         if (not mpi::my_orb(phi_i)) PhiBank.get_orb(i + id_shift, phi_i, 1);
-        if (not mpi::my_orb(x_i)) PhiBank.get_orb(i + 2 * id_shift, x_i, 1);
-        if (not mpi::my_orb(y_i)) PhiBank.get_orb(i + 3 * id_shift, y_i, 1);
+        if (not mpi::my_orb(x_i)) XBank.get_orb(i + 2 * id_shift, x_i, 1);
+        if (not mpi::my_orb(y_i)) YBank.get_orb(i + 3 * id_shift, y_i, 1);
 
         double spin_fac = getSpinFactor(phi_i, phi_p);
         if (std::abs(spin_fac) >= mrcpp::MachineZero) {

--- a/tests/qmfunctions/qmfunction.cpp
+++ b/tests/qmfunctions/qmfunction.cpp
@@ -97,13 +97,14 @@ TEST_CASE("QMFunction", "[qmfunction]") {
     SECTION("copy shared function") {
         QMFunction func_1(true);
         qmfunction::project(func_1, f, NUMBER::Real, prec);
+        qmfunction::project(func_1, g, NUMBER::Imag, prec);
 
         SECTION("copy constructor") {
             QMFunction func_2(func_1);
             REQUIRE(func_2.isShared() == func_1.isShared());
             REQUIRE(func_2.norm() == Approx(func_1.norm()));
-            REQUIRE(&func_2.real() == &func_1.real());
-            REQUIRE(&func_2.imag() == &func_1.imag());
+            REQUIRE(func_2.integrate().real() == Approx(func_1.integrate().real()));
+            REQUIRE(func_2.integrate().imag() == Approx(func_1.integrate().imag()));
         }
 
         SECTION("default constructor plus assignment") {
@@ -111,16 +112,16 @@ TEST_CASE("QMFunction", "[qmfunction]") {
             func_2 = func_1;
             REQUIRE(func_2.isShared() == func_1.isShared());
             REQUIRE(func_2.norm() == Approx(func_1.norm()));
-            REQUIRE(&func_2.real() == &func_1.real());
-            REQUIRE(&func_2.imag() == &func_1.imag());
+            REQUIRE(func_2.integrate().real() == Approx(func_1.integrate().real()));
+            REQUIRE(func_2.integrate().imag() == Approx(func_1.integrate().imag()));
         }
 
         SECTION("assigment constructor") {
             QMFunction func_2 = func_1;
             REQUIRE(func_2.isShared() == func_1.isShared());
             REQUIRE(func_2.norm() == Approx(func_1.norm()));
-            REQUIRE(&func_2.real() == &func_1.real());
-            REQUIRE(&func_2.imag() == &func_1.imag());
+            REQUIRE(func_2.integrate().real() == Approx(func_1.integrate().real()));
+            REQUIRE(func_2.integrate().imag() == Approx(func_1.integrate().imag()));
         }
 
         SECTION("deep copy to non-shared") {
@@ -128,16 +129,17 @@ TEST_CASE("QMFunction", "[qmfunction]") {
             qmfunction::deep_copy(func_2, func_1);
             REQUIRE(not func_2.isShared());
             REQUIRE(func_2.norm() == Approx(func_1.norm()));
-            REQUIRE(&func_2.real() != &func_1.real());
-            REQUIRE(&func_2.imag() == &func_1.imag());
+            REQUIRE(func_2.integrate().real() == Approx(func_1.integrate().real()));
+            REQUIRE(func_2.integrate().imag() == Approx(func_1.integrate().imag()));
         }
+
         SECTION("deep copy to shared") {
             QMFunction func_2(true);
             qmfunction::deep_copy(func_2, func_1);
             REQUIRE(func_2.isShared() == func_1.isShared());
             REQUIRE(func_2.norm() == Approx(func_1.norm()));
-            REQUIRE(&func_2.real() != &func_1.real());
-            REQUIRE(&func_2.imag() == &func_1.imag());
+            REQUIRE(func_2.integrate().real() == Approx(func_1.integrate().real()));
+            REQUIRE(func_2.integrate().imag() == Approx(func_1.integrate().imag()));
         }
     }
 
@@ -172,11 +174,10 @@ TEST_CASE("QMFunction", "[qmfunction]") {
             REQUIRE(func.imag().integrate() == Approx(im * f_int + re * g_int));
         }
     }
-
     SECTION("rescale shared function") {
         QMFunction func(true);
-        qmfunction::project(func, f, NUMBER::Real, prec);
-        qmfunction::project(func, g, NUMBER::Imag, prec);
+        qmfunction::project(func, g, NUMBER::Real, prec);
+        qmfunction::project(func, f, NUMBER::Imag, prec);
 
         const double ref_norm = func.norm();
         const double f_int = func.real().integrate();

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -4,7 +4,10 @@
 #include "mrchem.h"
 #include "parallel.h"
 
+#include "utils/print_utils.h"
+
 #include "MRCPP/MWFunctions"
+#include "MRCPP/Printer"
 
 mrcpp::MultiResolutionAnalysis<3> *mrchem::MRA;
 
@@ -17,6 +20,14 @@ int main(int argc, char *argv[]) {
     mrchem::mpi::bank_size = 1;            // Will be set to zero if world_size == 1
     mrchem::mpi::numerically_exact = true; // Required for MPI invariant results
     mrchem::mpi::initialize();
+
+    // print MPI info
+    mrcpp::Printer::init(0, mrchem::mpi::world_rank, mrchem::mpi::world_size);
+    mrcpp::print::separator(0, '-');
+    mrchem::print_utils::scalar(0, "MPI processes  ", mrchem::mpi::world_size, "(" + std::to_string(mrchem::mpi::bank_size) + " bank)", 0, false);
+    mrchem::print_utils::scalar(0, "OpenMP threads ", mrchem::omp::n_threads, "", 0, false);
+    mrchem::print_utils::scalar(0, "Total cores    ", mrchem::mpi::world_size * mrchem::omp::n_threads, "", 0, false);
+    mrcpp::print::separator(0, '-');
 
     // run tests
     int result = Catch::Session().run(argc, argv);


### PR DESCRIPTION
The MPI coverage in the unit tests were actually quite decent. It is still only serial in the GitHub CI and when running `ctest`, but can be run explicitly in parallel with
```
$ mpirun -np 2 bin/mrchem-tests
------------------------------------------------------------
 MPI processes        :    (1 bank)                       2
 OpenMP threads       :                                   2
 Total cores          :                                   4
------------------------------------------------------------
===============================================================================
All tests passed (571 assertions in 21 test cases)
```

Found and corrected a few bugs along the way, and the tests should now pass with any number of procs.