### PR TITLE
Fix NMR shieldings, closes #384

### DIFF
--- a/src/analyticfunctions/NuclearGradientFunction.h
+++ b/src/analyticfunctions/NuclearGradientFunction.h
@@ -62,8 +62,8 @@ protected:
 
 namespace detail {
 /*! @brief Compute nucleus- and precision-dependent smoothing parameter */
-inline auto nuclear_gradient_smoothing(double prec, double Z) -> double {
-    auto tmp = prec / (0.00435 * std::pow(Z, 5));
+inline auto nuclear_gradient_smoothing(double prec, double Z, int N) -> double {
+    auto tmp = prec / (0.00435 * std::pow(Z, 5) * N);
     return std::cbrt(tmp);
 }
 } // namespace detail

--- a/src/qmoperators/one_electron/H_BM_dia.h
+++ b/src/qmoperators/one_electron/H_BM_dia.h
@@ -64,15 +64,15 @@ public:
 
         // Invoke operator= to assign *this operator
         RankTwoOperator<3, 3> &h = (*this);
-        h[0][0] = -(alpha_2 / 2.0) * (o_y(k_y) + o_z(k_z));
-        h[0][1] = (alpha_2 / 2.0) * o_x(k_y);
-        h[0][2] = (alpha_2 / 2.0) * o_x(k_z);
-        h[1][0] = (alpha_2 / 2.0) * o_y(k_x);
-        h[1][1] = -(alpha_2 / 2.0) * (o_x(k_x) + o_z(k_z));
-        h[1][2] = (alpha_2 / 2.0) * o_y(k_z);
-        h[2][0] = (alpha_2 / 2.0) * o_z(k_x);
-        h[2][1] = (alpha_2 / 2.0) * o_z(k_y);
-        h[2][2] = -(alpha_2 / 2.0) * (o_x(k_x) + o_y(k_y));
+        h[0][0] = (alpha_2 / 2.0) * (o_y(k_y) + o_z(k_z));
+        h[0][1] = -(alpha_2 / 2.0) * o_y(k_x);
+        h[0][2] = -(alpha_2 / 2.0) * o_z(k_x);
+        h[1][0] = -(alpha_2 / 2.0) * o_x(k_y);
+        h[1][1] = (alpha_2 / 2.0) * (o_x(k_x) + o_z(k_z));
+        h[1][2] = -(alpha_2 / 2.0) * o_z(k_y);
+        h[2][0] = -(alpha_2 / 2.0) * o_x(k_z);
+        h[2][1] = -(alpha_2 / 2.0) * o_y(k_z);
+        h[2][2] = (alpha_2 / 2.0) * (o_x(k_x) + o_y(k_y));
         h[0][0].name() = "h_BM_dia[x,x]";
         h[0][1].name() = "h_BM_dia[x,y]";
         h[0][2].name() = "h_BM_dia[x,z]";

--- a/src/qmoperators/one_electron/H_MB_dia.h
+++ b/src/qmoperators/one_electron/H_MB_dia.h
@@ -42,7 +42,7 @@ namespace mrchem {
  * d^2H/dM_KdB = H_MB_dia
  *
  * H_MB_dia = \frac{alpha^2}{2}
- *            \sum_j \frac{(r_{jO} \cdot r_{jK})1 - r_{jO}r_{jK}^T}{r_jK}^3}
+ *            \sum_j \frac{(r_{jK} \cdot r_{jO})1 - r_{jO}r_{jK}^T}{r_jK}^3}
  *
  * This operator is the transpose of H_BM_dia.
  */
@@ -64,15 +64,15 @@ public:
 
         // Invoke operator= to assign *this operator
         RankTwoOperator<3, 3> &h = (*this);
