### PR TITLE
Sanity checking the multiplicity during input parsing

### DIFF
--- a/python/mrchem/api.py
+++ b/python/mrchem/api.py
@@ -207,8 +207,8 @@ def write_molecule(user_dict, origin):
 
     # Check for unphysical multiplicity (not likely to be much of a problem, but still...)
     if n_unpaired > n_electrons:
-        raise RuntimeError(f"The specified multiplicity requires more electrons ({mult - 1}) than are present ({n_electrons}))")
-        
+        raise RuntimeError(f"The specified multiplicity requires more unpaired electrons ({mult - 1}) than are available ({n_electrons}))")
+
     # Check for restricted open-shell
     elif restricted and n_unpaired > 0: 
         raise RuntimeError("Restricted open-shell calculations are not available")


### PR DESCRIPTION
The motivation for this PR is to help prevent people (me) from submitting jobs to an HPC cluster only to find it failing due to an invalid multiplicity after waiting several hours for it to start 😭 

This is a suggestion for a quick sanity check of the specified multiplicity during the input parsing, instead of performing the check only in `driver.cpp`. Now an invalid multiplicity can be caught during a dry run (no need to call the executable with invalid input). The original check in `driver.cpp` is untouched, as in principle someone could edit the `program.json` file directly and pass this to `mrchem.x`. 

The following checks have been added to `./python/mrchem/api.py`:

- Too high multiplicities that would require `n_unpaired > n_electrons` (which was not currently checked for)
- `n_unpaired > 0 and WaveFunction.restricted = true` (restricted open-shell is not available)
- An even multiplicity is only compatible with an odd number of electrons