### PR TITLE
Fix uninitialized value in orbital::rotate

### DIFF
--- a/src/qmfunctions/orbital_utils.cpp
+++ b/src/qmfunctions/orbital_utils.cpp
@@ -260,7 +260,7 @@ OrbitalVector orbital::rotate(OrbitalVector &Phi, const ComplexMatrix &U, double
         }
     }
 
-    IntVector PsihasReIm(2);
+    IntVector PsihasReIm = IntVector::Zero(2);
     for (int i = 0; i < N; i++) {
         if (!mpi::my_orb(Phi[i])) continue;
         PsihasReIm[0] = (Phi[i].hasReal()) ? 1 : 0;


### PR DESCRIPTION
Only triggered when size of `mpi::comm_orb` is greater than number of orbitals, i.e. when some MPI ranks does not have any orbitals. Closes #378.