-        h[0][0] = -(alpha_2 / 2.0) * (o_y(k_y) + o_z(k_z));
-        h[0][1] = (alpha_2 / 2.0) * o_y(k_x);
-        h[0][2] = (alpha_2 / 2.0) * o_z(k_x);
-        h[1][0] = (alpha_2 / 2.0) * o_x(k_y);
-        h[1][1] = -(alpha_2 / 2.0) * (o_x(k_x) + o_z(k_z));
-        h[1][2] = (alpha_2 / 2.0) * o_z(k_y);
-        h[2][0] = (alpha_2 / 2.0) * o_x(k_z);
-        h[2][1] = (alpha_2 / 2.0) * o_y(k_z);
-        h[2][2] = -(alpha_2 / 2.0) * (o_x(k_x) + o_y(k_y));
+        h[0][0] = (alpha_2 / 2.0) * (o_y(k_y) + o_z(k_z));
+        h[0][1] = -(alpha_2 / 2.0) * o_x(k_y);
+        h[0][2] = -(alpha_2 / 2.0) * o_x(k_z);
+        h[1][0] = -(alpha_2 / 2.0) * o_y(k_x);
+        h[1][1] = (alpha_2 / 2.0) * (o_x(k_x) + o_z(k_z));
+        h[1][2] = -(alpha_2 / 2.0) * o_y(k_z);
+        h[2][0] = -(alpha_2 / 2.0) * o_z(k_x);
+        h[2][1] = -(alpha_2 / 2.0) * o_z(k_y);
+        h[2][2] = (alpha_2 / 2.0) * (o_x(k_x) + o_y(k_y));
         h[0][0].name() = "h_MB_dia[x,x]";
         h[0][1].name() = "h_MB_dia[x,y]";
         h[0][2].name() = "h_MB_dia[x,z]";

--- a/src/qmoperators/one_electron/NuclearGradientOperator.h
+++ b/src/qmoperators/one_electron/NuclearGradientOperator.h
@@ -27,6 +27,7 @@
 
 #include "tensor/RankOneOperator.h"
 
+#include "analyticfunctions/NuclearFunction.h"
 #include "analyticfunctions/NuclearGradientFunction.h"
 #include "qmfunctions/qmfunction_utils.h"
 #include "qmoperators/QMPotential.h"
@@ -40,14 +41,12 @@ public:
      *  @param z: Nuclear charge of nucleus
      *  @param o: Coordinate of origin
      *  @param proj_prec: Precision for projection of analytic function
-     *  @param smooth_prec: Precision for smoothing of analytic function
+     *  @param c: Smoothing parameter for analytic function
      */
-    NuclearGradientOperator(double z, const mrcpp::Coord<3> &o, double proj_prec, double smooth_prec = -1.0) {
+    NuclearGradientOperator(double z, const mrcpp::Coord<3> &o, double proj_prec, double c) {
         if (proj_prec < 0.0) MSG_ABORT("Negative projection precision");
-        if (smooth_prec < 0.0) smooth_prec = proj_prec;
 
         // Define analytic potential
-        double c = detail::nuclear_gradient_smoothing(smooth_prec, z);
         NuclearGradientFunction f_x(0, z, o, c);
         NuclearGradientFunction f_y(1, z, o, c);
         NuclearGradientFunction f_z(2, z, o, c);


### PR DESCRIPTION
The smoothing parameter for the `r/r^3` function, as computed for use in nuclear gradients, was not sufficiently tight for NMR calculations. The old parameter was computed as described by [Yanai et.al.](https://aip.scitation.org/doi/10.1063/1.1768161) as
```
c = [prec / (0.00435*Z^5*N_atoms)]^(1/3)
  = [prec / 0.00435]^(1/3), with Z = N_atoms = 1 in the NMR operator
```
The new parameter is simply set to
```
c = prec, in the NMR operator
```
This is the same as in v1.0.1, and seems to give nice and consistent NMR parameters, but we should reconsider the forms and parameters of all our smoothed functions (nuclear potential, nuclear gradient, NMR operator, ZORA potential, etc). A quick peek into the MADNESS source reveals that they are no longer using the same form for their potentials.