### PR TITLE
Solvent fixes

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -986,9 +986,9 @@ void driver::build_fock_operator(const json &json_fock, Molecule &mol, FockOpera
         auto density_type = json_fock["reaction_operator"]["density_type"];
         Permittivity dielectric_func(*cavity_r, eps_in_r, eps_out_r, formulation);
 
-        SCRF helper(dielectric_func, nuclei, P_r, D_r, poisson_prec, hist_r, max_iter, accelerate_Vr, convergence_criterion, algorithm, density_type);
-        auto Reo = std::make_shared<ReactionOperator>(Phi_p, helper);
-        F.getReactionOperator() = Reo;
+        auto scrf_p = std::make_unique<SCRF>(dielectric_func, nuclei, P_r, D_r, poisson_prec, hist_r, max_iter, accelerate_Vr, convergence_criterion, algorithm, density_type);
+        auto V_R = std::make_shared<ReactionOperator>(scrf_p, Phi_p);
+        F.getReactionOperator() = V_R;
     }
     ///////////////////////////////////////////////////////////
     ////////////////////   XC Operator   //////////////////////

--- a/src/environment/SCRF.h
+++ b/src/environment/SCRF.h
@@ -48,7 +48,7 @@ public:
          std::string convergence_criterion,
          std::string algorithm,
          std::string density_type);
-    friend class ReactionPotential;
+    ~SCRF();
     void UpdateExternalDensity(Density new_density) { this->rho_ext = new_density; }
 
     QMFunction &getCurrentReactionPotential() { return this->Vr_n; }
@@ -60,6 +60,8 @@ public:
     QMFunction &getCurrentDifferenceGamma() { return this->dgamma_n; }
 
     void updateMOResidual(double const err_t) { this->mo_residual = err_t; }
+
+    friend class ReactionPotential;
 
 protected:
     void clear();
@@ -96,7 +98,7 @@ private:
     void setDCavity();
 
     void computeDensities(OrbitalVector &Phi);
-    void computeGamma(QMFunction Potential, QMFunction &out_gamma);
+    void computeGamma(QMFunction &potential, QMFunction &out_gamma);
 
     QMFunction solvePoissonEquation(const QMFunction &ingamma);
 

