### PR TITLE
Fix wrong size parameter in contracted XC output

### DIFF
--- a/src/mrdft/MRDFT.cpp
+++ b/src/mrdft/MRDFT.cpp
@@ -113,11 +113,11 @@ mrcpp::FunctionTreeVector<3> MRDFT::evaluate(mrcpp::FunctionTreeVector<3> &inp) 
         mrchem::BankAccount ctrOutBank; // to put the ctrOutDataVec;
 
         // note that mpi cannot run in multiple omp threads
-        int size = nFcs * nCoefs;
+        int size = nOutCtr * nCoefs;
         for (int n = n_start; n < n_end; n++) ctrOutBank.put_data(n, size, ctrOutDataVec[n - n_start].data());
         // fetch all nodes from bank and postprocess
         for (int n = 0; n < nNodes; n++) {
-            Eigen::MatrixXd ctrOutData(nFcs, nCoefs);
+            Eigen::MatrixXd ctrOutData(nOutCtr, nCoefs);
             ctrOutBank.get_data(n, size, ctrOutData.data());
             auto ctrOutNodes = xc_utils::fetch_nodes(n, ctrOutVec);
             xc_utils::expand_nodes(ctrOutNodes, ctrOutData);

--- a/src/mrdft/xc_utils.cpp
+++ b/src/mrdft/xc_utils.cpp
@@ -170,7 +170,7 @@ Eigen::MatrixXd xc_utils::compress_nodes(std::vector<mrcpp::FunctionNode<3> *> &
  */
 void xc_utils::expand_nodes(std::vector<mrcpp::FunctionNode<3> *> &out_nodes, Eigen::MatrixXd &inp_data) {
     auto nFuncs = out_nodes.size();
-    if (inp_data.rows() != nFuncs) MSG_ERROR("Size mismatch");
+    if (inp_data.rows() != nFuncs) MSG_ERROR("Size mismatch " << inp_data.rows() << " vs " << nFuncs);
 
     for (auto i = 0; i < nFuncs; i++) {
         auto &node = out_nodes[i];


### PR DESCRIPTION
Another simple bugfix, closes #374