### PR TITLE
Nuclear potential prec scaled with box size

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -1044,7 +1044,7 @@ void driver::build_fock_operator(const json &json_fock, Molecule &mol, FockOpera
     /////////////////   External Operator   ///////////////////
     ///////////////////////////////////////////////////////////
     if (json_fock.contains("external_operator")) {
-        auto field = json_fock["external_operator"]["electric_field"];
+        auto field = json_fock["external_operator"]["electric_field"].get<std::array<double, 3>>();
         auto r_O = json_fock["external_operator"]["r_O"];
         auto V_ext = std::make_shared<ElectricFieldOperator>(field, r_O);
         F.getExtOperator() = V_ext;


### PR DESCRIPTION
Scale the relative prec for Nuclear potential with box size. 
V.norm increase with 6th root of box volume = additional scaling factor.

Note that the prec for the " allreducePotential" should be rethinked too. It seems to use absolute prec, not relative prec, but probably it is so small, that there is no neglect of nodes anyway, which is probably what we want.

The correct treatment would be to not copy the entire nuclear potential everywhere, but to treat it "locally", i.e. save the nodes in bank, and when multiplied by an orbitalvector, loop over orbitals for fixed node, (instead of loop over nodes for fixed orbitals). This can easily(?) be done transparently.