--- a/src/qmoperators/two_electron/ReactionOperator.h
+++ b/src/qmoperators/two_electron/ReactionOperator.h
@@ -42,27 +42,26 @@ class SCRF;
 
 class ReactionOperator final : public RankZeroOperator {
 public:
-    ReactionOperator(std::shared_ptr<mrchem::OrbitalVector> Phi_p, SCRF help) {
-        potential = std::make_shared<ReactionPotential>(Phi_p, help);
+    ReactionOperator(std::unique_ptr<SCRF> &scrf_p, std::shared_ptr<mrchem::OrbitalVector> Phi_p) {
+        potential = std::make_shared<ReactionPotential>(scrf_p, Phi_p);
         // Invoke operator= to assign *this operator
-        RankZeroOperator &J = (*this);
-        J = potential;
+        RankZeroOperator &V = (*this);
+        V = potential;
     }
 
     ComplexDouble trace(OrbitalVector &Phi) { return RankZeroOperator::trace(Phi); }
 
     double getTotalEnergy() { return this->potential->getTotalEnergy(); }
-    double getElectronicEnergy() { return this->potential->getElectronicEnergy(); }
     double getNuclearEnergy() { return this->potential->getNuclearEnergy(); }
-    SCRF getHelper() { return this->potential->getHelper(); }
+    double getElectronicEnergy() { return this->potential->getElectronicEnergy(); }
+
+    SCRF* getHelper() { return this->potential->getHelper(); }
     std::shared_ptr<ReactionPotential> getPotential() { return this->potential; }
     void updateMOResidual(double const err_t) { this->potential->updateMOResidual(err_t); }
 
     QMFunction &getCurrentReactionPotential() { return this->potential->getCurrentReactionPotential(); }
     QMFunction &getPreviousReactionPotential() { return this->potential->getPreviousReactionPotential(); }
-    QMFunction &getCurrentDifferenceReactionPotential() {
-        return this->potential->getCurrentDifferenceReactionPotential();
-    }
+    QMFunction &getCurrentDifferenceReactionPotential() { return this->potential->getCurrentDifferenceReactionPotential(); }
 
     QMFunction &getCurrentGamma() { return this->potential->getCurrentGamma(); }
     QMFunction &getPreviousGamma() { return this->potential->getPreviousGamma(); }

--- a/src/qmoperators/two_electron/ReactionPotential.cpp
+++ b/src/qmoperators/two_electron/ReactionPotential.cpp
@@ -27,28 +27,29 @@
 
 #include "qmfunctions/qmfunction_utils.h"
 
+using SCRF_p = std::unique_ptr<mrchem::SCRF>;
 using OrbitalVector_p = std::shared_ptr<mrchem::OrbitalVector>;
 
 namespace mrchem {
 
-ReactionPotential::ReactionPotential(OrbitalVector_p Phi_p, SCRF helper)
+ReactionPotential::ReactionPotential(SCRF_p &scrf_p, OrbitalVector_p Phi_p)
         : QMPotential(1, false)
-        , Phi(Phi_p)
-        , helper(helper) {}
+        , helper(std::move(scrf_p))
+        , Phi(Phi_p) {}
 
 void ReactionPotential::setup(double prec) {
     setApplyPrec(prec);
-    QMFunction &temp = *this;
     if (this->first_iteration) {
         this->first_iteration = false;
         return;
     }
-    qmfunction::deep_copy(temp, this->helper.setup(prec, this->Phi));
+    auto potential = this->helper->setup(prec, this->Phi);
+    qmfunction::deep_copy(*this, potential);
 }
 
 void ReactionPotential::clear() {
     clearApplyPrec();
-    this->helper.clear();
+    this->helper->clear();
 }
 
 } // namespace mrchem

--- a/src/qmoperators/two_electron/ReactionPotential.h
+++ b/src/qmoperators/two_electron/ReactionPotential.h
@@ -42,55 +42,33 @@ namespace mrchem {
 class ReactionPotential final : public QMPotential {
 public:
     /** @brief Initializes the ReactionPotential class.
-     *  @param Phi_p A pointer to a vector which contains the orbitals optimized in the SCF procedure.
-     *  @param helper A SCRF instance which contains the parameters needed to compute the ReactionPotential.
-     */
-    ReactionPotential(std::shared_ptr<mrchem::OrbitalVector> Phi_p, SCRF helper);
-
-    /** @brief Destructor assures that all memory is de-allocated before deleting the instance.*/
+     *  @param scrf_p A SCRF instance which contains the parameters needed to compute the ReactionPotential.
+     *  @param Phi_p A pointer to a vector which contains the orbitals optimized in the SCF procedure. */
+    ReactionPotential(std::unique_ptr<SCRF> &scrf_p, std::shared_ptr<mrchem::OrbitalVector> Phi_p);
     ~ReactionPotential() override { free(NUMBER::Total); }
 
-    friend class ReactionOperator;
-
-    SCRF getHelper() { return this->helper; } //!< Returns #helper
-    double getNuclearEnergy() {
-        return this->helper.getNuclearEnergy();
-    } //!< Calls the SCRF::getNuclearEnergy function of the #helper instance.
-    double getElectronicEnergy() {
-        return this->helper.getElectronicEnergy();
-    } //!< Calls the SCRF::getElectronicEnergy function of the #helper instance.
-    double getTotalEnergy() {
-        return this->helper.getTotalEnergy();
-    } //!< Calls the SCRF::getTotalEnergy function of the #helper instance.
+    SCRF *getHelper() { return this->helper.get(); }
+    double getElectronicEnergy() { return this->helper->getElectronicEnergy(); }
+    double getNuclearEnergy() { return this->helper->getNuclearEnergy(); }
+    double getTotalEnergy() { return this->helper->getTotalEnergy(); }
 
     /** @brief Updates the helper.mo_residual member variable. This variable is used to set the convergence criterion in
-     * the dynamic convergence method.
-     */
-    void updateMOResidual(double const err_t) { this->helper.mo_residual = err_t; }
+     * the dynamic convergence method. */
+    void updateMOResidual(double const err_t) { this->helper->mo_residual = err_t; }
 
-    QMFunction &getCurrentReactionPotential() {
-        return this->helper.getCurrentReactionPotential();
-    } //!< Calls the SCRF::getCurrentReactionPotential function of the #helper instance.
-    QMFunction &getPreviousReactionPotential() {
-        return this->helper.getPreviousReactionPotential();
-    } //!< Calls the SCRF::getPreviousReactionPotential function of the #helper instance.
-    QMFunction &getCurrentDifferenceReactionPotential() {
-        return this->helper.getCurrentDifferenceReactionPotential();
-    } //!< Calls the SCRF::getCurrentDifferenceReactionPotential function of the #helper instance.
+    QMFunction &getCurrentReactionPotential() { return this->helper->getCurrentReactionPotential(); }
+    QMFunction &getPreviousReactionPotential() { return this->helper->getPreviousReactionPotential(); }
+    QMFunction &getCurrentDifferenceReactionPotential() { return this->helper->getCurrentDifferenceReactionPotential(); }
 
-    QMFunction &getCurrentGamma() {
-        return this->helper.getCurrentGamma();
-    } //!< Calls the SCRF::getCurrentGamma function of the #helper instance.
-    QMFunction &getPreviousGamma() {
-        return this->helper.getPreviousGamma();
-    } //!< Calls the SCRF::getPreviousGamma function of the #helper instance.
-    QMFunction &getCurrentDifferenceGamma() {
-        return this->helper.getCurrentDifferenceGamma();
-    } //!< Calls the SCRF::getCurrentDifferenceGamma function of the #helper instance.
+    QMFunction &getCurrentGamma() { return this->helper->getCurrentGamma(); }
+    QMFunction &getPreviousGamma() { return this->helper->getPreviousGamma(); }
+    QMFunction &getCurrentDifferenceGamma() { return this->helper->getCurrentDifferenceGamma(); }
+
     /** @brief changes the #first_iteration variable to false. This is done in tests where we want the ReactionPotential
-     * to be calculated at the zero-th iteration in the SCF cycle instead of not doing it, as is the deafult.
-     */
+     * to be calculated at the zero-th iteration in the SCF cycle instead of not doing it, as is the deafult.*/
     void setTesting() { this->first_iteration = false; }
+
+    friend class ReactionOperator;
 
 protected:
     void clear();
@@ -98,9 +76,8 @@ protected:
 private:
     bool first_iteration = true; //!< when this variable is true the reaction potential is not calculated. This is done
                                  //!< only in the zero-th iteration of the SCF procedure, after that it is set to false.
-    std::shared_ptr<mrchem::OrbitalVector>
-        Phi; //!< holds the Orbitals of the molecule needed to compute the electronic density for the SCRF procedure.
-    SCRF helper; //!< A SCRF instance used to compute the ReactionPotential.
+    std::unique_ptr<SCRF> helper; //!< A SCRF instance used to compute the ReactionPotential.
+    std::shared_ptr<mrchem::OrbitalVector> Phi; //!< holds the Orbitals needed to compute the electronic density for the SCRF procedure.
 
     void setup(double prec);
 };

--- a/tests/solventeffect/reaction_operator.cpp
+++ b/tests/solventeffect/reaction_operator.cpp
@@ -88,13 +88,14 @@ TEST_CASE("ReactionOperator", "[reaction_operator]") {
     if (mpi::my_orb(Phi[0])) qmfunction::project(Phi[0], f, NUMBER::Real, prec);
 
     int kain = 4;
-    SCRF helper(dielectric_func, molecule, P_p, D_p, prec, kain, 100, true, "dynamic", "scrf", "total");
+    auto scrf_p = std::make_unique<SCRF>(dielectric_func, molecule, P_p, D_p, prec, kain, 100, true, "dynamic", "scrf", "total");
 
-    auto Reo = std::make_shared<ReactionOperator>(Phi_p, helper);
+    auto Reo = std::make_shared<ReactionOperator>(scrf_p, Phi_p);
     Reo->setTesting();
     Reo->setup(prec);
     double total_energy = Reo->getTotalEnergy();
     Reo->clear();
     REQUIRE(total_energy == Approx(-0.191434124263).epsilon(thrs));
 }
+
 } // namespace reaction_operator


### PR DESCRIPTION
- The SCRF instance was not copied correctly, so I made it a `unique_ptr` and `move` it into the `ReactionPotential`.
- The `d_cavity` vector was not properly deallocated
- The `mo_residual` variable was not initialized in the constructor
- Removed some "noisy" documentation

Not sure if any of this helps with the issues we have seen, I think they might be unrelated to the solvent code.