### PR TITLE
Bugfix in input parser (+ license updates to 2022)

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/pilot/mrchem.cpp
+++ b/pilot/mrchem.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/pilot/mrchem.in
+++ b/pilot/mrchem.in
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
 
+
 #
 # MRChem, a numerical real-space code for molecular electronic structure
 # calculations within the self-consistent field (SCF) approximations of quantum
 # chemistry (Hartree-Fock and Density Functional Theory).
-# Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+# Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
 #
 # This file is part of MRChem.
 #

--- a/python/mrchem.in
+++ b/python/mrchem.in
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
 
+
 #
 # MRChem, a numerical real-space code for molecular electronic structure
 # calculations within the self-consistent field (SCF) approximations of quantum
 # chemistry (Hartree-Fock and Density Functional Theory).
-# Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+# Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
 #
 # This file is part of MRChem.
 #

--- a/python/mrchem/CUBEparser.py
+++ b/python/mrchem/CUBEparser.py
@@ -3,7 +3,7 @@
 # MRChem, a numerical real-space code for molecular electronic structure
 # calculations within the self-consistent field (SCF) approximations of quantum
 # chemistry (Hartree-Fock and Density Functional Theory).
-# Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+# Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
 #
 # This file is part of MRChem.
 #

--- a/python/mrchem/__init__.py
+++ b/python/mrchem/__init__.py
@@ -2,7 +2,7 @@
 # MRChem, a numerical real-space code for molecular electronic structure
 # calculations within the self-consistent field (SCF) approximations of quantum
 # chemistry (Hartree-Fock and Density Functional Theory).
-# Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+# Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
 #
 # This file is part of MRChem.
 #

--- a/python/mrchem/api.py
+++ b/python/mrchem/api.py
@@ -2,7 +2,7 @@
 # MRChem, a numerical real-space code for molecular electronic structure
 # calculations within the self-consistent field (SCF) approximations of quantum
 # chemistry (Hartree-Fock and Density Functional Theory).
-# Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+# Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
 #
 # This file is part of MRChem.
 #

--- a/python/mrchem/cli.py
+++ b/python/mrchem/cli.py
@@ -2,7 +2,7 @@
 # MRChem, a numerical real-space code for molecular electronic structure
 # calculations within the self-consistent field (SCF) approximations of quantum
 # chemistry (Hartree-Fock and Density Functional Theory).
-# Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+# Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
 #
 # This file is part of MRChem.
 #

--- a/python/mrchem/config.py.in
+++ b/python/mrchem/config.py.in
@@ -2,7 +2,7 @@
 # MRChem, a numerical real-space code for molecular electronic structure
 # calculations within the self-consistent field (SCF) approximations of quantum
 # chemistry (Hartree-Fock and Density Functional Theory).
-# Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+# Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
 #
 # This file is part of MRChem.
 #

--- a/python/mrchem/helpers.py
+++ b/python/mrchem/helpers.py
@@ -2,7 +2,7 @@
 # MRChem, a numerical real-space code for molecular electronic structure
 # calculations within the self-consistent field (SCF) approximations of quantum
 # chemistry (Hartree-Fock and Density Functional Theory).
-# Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+# Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
 #
 # This file is part of MRChem.
 #

--- a/python/mrchem/helpers.py
+++ b/python/mrchem/helpers.py
@@ -162,7 +162,7 @@ def write_scf_guess(user_dict, wf_dict):
         elif zeta_str == 'gto':
             guess_type = guess_str
         else:
-            print("Invalid zeta:" + guess_suffix)
+            print("Invalid zeta:" + zeta_str)
 
     file_dict = user_dict["Files"]
 

--- a/python/mrchem/periodictable.py
+++ b/python/mrchem/periodictable.py
@@ -2,7 +2,7 @@
 # MRChem, a numerical real-space code for molecular electronic structure
 # calculations within the self-consistent field (SCF) approximations of quantum
 # chemistry (Hartree-Fock and Density Functional Theory).
-# Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+# Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
 #
 # This file is part of MRChem.
 #

--- a/src/analyticfunctions/CUBEfunction.cpp
+++ b/src/analyticfunctions/CUBEfunction.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/analyticfunctions/CUBEfunction.h
+++ b/src/analyticfunctions/CUBEfunction.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/analyticfunctions/HarmonicOscillatorFunction.h
+++ b/src/analyticfunctions/HarmonicOscillatorFunction.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -65,10 +65,7 @@ protected:
 
 class HarmonicOscillatorFunction final : public mrcpp::RepresentableFunction<3> {
 public:
-    HarmonicOscillatorFunction(int n[3],
-                               double m = 1.0,
-                               double *k = nullptr,
-                               const mrcpp::Coord<3> &o = {0.0, 0.0, 0.0})
+    HarmonicOscillatorFunction(int n[3], double m = 1.0, double *k = nullptr, const mrcpp::Coord<3> &o = {0.0, 0.0, 0.0})
             : fx(n[0], m, ((k != nullptr) ? k[0] : 1.0), o[0])
             , fy(n[1], m, ((k != nullptr) ? k[1] : 1.0), o[1])
             , fz(n[2], m, ((k != nullptr) ? k[2] : 1.0), o[2]) {}

--- a/src/analyticfunctions/HydrogenFunction.cpp
+++ b/src/analyticfunctions/HydrogenFunction.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/analyticfunctions/HydrogenFunction.h
+++ b/src/analyticfunctions/HydrogenFunction.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/analyticfunctions/NuclearFunction.cpp
+++ b/src/analyticfunctions/NuclearFunction.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/analyticfunctions/NuclearFunction.h
+++ b/src/analyticfunctions/NuclearFunction.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/analyticfunctions/NuclearGradientFunction.cpp
+++ b/src/analyticfunctions/NuclearGradientFunction.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/analyticfunctions/NuclearGradientFunction.h
+++ b/src/analyticfunctions/NuclearGradientFunction.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/Element.h
+++ b/src/chemistry/Element.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/Molecule.cpp
+++ b/src/chemistry/Molecule.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/Molecule.h
+++ b/src/chemistry/Molecule.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/Nucleus.h
+++ b/src/chemistry/Nucleus.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/PeriodicTable.cpp
+++ b/src/chemistry/PeriodicTable.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/PeriodicTable.h
+++ b/src/chemistry/PeriodicTable.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/chemistry_fwd.h
+++ b/src/chemistry/chemistry_fwd.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/chemistry_utils.cpp
+++ b/src/chemistry/chemistry_utils.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/chemistry/chemistry_utils.h
+++ b/src/chemistry/chemistry_utils.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -984,7 +984,7 @@ void driver::build_fock_operator(const json &json_fock, Molecule &mol, FockBuild
         auto c = json_fock["zora_operator"]["light_speed"];
         if (c <= 0.0) c = PHYSCONST::alpha_inv;
         F.setLightSpeed(c);
-        
+
         auto include_nuclear = json_fock["zora_operator"]["include_nuclear"];
         auto include_coulomb = json_fock["zora_operator"]["include_coulomb"];
         auto include_xc = json_fock["zora_operator"]["include_xc"];

--- a/src/driver.h
+++ b/src/driver.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/environment/Cavity.cpp
+++ b/src/environment/Cavity.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -57,11 +57,7 @@ Cavity::Cavity(std::vector<mrcpp::Coord<3>> &centers, std::vector<double> &radii
  *   @param width A double value describing the width of the transition at the boundary of the spheres.
  *   @return A double number which represents the value of the differential (w.r.t. x, y or z) at point r.
  */
-auto gradCavity(const mrcpp::Coord<3> &r,
-                int index,
-                const std::vector<mrcpp::Coord<3>> &centers,
-                std::vector<double> &radii,
-                double width) -> double {
+auto gradCavity(const mrcpp::Coord<3> &r, int index, const std::vector<mrcpp::Coord<3>> &centers, std::vector<double> &radii, double width) -> double {
     double C = 1.0;
     double DC = 0.0;
     for (int i = 0; i < centers.size(); i++) {
@@ -94,12 +90,9 @@ auto gradCavity(const mrcpp::Coord<3> &r,
 }
 /** @brief Sets the different partial derivatives in the \link #gradvector gradient \endlink of the Cavity. */
 void Cavity::setGradVector() {
-    auto p_gradcavity = [this](const mrcpp::Coord<3> &r, int index) {
-        return gradCavity(r, index, centers, radii, width);
-    };
+    auto p_gradcavity = [this](const mrcpp::Coord<3> &r, int index) { return gradCavity(r, index, centers, radii, width); };
     for (auto i = 0; i < 3; i++) {
-        this->gradvector.push_back(
-            [i, p_gradcavity](const mrcpp::Coord<3> &r) -> double { return p_gradcavity(r, i); });
+        this->gradvector.push_back([i, p_gradcavity](const mrcpp::Coord<3> &r) -> double { return p_gradcavity(r, i); });
     }
 }
 /** @brief Evaluates the value of the cavity at a 3D point \f$\mathbf{r}\f$
@@ -134,9 +127,7 @@ bool Cavity::isZeroOnInterval(const double *a, const double *b) const {
             double cavityMinIn = (this->centers[k][i] - radii[i]) + 3.0 * this->width;
             double cavityMaxIn = (this->centers[k][i] + radii[i]) - 3.0 * this->width;
             double cavityMaxOut = (this->centers[k][i] + radii[i]) + 3.0 * this->width;
-            if (a[i] > cavityMaxOut or (a[i] > cavityMinIn and b[i] < cavityMaxIn) or b[i] < cavityMinOut) {
-                return true;
-            }
+            if (a[i] > cavityMaxOut or (a[i] > cavityMinIn and b[i] < cavityMaxIn) or b[i] < cavityMinOut) { return true; }
         }
     }
     return false;

--- a/src/environment/Cavity.h
+++ b/src/environment/Cavity.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -53,9 +53,9 @@ public:
     friend class Permittivity;
 
 protected:
-    double width;                         //!< width of the Cavity boundary.
-    std::vector<double> radii;            //!< Contains the radius of each sphere in #Center.
-    std::vector<mrcpp::Coord<3>> centers; //!< Contains each of the spheres centered on the nuclei of the Molecule.
+    double width;                                                            //!< width of the Cavity boundary.
+    std::vector<double> radii;                                               //!< Contains the radius of each sphere in #Center.
+    std::vector<mrcpp::Coord<3>> centers;                                    //!< Contains each of the spheres centered on the nuclei of the Molecule.
     std::vector<std::function<double(const mrcpp::Coord<3> &r)>> gradvector; //< Analytical derivatives of the Cavity.
 
     void setGradVector();

--- a/src/environment/Permittivity.cpp
+++ b/src/environment/Permittivity.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/environment/Permittivity.h
+++ b/src/environment/Permittivity.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/environment/SCRF.cpp
+++ b/src/environment/SCRF.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/environment/SCRF.h
+++ b/src/environment/SCRF.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/chk.cpp
+++ b/src/initial_guess/chk.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/chk.h
+++ b/src/initial_guess/chk.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/core.cpp
+++ b/src/initial_guess/core.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/core.h
+++ b/src/initial_guess/core.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/cube.cpp
+++ b/src/initial_guess/cube.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/cube.h
+++ b/src/initial_guess/cube.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/gto.cpp
+++ b/src/initial_guess/gto.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -67,13 +67,7 @@ namespace mrchem {
  * Projects only the occupied orbitals of each spin.
  *
  */
-bool initial_guess::gto::setup(OrbitalVector &Phi,
-                               double prec,
-                               double screen,
-                               const std::string &bas_file,
-                               const std::string &mop_file,
-                               const std::string &moa_file,
-                               const std::string &mob_file) {
+bool initial_guess::gto::setup(OrbitalVector &Phi, double prec, double screen, const std::string &bas_file, const std::string &mop_file, const std::string &moa_file, const std::string &mob_file) {
     if (Phi.size() == 0) return false;
 
     mrcpp::print::separator(0, '~');
@@ -119,11 +113,7 @@ bool initial_guess::gto::setup(OrbitalVector &Phi,
  * corresponding MW orbitals.
  *
  */
-void initial_guess::gto::project_mo(OrbitalVector &Phi,
-                                    double prec,
-                                    const std::string &bas_file,
-                                    const std::string &mo_file,
-                                    double screen) {
+void initial_guess::gto::project_mo(OrbitalVector &Phi, double prec, const std::string &bas_file, const std::string &mo_file, double screen) {
     if (Phi.size() == 0) return;
 
     Timer t_tot;
@@ -255,11 +245,7 @@ void initial_guess::gto::project_ao(OrbitalVector &Phi, double prec, const Nucle
     mrcpp::print::footer(2, timer, 2);
 }
 
-Density initial_guess::gto::project_density(double prec,
-                                            const Nucleus &nuc,
-                                            const std::string &bas_file,
-                                            const std::string &dens_file,
-                                            double screen) {
+Density initial_guess::gto::project_density(double prec, const Nucleus &nuc, const std::string &bas_file, const std::string &dens_file, double screen) {
     // Setup AO basis
     gto_utils::Intgrl intgrl(bas_file);
     intgrl.getNucleus(0).setCoord(nuc.getCoord());

--- a/src/initial_guess/gto.h
+++ b/src/initial_guess/gto.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/mw.cpp
+++ b/src/initial_guess/mw.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -47,11 +47,7 @@ bool project_mo(OrbitalVector &Phi, double prec, const std::string &mo_file);
 } // namespace mw
 } // namespace initial_guess
 
-bool initial_guess::mw::setup(OrbitalVector &Phi,
-                              double prec,
-                              const std::string &file_p,
-                              const std::string &file_a,
-                              const std::string &file_b) {
+bool initial_guess::mw::setup(OrbitalVector &Phi, double prec, const std::string &file_p, const std::string &file_a, const std::string &file_b) {
     if (Phi.size() == 0) return false;
 
     mrcpp::print::separator(0, '~');

--- a/src/initial_guess/mw.h
+++ b/src/initial_guess/mw.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -41,11 +41,7 @@ namespace mrchem {
 namespace initial_guess {
 namespace mw {
 
-bool setup(OrbitalVector &Phi,
-           double prec,
-           const std::string &file_p,
-           const std::string &file_a,
-           const std::string &file_b);
+bool setup(OrbitalVector &Phi, double prec, const std::string &file_p, const std::string &file_a, const std::string &file_b);
 
 } // namespace mw
 } // namespace initial_guess

--- a/src/initial_guess/sad.cpp
+++ b/src/initial_guess/sad.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/initial_guess/sad.cpp
+++ b/src/initial_guess/sad.cpp
@@ -193,7 +193,7 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, c
     t_lap.start();
     OrbitalVector Psi;
     initial_guess::gto::project_ao(Psi, prec, nucs);
-    if (plevel == 1) mrcpp::print::time(1, "Projecting Hydrogen AOs", t_lap);
+    if (plevel == 1) mrcpp::print::time(1, "Projecting GTO AOs", t_lap);
 
     mrcpp::print::header(2, "Building Fock operator");
     t_lap.start();

--- a/src/initial_guess/sad.h
+++ b/src/initial_guess/sad.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrchem.cpp
+++ b/src/mrchem.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrchem.h
+++ b/src/mrchem.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/Factory.cpp
+++ b/src/mrdft/Factory.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -50,16 +50,15 @@ std::unique_ptr<MRDFT> Factory::build() {
     // Init XCFun
     bool gga = xcfun_is_gga(xcfun_p.get());
     bool lda = not(gga);
-    unsigned int mode = 1;                  //!< only partial derivative mode implemented
-    unsigned int func_type = (gga) ? 1 : 0; //!< only LDA and GGA supported for now
-    unsigned int dens_type = 1 + spin;      //!< only n (dens_type = 1) or alpha & beta (denst_type = 2) supported now.
-    unsigned int laplacian = 0;             //!< no laplacian
-    unsigned int kinetic = 0;               //!< no kinetic energy density
-    unsigned int current = 0;               //!< no current density
+    unsigned int mode = 1;                    //!< only partial derivative mode implemented
+    unsigned int func_type = (gga) ? 1 : 0;   //!< only LDA and GGA supported for now
+    unsigned int dens_type = 1 + spin;        //!< only n (dens_type = 1) or alpha & beta (denst_type = 2) supported now.
+    unsigned int laplacian = 0;               //!< no laplacian
+    unsigned int kinetic = 0;                 //!< no kinetic energy density
+    unsigned int current = 0;                 //!< no current density
     unsigned int exp_derivative = not(gamma); //!< use gamma or explicit derivatives
     if (not(gga)) exp_derivative = 0;         //!< fall back to gamma-type derivatives if LDA
-    xcfun_user_eval_setup(
-        xcfun_p.get(), order, func_type, dens_type, mode, laplacian, kinetic, current, exp_derivative);
+    xcfun_user_eval_setup(xcfun_p.get(), order, func_type, dens_type, mode, laplacian, kinetic, current, exp_derivative);
 
     // Init MW derivative
     if (gga) {

--- a/src/mrdft/Factory.h
+++ b/src/mrdft/Factory.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/Functional.cpp
+++ b/src/mrdft/Functional.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/Functional.h
+++ b/src/mrdft/Functional.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/GGA.cpp
+++ b/src/mrdft/GGA.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/GGA.h
+++ b/src/mrdft/GGA.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/Grid.h
+++ b/src/mrdft/Grid.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/LDA.cpp
+++ b/src/mrdft/LDA.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/LDA.h
+++ b/src/mrdft/LDA.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/MRDFT.cpp
+++ b/src/mrdft/MRDFT.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/MRDFT.h
+++ b/src/mrdft/MRDFT.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/SpinGGA.cpp
+++ b/src/mrdft/SpinGGA.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/SpinGGA.h
+++ b/src/mrdft/SpinGGA.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/SpinLDA.cpp
+++ b/src/mrdft/SpinLDA.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/SpinLDA.h
+++ b/src/mrdft/SpinLDA.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrdft/xc_utils.cpp
+++ b/src/mrdft/xc_utils.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -187,8 +187,7 @@ void xc_utils::expand_nodes(std::vector<mrcpp::FunctionNode<3> *> &out_nodes, Ei
  * param[in] inp_func Function to differentiate
  * param[out] out_grad Gradient of input function
  */
-mrcpp::FunctionTreeVector<3> xc_utils::log_gradient(mrcpp::DerivativeOperator<3> &diff_oper,
-                                                    mrcpp::FunctionTree<3> &inp_func) {
+mrcpp::FunctionTreeVector<3> xc_utils::log_gradient(mrcpp::DerivativeOperator<3> &diff_oper, mrcpp::FunctionTree<3> &inp_func) {
     mrcpp::FunctionTree<3> zeta(inp_func.getMRA());
     mrcpp::copy_grid(zeta, inp_func);
     mrcpp::copy_func(zeta, inp_func);

--- a/src/mrdft/xc_utils.h
+++ b/src/mrdft/xc_utils.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrenum.h
+++ b/src/mrenum.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrenv.cpp
+++ b/src/mrenv.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/mrenv.h
+++ b/src/mrenv.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -80,7 +80,7 @@ int is_bankclient = 1;
 int is_bankmaster = 0; // only one bankmaster is_bankmaster
 int bank_size = 0;
 int tot_bank_size = 0; // size of bank, including the task manager
-int max_tag = 0;        // max value allowed by MPI
+int max_tag = 0;       // max value allowed by MPI
 std::vector<int> bankmaster;
 int task_bank = -1; // world rank of the task manager
 

--- a/src/parallel.h
+++ b/src/parallel.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/DipoleMoment.h
+++ b/src/properties/DipoleMoment.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/GeometricDerivative.h
+++ b/src/properties/GeometricDerivative.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/Magnetizability.h
+++ b/src/properties/Magnetizability.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/NMRShielding.h
+++ b/src/properties/NMRShielding.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/OrbitalEnergies.h
+++ b/src/properties/OrbitalEnergies.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/Polarizability.h
+++ b/src/properties/Polarizability.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/QuadrupoleMoment.h
+++ b/src/properties/QuadrupoleMoment.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/SCFEnergy.h
+++ b/src/properties/SCFEnergy.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/properties/properties_fwd.h
+++ b/src/properties/properties_fwd.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/ComplexFunction.h
+++ b/src/qmfunctions/ComplexFunction.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/Density.cpp
+++ b/src/qmfunctions/Density.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/Density.h
+++ b/src/qmfunctions/Density.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/Orbital.cpp
+++ b/src/qmfunctions/Orbital.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/Orbital.h
+++ b/src/qmfunctions/Orbital.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/OrbitalIterator.cpp
+++ b/src/qmfunctions/OrbitalIterator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -27,7 +27,7 @@
  * Mrchem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -210,8 +210,7 @@ bool OrbitalIterator::next(int max_recv) {
             }
         }
 
-        if ((this->sent_counter >= send_size or not IamSender) and
-            (this->received_counter >= recv_size or not IamReceiver)) {
+        if ((this->sent_counter >= send_size or not IamSender) and (this->received_counter >= recv_size or not IamReceiver)) {
             // all orbitals to be processed during this iteration are ready. Start next iteration
             this->sent_counter = 0;
             this->received_counter = 0;

--- a/src/qmfunctions/OrbitalIterator.h
+++ b/src/qmfunctions/OrbitalIterator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/QMFunction.cpp
+++ b/src/qmfunctions/QMFunction.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/QMFunction.h
+++ b/src/qmfunctions/QMFunction.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/density_utils.cpp
+++ b/src/qmfunctions/density_utils.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -51,12 +51,7 @@ extern mrcpp::MultiResolutionAnalysis<3> *MRA; // Global MRA
 namespace density {
 Density compute(double prec, Orbital phi, DensityType spin);
 void compute_local_X(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &X, DensityType spin);
-void compute_local_XY(double prec,
-                      Density &rho,
-                      OrbitalVector &Phi,
-                      OrbitalVector &X,
-                      OrbitalVector &Y,
-                      DensityType spin);
+void compute_local_XY(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &X, OrbitalVector &Y, DensityType spin);
 double compute_occupation(Orbital &phi, DensityType dens_spin);
 } // namespace density
 
@@ -120,12 +115,7 @@ void density::compute(double prec, Density &rho, OrbitalVector &Phi, DensityType
  *      and X/Y must be the same.
  *
  */
-void density::compute(double prec,
-                      Density &rho,
-                      OrbitalVector &Phi,
-                      OrbitalVector &X,
-                      OrbitalVector &Y,
-                      DensityType spin) {
+void density::compute(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &X, OrbitalVector &Y, DensityType spin) {
     int N_el = orbital::get_electron_number(Phi);
     double rel_prec = prec;        // prec for rho_i = |x_i><phi_i| + |phi_i><x_i|
     double abs_prec = prec / N_el; // prec for rho = sum_i rho_i
@@ -162,12 +152,7 @@ void density::compute_local(double prec, Density &rho, OrbitalVector &Phi, Densi
 
 /** @brief Compute local density as the sum of own (MPI) orbitals
  */
-void density::compute_local(double prec,
-                            Density &rho,
-                            OrbitalVector &Phi,
-                            OrbitalVector &X,
-                            OrbitalVector &Y,
-                            DensityType spin) {
+void density::compute_local(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &X, OrbitalVector &Y, DensityType spin) {
     if (&X == &Y) {
         density::compute_local_X(prec, rho, Phi, X, spin);
     } else {
@@ -200,12 +185,7 @@ void density::compute_local_X(double prec, Density &rho, OrbitalVector &Phi, Orb
     }
 }
 
-void density::compute_local_XY(double prec,
-                               Density &rho,
-                               OrbitalVector &Phi,
-                               OrbitalVector &X,
-                               OrbitalVector &Y,
-                               DensityType spin) {
+void density::compute_local_XY(double prec, Density &rho, OrbitalVector &Phi, OrbitalVector &X, OrbitalVector &Y, DensityType spin) {
     int N_el = orbital::get_electron_number(Phi);
     double mult_prec = prec;       // prec for rho_i = |x_i><phi_i| + |phi_i><y_i|
     double add_prec = prec / N_el; // prec for rho = sum_i rho_i

--- a/src/qmfunctions/density_utils.h
+++ b/src/qmfunctions/density_utils.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/orbital_utils.cpp
+++ b/src/qmfunctions/orbital_utils.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/orbital_utils.h
+++ b/src/qmfunctions/orbital_utils.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/qmfunction_fwd.h
+++ b/src/qmfunctions/qmfunction_fwd.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmfunctions/qmfunction_utils.cpp
+++ b/src/qmfunctions/qmfunction_utils.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -156,12 +156,7 @@ void qmfunction::project(QMFunction &out, mrcpp::RepresentableFunction<3> &f, in
  * Recast into linear_combination.
  *
  */
-void qmfunction::add(QMFunction &out,
-                     ComplexDouble a,
-                     QMFunction inp_a,
-                     ComplexDouble b,
-                     QMFunction inp_b,
-                     double prec) {
+void qmfunction::add(QMFunction &out, ComplexDouble a, QMFunction inp_a, ComplexDouble b, QMFunction inp_b, double prec) {
     ComplexVector coefs(2);
     coefs(0) = a;
     coefs(1) = b;
@@ -176,12 +171,7 @@ void qmfunction::add(QMFunction &out,
 /** @brief out = inp_a * inp_b
  *
  */
-void qmfunction::multiply(QMFunction &out,
-                          QMFunction inp_a,
-                          QMFunction inp_b,
-                          double prec,
-                          bool absPrec,
-                          bool useMaxNorms) {
+void qmfunction::multiply(QMFunction &out, QMFunction inp_a, QMFunction inp_b, double prec, bool absPrec, bool useMaxNorms) {
     multiply_real(out, inp_a, inp_b, prec, absPrec, useMaxNorms);
     multiply_imag(out, inp_a, inp_b, prec, absPrec, useMaxNorms);
 }
@@ -239,12 +229,7 @@ void qmfunction::linear_combination(QMFunction &out, const ComplexVector &c, QMF
 /** @brief out = Re(inp_a * inp_b)
  *
  */
-void qmfunction::multiply_real(QMFunction &out,
-                               QMFunction inp_a,
-                               QMFunction inp_b,
-                               double prec,
-                               bool absPrec,
-                               bool useMaxNorms) {
+void qmfunction::multiply_real(QMFunction &out, QMFunction inp_a, QMFunction inp_b, double prec, bool absPrec, bool useMaxNorms) {
     double conj_a = (inp_a.conjugate()) ? -1.0 : 1.0;
     double conj_b = (inp_b.conjugate()) ? -1.0 : 1.0;
 
@@ -313,12 +298,7 @@ void qmfunction::multiply_real(QMFunction &out,
 /** @brief out = Im(inp_a * inp_b)
  *
  */
-void qmfunction::multiply_imag(QMFunction &out,
-                               QMFunction inp_a,
-                               QMFunction inp_b,
-                               double prec,
-                               bool absPrec,
-                               bool useMaxNorms) {
+void qmfunction::multiply_imag(QMFunction &out, QMFunction inp_a, QMFunction inp_b, double prec, bool absPrec, bool useMaxNorms) {
     double conj_a = (inp_a.conjugate()) ? -1.0 : 1.0;
     double conj_b = (inp_b.conjugate()) ? -1.0 : 1.0;
 

--- a/src/qmfunctions/qmfunction_utils.h
+++ b/src/qmfunctions/qmfunction_utils.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -38,24 +38,9 @@ void add(QMFunction &out, ComplexDouble a, QMFunction inp_a, ComplexDouble b, QM
 void project(QMFunction &out, std::function<double(const mrcpp::Coord<3> &r)> f, int type, double prec);
 void project(QMFunction &out, mrcpp::RepresentableFunction<3> &f, int type, double prec);
 void project(QMFunction &out, mrcpp::GaussExp<3> &f, int type, double prec);
-void multiply(QMFunction &out,
-              QMFunction inp_a,
-              QMFunction inp_b,
-              double prec,
-              bool absPrec = false,
-              bool useMaxNorms = false);
-void multiply_real(QMFunction &out,
-                   QMFunction inp_a,
-                   QMFunction inp_b,
-                   double prec,
-                   bool absPrec = false,
-                   bool useMaxNorms = false);
-void multiply_imag(QMFunction &out,
-                   QMFunction inp_a,
-                   QMFunction inp_b,
-                   double prec,
-                   bool absPrec = false,
-                   bool useMaxNorms = false);
+void multiply(QMFunction &out, QMFunction inp_a, QMFunction inp_b, double prec, bool absPrec = false, bool useMaxNorms = false);
+void multiply_real(QMFunction &out, QMFunction inp_a, QMFunction inp_b, double prec, bool absPrec = false, bool useMaxNorms = false);
+void multiply_imag(QMFunction &out, QMFunction inp_a, QMFunction inp_b, double prec, bool absPrec = false, bool useMaxNorms = false);
 void linear_combination(QMFunction &out, const ComplexVector &c, QMFunctionVector &inp, double prec);
 
 } // namespace qmfunction

--- a/src/qmoperators/QMDerivative.cpp
+++ b/src/qmoperators/QMDerivative.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/QMDerivative.h
+++ b/src/qmoperators/QMDerivative.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/QMIdentity.cpp
+++ b/src/qmoperators/QMIdentity.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/QMIdentity.h
+++ b/src/qmoperators/QMIdentity.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/QMOperator.h
+++ b/src/qmoperators/QMOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/QMPotential.cpp
+++ b/src/qmoperators/QMPotential.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/QMPotential.h
+++ b/src/qmoperators/QMPotential.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/QMSpin.cpp
+++ b/src/qmoperators/QMSpin.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/QMSpin.h
+++ b/src/qmoperators/QMSpin.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -34,15 +34,15 @@ namespace mrchem {
  * @brief Cartesian spin operator
  *
  * Defined by:
- * 
+ *
  *  S_{x} alpha = (1/2)*beta
  *  S_{y} alpha = (i/2)*beta
  *  S_{z} alpha = (1/2)*alpha
- * 
+ *
  *  S_{x} beta =  (1/2)*alpha
  *  S_{y} beta = -(i/2)*alpha
  *  S_{z} beta = -(1/2)*beta
- * 
+ *
  */
 
 class QMSpin final : public QMOperator {
@@ -62,27 +62,26 @@ private:
     QMOperatorVector apply(std::shared_ptr<QMOperator> &O) override;
 };
 
-
 /** @class QMAlpha
  *
  * @brief Spin alpha operator
  *
  * Operator that acts as Identity when applied on alpha (or paired) orbitals,
  * and as Zero when applid on beta orbitals.
- * 
+ *
  * Can be defined as:
- * 
+ *
  *  S_{alpha} = S_{+} * S_{-},
- * 
+ *
  * using the shift operators:
- * 
+ *
  *  S_{+} = S_{x} + i*S_{y}
  *  S_{-} = S_{x} - i*S_{y}
- * 
- * Could have been implemented using the Cartesian spin operators above, 
+ *
+ * Could have been implemented using the Cartesian spin operators above,
  * but we rather do it explicitly as Identity or Zero, to avoid unnecessary
  * deep copies and addition/subtraction of identical contributions.
- *  
+ *
  */
 
 class QMAlpha final : public QMOperator {
@@ -103,20 +102,20 @@ private:
  *
  * Operator that acts as Identity when applied on beta (or paired) orbitals,
  * and as Zero when applid on alpha orbitals.
- * 
+ *
  * Can be defined as:
- * 
+ *
  *  S_{beta} = S_{-} * S_{+},
- * 
+ *
  * using the shift operators:
- * 
+ *
  *  S_{+} = S_{x} + i*S_{y}
  *  S_{-} = S_{x} - i*S_{y}
- *  
- * Could have been implemented using the Cartesian spin operators above, 
+ *
+ * Could have been implemented using the Cartesian spin operators above,
  * but we rather do it explicitly as Identity or Zero, to avoid unnecessary
  * deep copies and addition/subtraction of identical contributions.
- * 
+ *
  */
 
 class QMBeta final : public QMOperator {

--- a/src/qmoperators/one_electron/AngularMomentumOperator.h
+++ b/src/qmoperators/one_electron/AngularMomentumOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/DeltaOperator.h
+++ b/src/qmoperators/one_electron/DeltaOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/DistanceOperator.h
+++ b/src/qmoperators/one_electron/DistanceOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/ElectricFieldOperator.h
+++ b/src/qmoperators/one_electron/ElectricFieldOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/H_BB_dia.h
+++ b/src/qmoperators/one_electron/H_BB_dia.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/H_BM_dia.h
+++ b/src/qmoperators/one_electron/H_BM_dia.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/H_B_dip.h
+++ b/src/qmoperators/one_electron/H_B_dip.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/H_B_spin.h
+++ b/src/qmoperators/one_electron/H_B_spin.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/H_E_dip.h
+++ b/src/qmoperators/one_electron/H_E_dip.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/H_E_quad.h
+++ b/src/qmoperators/one_electron/H_E_quad.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/H_MB_dia.h
+++ b/src/qmoperators/one_electron/H_MB_dia.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/H_M_fc.h
+++ b/src/qmoperators/one_electron/H_M_fc.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/H_M_pso.h
+++ b/src/qmoperators/one_electron/H_M_pso.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/IdentityOperator.h
+++ b/src/qmoperators/one_electron/IdentityOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/KineticOperator.h
+++ b/src/qmoperators/one_electron/KineticOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/MagneticFieldOperator.h
+++ b/src/qmoperators/one_electron/MagneticFieldOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/MomentumOperator.h
+++ b/src/qmoperators/one_electron/MomentumOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/NablaOperator.h
+++ b/src/qmoperators/one_electron/NablaOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/NuclearGradientOperator.h
+++ b/src/qmoperators/one_electron/NuclearGradientOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/NuclearOperator.cpp
+++ b/src/qmoperators/one_electron/NuclearOperator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/NuclearOperator.h
+++ b/src/qmoperators/one_electron/NuclearOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/PositionOperator.h
+++ b/src/qmoperators/one_electron/PositionOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/SpinOperator.h
+++ b/src/qmoperators/one_electron/SpinOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/ZoraKineticOperator.h
+++ b/src/qmoperators/one_electron/ZoraKineticOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/one_electron/ZoraOperator.h
+++ b/src/qmoperators/one_electron/ZoraOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "tensor/RankZeroOperator.h"
-#include "qmoperators/QMPotential.h"
 #include "qmfunctions/qmfunction_utils.h"
+#include "qmoperators/QMPotential.h"
+#include "tensor/RankZeroOperator.h"
 
 namespace mrchem {
 
@@ -59,5 +59,5 @@ public:
         }
     }
 };
-   
+
 } // namespace mrchem

--- a/src/qmoperators/qmoperator_utils.cpp
+++ b/src/qmoperators/qmoperator_utils.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -154,13 +154,13 @@ ComplexMatrix qmoperator::calc_kinetic_matrix_component_symmetrized(int d, Momen
 
     int nNodes = 0, sNodes = 0;
     if (&bra == &ket) {
-        OrbitalVector dKet = (V*p[d])(ket);
+        OrbitalVector dKet = (V * p[d])(ket);
         nNodes += orbital::get_n_nodes(dKet);
         sNodes += orbital::get_size_nodes(dKet);
         T = orbital::calc_overlap_matrix(dKet, dKet);
     } else {
-        OrbitalVector dBra = (V*p[d])(bra);
-        OrbitalVector dKet = (V*p[d])(ket);
+        OrbitalVector dBra = (V * p[d])(bra);
+        OrbitalVector dKet = (V * p[d])(ket);
         nNodes += orbital::get_n_nodes(dBra);
         nNodes += orbital::get_n_nodes(dKet);
         sNodes += orbital::get_size_nodes(dBra);

--- a/src/qmoperators/qmoperator_utils.h
+++ b/src/qmoperators/qmoperator_utils.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/two_electron/CoulombOperator.h
+++ b/src/qmoperators/two_electron/CoulombOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -51,9 +51,7 @@ public:
         J = potential;
         J.name() = "J";
     }
-    CoulombOperator(std::shared_ptr<mrcpp::PoissonOperator> P,
-                    std::shared_ptr<OrbitalVector> Phi,
-                    bool mpi_share = false) {
+    CoulombOperator(std::shared_ptr<mrcpp::PoissonOperator> P, std::shared_ptr<OrbitalVector> Phi, bool mpi_share = false) {
         potential = std::make_shared<CoulombPotentialD1>(P, Phi, mpi_share);
 
         // Invoke operator= to assign *this operator
@@ -61,11 +59,7 @@ public:
         J = potential;
         J.name() = "J";
     }
-    CoulombOperator(std::shared_ptr<mrcpp::PoissonOperator> P,
-                    std::shared_ptr<OrbitalVector> Phi,
-                    std::shared_ptr<OrbitalVector> X,
-                    std::shared_ptr<OrbitalVector> Y,
-                    bool mpi_share = false) {
+    CoulombOperator(std::shared_ptr<mrcpp::PoissonOperator> P, std::shared_ptr<OrbitalVector> Phi, std::shared_ptr<OrbitalVector> X, std::shared_ptr<OrbitalVector> Y, bool mpi_share = false) {
         potential = std::make_shared<CoulombPotentialD2>(P, Phi, X, Y, mpi_share);
 
         // Invoke operator= to assign *this operator

--- a/src/qmoperators/two_electron/CoulombPotential.cpp
+++ b/src/qmoperators/two_electron/CoulombPotential.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/two_electron/CoulombPotential.h
+++ b/src/qmoperators/two_electron/CoulombPotential.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -51,9 +51,7 @@ namespace mrchem {
 
 class CoulombPotential : public QMPotential {
 public:
-    explicit CoulombPotential(std::shared_ptr<mrcpp::PoissonOperator> P,
-                              std::shared_ptr<OrbitalVector> Phi = nullptr,
-                              bool mpi_share = false);
+    explicit CoulombPotential(std::shared_ptr<mrcpp::PoissonOperator> P, std::shared_ptr<OrbitalVector> Phi = nullptr, bool mpi_share = false);
     ~CoulombPotential() override = default;
 
     friend class CoulombOperator;
@@ -61,7 +59,7 @@ public:
 protected:
     Density density; ///< Ground-state electron density
 
-    std::shared_ptr<OrbitalVector> orbitals; ///< Unperturbed orbitals defining the ground-state electron density
+    std::shared_ptr<OrbitalVector> orbitals;         ///< Unperturbed orbitals defining the ground-state electron density
     std::shared_ptr<mrcpp::PoissonOperator> poisson; ///< Operator used to compute the potential
 
     auto &getPoisson() { return this->poisson; }

--- a/src/qmoperators/two_electron/CoulombPotentialD1.cpp
+++ b/src/qmoperators/two_electron/CoulombPotentialD1.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/two_electron/CoulombPotentialD1.h
+++ b/src/qmoperators/two_electron/CoulombPotentialD1.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -31,9 +31,7 @@ namespace mrchem {
 
 class CoulombPotentialD1 final : public CoulombPotential {
 public:
-    CoulombPotentialD1(std::shared_ptr<mrcpp::PoissonOperator> P,
-                       std::shared_ptr<OrbitalVector> Phi,
-                       bool mpi_share = false)
+    CoulombPotentialD1(std::shared_ptr<mrcpp::PoissonOperator> P, std::shared_ptr<OrbitalVector> Phi, bool mpi_share = false)
             : CoulombPotential(P, Phi, mpi_share) {}
 
 private:

--- a/src/qmoperators/two_electron/CoulombPotentialD2.cpp
+++ b/src/qmoperators/two_electron/CoulombPotentialD2.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -39,11 +39,7 @@ using OrbitalVector_p = std::shared_ptr<mrchem::OrbitalVector>;
 
 namespace mrchem {
 
-CoulombPotentialD2::CoulombPotentialD2(PoissonOperator_p P,
-                                       OrbitalVector_p Phi,
-                                       OrbitalVector_p X,
-                                       OrbitalVector_p Y,
-                                       bool mpi_share)
+CoulombPotentialD2::CoulombPotentialD2(PoissonOperator_p P, OrbitalVector_p Phi, OrbitalVector_p X, OrbitalVector_p Y, bool mpi_share)
         : CoulombPotential(P, Phi, mpi_share)
         , orbitals_x(X)
         , orbitals_y(Y) {}

--- a/src/qmoperators/two_electron/CoulombPotentialD2.h
+++ b/src/qmoperators/two_electron/CoulombPotentialD2.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -31,11 +31,7 @@ namespace mrchem {
 
 class CoulombPotentialD2 final : public CoulombPotential {
 public:
-    CoulombPotentialD2(std::shared_ptr<mrcpp::PoissonOperator> P,
-                       std::shared_ptr<OrbitalVector> Phi,
-                       std::shared_ptr<OrbitalVector> X,
-                       std::shared_ptr<OrbitalVector> Y,
-                       bool mpi_share = false);
+    CoulombPotentialD2(std::shared_ptr<mrcpp::PoissonOperator> P, std::shared_ptr<OrbitalVector> Phi, std::shared_ptr<OrbitalVector> X, std::shared_ptr<OrbitalVector> Y, bool mpi_share = false);
 
 private:
     std::shared_ptr<OrbitalVector> orbitals_x; ///< Perturbed orbitals

--- a/src/qmoperators/two_electron/ExchangeOperator.h
+++ b/src/qmoperators/two_electron/ExchangeOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -46,9 +46,7 @@ namespace mrchem {
 
 class ExchangeOperator final : public RankZeroOperator {
 public:
-    ExchangeOperator(std::shared_ptr<mrcpp::PoissonOperator> P,
-                     std::shared_ptr<OrbitalVector> Phi,
-                     double exchange_prec = -1.0) {
+    ExchangeOperator(std::shared_ptr<mrcpp::PoissonOperator> P, std::shared_ptr<OrbitalVector> Phi, double exchange_prec = -1.0) {
         exchange = std::make_shared<ExchangePotentialD1>(P, Phi, exchange_prec);
 
         // Invoke operator= to assign *this operator
@@ -57,11 +55,7 @@ public:
         K.name() = "K";
     }
 
-    ExchangeOperator(std::shared_ptr<mrcpp::PoissonOperator> P,
-                     std::shared_ptr<OrbitalVector> Phi,
-                     std::shared_ptr<OrbitalVector> X,
-                     std::shared_ptr<OrbitalVector> Y,
-                     double exchange_prec = -1.0) {
+    ExchangeOperator(std::shared_ptr<mrcpp::PoissonOperator> P, std::shared_ptr<OrbitalVector> Phi, std::shared_ptr<OrbitalVector> X, std::shared_ptr<OrbitalVector> Y, double exchange_prec = -1.0) {
         exchange = std::make_shared<ExchangePotentialD2>(P, Phi, X, Y, exchange_prec);
 
         // Invoke operator= to assign *this operator

--- a/src/qmoperators/two_electron/ExchangePotential.cpp
+++ b/src/qmoperators/two_electron/ExchangePotential.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -147,12 +147,7 @@ void ExchangePotential::clear() {
  * then applies the Poisson operator, and multiplies the result
  * by phi_k (and optionally by phi_j). The result is given in phi_out.
  */
-void ExchangePotential::calcExchange_kij(double prec,
-                                         Orbital phi_k,
-                                         Orbital phi_i,
-                                         Orbital phi_j,
-                                         Orbital &out_kij,
-                                         Orbital *out_jji) {
+void ExchangePotential::calcExchange_kij(double prec, Orbital phi_k, Orbital phi_i, Orbital phi_j, Orbital &out_kij, Orbital *out_jji) {
     Timer timer_tot;
     mrcpp::PoissonOperator &P = *this->poisson;
 
@@ -183,10 +178,8 @@ void ExchangePotential::calcExchange_kij(double prec,
     if (phi_j.hasReal() and &phi_j != &phi_k) phi_opt_vec.push_back(std::make_tuple(1.0, &phi_j.real()));
     if (phi_j.hasImag() and &phi_j != &phi_k) phi_opt_vec.push_back(std::make_tuple(1.0, &phi_j.imag()));
 
-    if (phi_i.hasReal() and &phi_i != &phi_k and &phi_i != &phi_j)
-        phi_opt_vec.push_back(std::make_tuple(1.0, &phi_i.real()));
-    if (phi_i.hasImag() and &phi_i != &phi_k and &phi_i != &phi_j)
-        phi_opt_vec.push_back(std::make_tuple(1.0, &phi_i.imag()));
+    if (phi_i.hasReal() and &phi_i != &phi_k and &phi_i != &phi_j) phi_opt_vec.push_back(std::make_tuple(1.0, &phi_i.real()));
+    if (phi_i.hasImag() and &phi_i != &phi_k and &phi_i != &phi_j) phi_opt_vec.push_back(std::make_tuple(1.0, &phi_i.imag()));
 
     // compute V_ij = P[rho_ij]
     Timer timer_p;
@@ -224,11 +217,9 @@ void ExchangePotential::calcExchange_kij(double prec,
 
     println(4,
             " time " << (int)((float)timer_tot.elapsed() * 1000) << " ms "
-                     << " mult1:" << (int)((float)timer_ij.elapsed() * 1000) << " Pot:"
-                     << (int)((float)timer_p.elapsed() * 1000) << " mult2:" << (int)((float)timer_kij.elapsed() * 1000)
-                     << " " << (int)((float)timer_jji.elapsed() * 1000) << " Nnodes: " << N_i << " " << N_j << " "
-                     << N_ij << " " << N_p << " " << N_kij << " " << N_jji << " norms " << norm_ij << " " << norm_p
-                     << " " << norm_kij << "  " << norm_jji);
+                     << " mult1:" << (int)((float)timer_ij.elapsed() * 1000) << " Pot:" << (int)((float)timer_p.elapsed() * 1000) << " mult2:" << (int)((float)timer_kij.elapsed() * 1000) << " "
+                     << (int)((float)timer_jji.elapsed() * 1000) << " Nnodes: " << N_i << " " << N_j << " " << N_ij << " " << N_p << " " << N_kij << " " << N_jji << " norms " << norm_ij << " "
+                     << norm_p << " " << norm_kij << "  " << norm_jji);
 }
 
 } // namespace mrchem

--- a/src/qmoperators/two_electron/ExchangePotential.h
+++ b/src/qmoperators/two_electron/ExchangePotential.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -79,12 +79,7 @@ protected:
     virtual void setupInternal(double prec) {}
     void clearInternal() { this->exchange.clear(); }
 
-    void calcExchange_kij(double prec,
-                          Orbital phi_k,
-                          Orbital phi_i,
-                          Orbital phi_j,
-                          Orbital &out_kij,
-                          Orbital *out_jji = nullptr);
+    void calcExchange_kij(double prec, Orbital phi_k, Orbital phi_i, Orbital phi_j, Orbital &out_kij, Orbital *out_jji = nullptr);
 };
 
 } // namespace mrchem

--- a/src/qmoperators/two_electron/ExchangePotentialD1.cpp
+++ b/src/qmoperators/two_electron/ExchangePotentialD1.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/two_electron/ExchangePotentialD1.h
+++ b/src/qmoperators/two_electron/ExchangePotentialD1.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/two_electron/ExchangePotentialD2.cpp
+++ b/src/qmoperators/two_electron/ExchangePotentialD2.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -50,11 +50,7 @@ namespace mrchem {
  * @param[in] P Poisson operator (does not take ownership)
  * @param[in] Phi vector of orbitals which define the exchange operator
  */
-ExchangePotentialD2::ExchangePotentialD2(PoissonOperator_p P,
-                                         OrbitalVector_p Phi,
-                                         OrbitalVector_p X,
-                                         OrbitalVector_p Y,
-                                         double prec)
+ExchangePotentialD2::ExchangePotentialD2(PoissonOperator_p P, OrbitalVector_p Phi, OrbitalVector_p X, OrbitalVector_p Y, double prec)
         : ExchangePotential(P, Phi, prec)
         , orbitals_x(X)
         , orbitals_y(Y) {
@@ -214,6 +210,5 @@ Orbital ExchangePotentialD2::dagger(Orbital phi_p) {
 QMOperatorVector ExchangePotentialD2::apply(QMOperator_p &O) {
     NOT_IMPLEMENTED_ABORT;
 }
-
 
 } // namespace mrchem

--- a/src/qmoperators/two_electron/ExchangePotentialD2.h
+++ b/src/qmoperators/two_electron/ExchangePotentialD2.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -52,11 +52,7 @@ namespace mrchem {
 
 class ExchangePotentialD2 final : public ExchangePotential {
 public:
-    ExchangePotentialD2(std::shared_ptr<mrcpp::PoissonOperator> P,
-                        std::shared_ptr<OrbitalVector> Phi,
-                        std::shared_ptr<OrbitalVector> X,
-                        std::shared_ptr<OrbitalVector> Y,
-                        double prec);
+    ExchangePotentialD2(std::shared_ptr<mrcpp::PoissonOperator> P, std::shared_ptr<OrbitalVector> Phi, std::shared_ptr<OrbitalVector> X, std::shared_ptr<OrbitalVector> Y, double prec);
     ~ExchangePotentialD2() override = default;
 
     friend class ExchangeOperator;

--- a/src/qmoperators/two_electron/FockBuilder.cpp
+++ b/src/qmoperators/two_electron/FockBuilder.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -37,10 +37,10 @@
 #include "qmfunctions/Orbital.h"
 #include "qmfunctions/orbital_utils.h"
 #include "qmoperators/one_electron/ElectricFieldOperator.h"
-#include "qmoperators/one_electron/KineticOperator.h"
-#include "qmoperators/one_electron/NuclearOperator.h"
-#include "qmoperators/one_electron/NablaOperator.h"
 #include "qmoperators/one_electron/IdentityOperator.h"
+#include "qmoperators/one_electron/KineticOperator.h"
+#include "qmoperators/one_electron/NablaOperator.h"
+#include "qmoperators/one_electron/NuclearOperator.h"
 #include "qmoperators/one_electron/ZoraOperator.h"
 #include "qmoperators/qmoperator_utils.h"
 #include "utils/math_utils.h"
@@ -243,7 +243,7 @@ OrbitalVector FockBuilder::buildHelmholtzArgumentZORA(OrbitalVector &Phi, Orbita
     OrbitalVector epsPhi = orbital::deep_copy(Phi);
     for (int i = 0; i < epsPhi.size(); i++) {
         if (not mpi::my_orb(epsPhi[i])) continue;
-        epsPhi[i].rescale(eps[i]/two_cc);
+        epsPhi[i].rescale(eps[i] / two_cc);
     }
 
     // Compute OrbitalVectors
@@ -268,7 +268,7 @@ OrbitalVector FockBuilder::buildHelmholtzArgumentZORA(OrbitalVector &Phi, Orbita
     operThree.clear();
     operOne.clear();
     return kappa_m1(out);
-} 
+}
 
 // Non-relativistic Helmholtz argument
 OrbitalVector FockBuilder::buildHelmholtzArgumentNREL(OrbitalVector &Phi, OrbitalVector &Psi) {

--- a/src/qmoperators/two_electron/FockBuilder.h
+++ b/src/qmoperators/two_electron/FockBuilder.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -25,9 +25,9 @@
 
 #pragma once
 
-#include "tensor/RankZeroOperator.h"
-#include "tensor/RankOneOperator.h"
 #include "qmoperators/QMPotential.h"
+#include "tensor/RankOneOperator.h"
+#include "tensor/RankZeroOperator.h"
 
 /** @class FockOperator
  *
@@ -93,16 +93,16 @@ private:
     double exact_exchange{1.0};
     RankZeroOperator zora_base;
 
-    RankZeroOperator V;       ///< Total potential energy operator
-    RankZeroOperator H_1;     ///< Perturbation operators
+    RankZeroOperator V;   ///< Total potential energy operator
+    RankZeroOperator H_1; ///< Perturbation operators
 
     std::shared_ptr<MomentumOperator> mom{nullptr};
     std::shared_ptr<NuclearOperator> nuc{nullptr};
     std::shared_ptr<CoulombOperator> coul{nullptr};
     std::shared_ptr<ExchangeOperator> ex{nullptr};
     std::shared_ptr<XCOperator> xc{nullptr};
-    std::shared_ptr<ReactionOperator> Ro{nullptr};           // Reaction field operator
-    std::shared_ptr<ElectricFieldOperator> ext{nullptr};     // Total external potential
+    std::shared_ptr<ReactionOperator> Ro{nullptr};       // Reaction field operator
+    std::shared_ptr<ElectricFieldOperator> ext{nullptr}; // Total external potential
     std::shared_ptr<ZoraOperator> kappa{nullptr};
     std::shared_ptr<ZoraOperator> kappa_inv{nullptr};
 

--- a/src/qmoperators/two_electron/ReactionOperator.h
+++ b/src/qmoperators/two_electron/ReactionOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -55,7 +55,7 @@ public:
     double getNuclearEnergy() { return this->potential->getNuclearEnergy(); }
     double getElectronicEnergy() { return this->potential->getElectronicEnergy(); }
 
-    SCRF* getHelper() { return this->potential->getHelper(); }
+    SCRF *getHelper() { return this->potential->getHelper(); }
     std::shared_ptr<ReactionPotential> getPotential() { return this->potential; }
     void updateMOResidual(double const err_t) { this->potential->updateMOResidual(err_t); }
 

--- a/src/qmoperators/two_electron/ReactionPotential.cpp
+++ b/src/qmoperators/two_electron/ReactionPotential.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/two_electron/ReactionPotential.h
+++ b/src/qmoperators/two_electron/ReactionPotential.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -74,9 +74,9 @@ protected:
     void clear();
 
 private:
-    bool first_iteration = true; //!< when this variable is true the reaction potential is not calculated. This is done
-                                 //!< only in the zero-th iteration of the SCF procedure, after that it is set to false.
-    std::unique_ptr<SCRF> helper; //!< A SCRF instance used to compute the ReactionPotential.
+    bool first_iteration = true;                //!< when this variable is true the reaction potential is not calculated. This is done
+                                                //!< only in the zero-th iteration of the SCF procedure, after that it is set to false.
+    std::unique_ptr<SCRF> helper;               //!< A SCRF instance used to compute the ReactionPotential.
     std::shared_ptr<mrchem::OrbitalVector> Phi; //!< holds the Orbitals needed to compute the electronic density for the SCRF procedure.
 
     void setup(double prec);

--- a/src/qmoperators/two_electron/XCOperator.h
+++ b/src/qmoperators/two_electron/XCOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -43,9 +43,7 @@ namespace mrchem {
 
 class XCOperator final : public RankZeroOperator {
 public:
-    explicit XCOperator(std::unique_ptr<mrdft::MRDFT> &F,
-                        std::shared_ptr<OrbitalVector> Phi = nullptr,
-                        bool mpi_shared = false) {
+    explicit XCOperator(std::unique_ptr<mrdft::MRDFT> &F, std::shared_ptr<OrbitalVector> Phi = nullptr, bool mpi_shared = false) {
         potential = std::make_shared<XCPotentialD1>(F, Phi, mpi_shared);
 
         // Invoke operator= to assign *this operator
@@ -53,11 +51,7 @@ public:
         XC = potential;
         XC.name() = "V_xc";
     }
-    XCOperator(std::unique_ptr<mrdft::MRDFT> &F,
-               std::shared_ptr<OrbitalVector> Phi,
-               std::shared_ptr<OrbitalVector> X,
-               std::shared_ptr<OrbitalVector> Y,
-               bool mpi_shared = false) {
+    XCOperator(std::unique_ptr<mrdft::MRDFT> &F, std::shared_ptr<OrbitalVector> Phi, std::shared_ptr<OrbitalVector> X, std::shared_ptr<OrbitalVector> Y, bool mpi_shared = false) {
         potential = std::make_shared<XCPotentialD2>(F, Phi, X, Y, mpi_shared);
 
         // Invoke operator= to assign *this operator

--- a/src/qmoperators/two_electron/XCPotential.cpp
+++ b/src/qmoperators/two_electron/XCPotential.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/two_electron/XCPotential.h
+++ b/src/qmoperators/two_electron/XCPotential.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -55,9 +55,7 @@ namespace mrchem {
 
 class XCPotential : public QMPotential {
 public:
-    explicit XCPotential(std::unique_ptr<mrdft::MRDFT> &F,
-                         std::shared_ptr<OrbitalVector> Phi = nullptr,
-                         bool mpi_shared = false)
+    explicit XCPotential(std::unique_ptr<mrdft::MRDFT> &F, std::shared_ptr<OrbitalVector> Phi = nullptr, bool mpi_shared = false)
             : QMPotential(1, mpi_shared)
             , energy(0.0)
             , orbitals(Phi)

--- a/src/qmoperators/two_electron/XCPotentialD1.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD1.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/qmoperators/two_electron/XCPotentialD1.h
+++ b/src/qmoperators/two_electron/XCPotentialD1.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -52,9 +52,7 @@ namespace mrchem {
 
 class XCPotentialD1 final : public XCPotential {
 public:
-    explicit XCPotentialD1(std::unique_ptr<mrdft::MRDFT> &F,
-                           std::shared_ptr<OrbitalVector> Phi = nullptr,
-                           bool mpi_shared = false);
+    explicit XCPotentialD1(std::unique_ptr<mrdft::MRDFT> &F, std::shared_ptr<OrbitalVector> Phi = nullptr, bool mpi_shared = false);
 
 private:
     mrcpp::FunctionTreeVector<3> setupDensities(double prec, mrcpp::FunctionTree<3> &grid) override;

--- a/src/qmoperators/two_electron/XCPotentialD2.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD2.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -41,11 +41,7 @@ using mrcpp::Timer;
 
 namespace mrchem {
 
-XCPotentialD2::XCPotentialD2(std::unique_ptr<mrdft::MRDFT> &F,
-                             std::shared_ptr<OrbitalVector> Phi,
-                             std::shared_ptr<OrbitalVector> X,
-                             std::shared_ptr<OrbitalVector> Y,
-                             bool mpi_shared)
+XCPotentialD2::XCPotentialD2(std::unique_ptr<mrdft::MRDFT> &F, std::shared_ptr<OrbitalVector> Phi, std::shared_ptr<OrbitalVector> X, std::shared_ptr<OrbitalVector> Y, bool mpi_shared)
         : XCPotential(F, Phi, mpi_shared)
         , orbitals_x(X)
         , orbitals_y(Y) {

--- a/src/qmoperators/two_electron/XCPotentialD2.h
+++ b/src/qmoperators/two_electron/XCPotentialD2.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -52,11 +52,7 @@ namespace mrchem {
 
 class XCPotentialD2 final : public XCPotential {
 public:
-    XCPotentialD2(std::unique_ptr<mrdft::MRDFT> &F,
-                  std::shared_ptr<OrbitalVector> Phi,
-                  std::shared_ptr<OrbitalVector> X,
-                  std::shared_ptr<OrbitalVector> Y,
-                  bool mpi_shared = false);
+    XCPotentialD2(std::unique_ptr<mrdft::MRDFT> &F, std::shared_ptr<OrbitalVector> Phi, std::shared_ptr<OrbitalVector> X, std::shared_ptr<OrbitalVector> Y, bool mpi_shared = false);
 
 private:
     std::shared_ptr<OrbitalVector> orbitals_x; ///< 1st external set of perturbed orbitals used to build the density

--- a/src/scf_solver/Accelerator.cpp
+++ b/src/scf_solver/Accelerator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -197,11 +197,7 @@ bool Accelerator::verifyOverlap(OrbitalVector &Phi) {
  * by new ones. If the length of history is _larger_ than maxHistory, the
  * oldest iteration is discarded.
  */
-void Accelerator::accelerate(double prec,
-                             OrbitalVector &Phi,
-                             OrbitalVector &dPhi,
-                             ComplexMatrix *F,
-                             ComplexMatrix *dF) {
+void Accelerator::accelerate(double prec, OrbitalVector &Phi, OrbitalVector &dPhi, ComplexMatrix *F, ComplexMatrix *dF) {
     if (this->maxHistory < 1) return;
 
     Timer t_tot;

--- a/src/scf_solver/Accelerator.h
+++ b/src/scf_solver/Accelerator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -106,11 +106,7 @@ protected:
     void sortLinearSystem(std::vector<ComplexMatrix> &A_mat, std::vector<ComplexVector> &b_vec);
 
     virtual void setupLinearSystem() = 0;
-    virtual void expandSolution(double prec,
-                                OrbitalVector &phi,
-                                OrbitalVector &dPhi,
-                                ComplexMatrix *F,
-                                ComplexMatrix *dF) = 0;
+    virtual void expandSolution(double prec, OrbitalVector &phi, OrbitalVector &dPhi, ComplexMatrix *F, ComplexMatrix *dF) = 0;
 };
 
 } // namespace mrchem

--- a/src/scf_solver/GroundStateSolver.cpp
+++ b/src/scf_solver/GroundStateSolver.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/GroundStateSolver.h
+++ b/src/scf_solver/GroundStateSolver.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/HelmholtzVector.cpp
+++ b/src/scf_solver/HelmholtzVector.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/HelmholtzVector.h
+++ b/src/scf_solver/HelmholtzVector.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/KAIN.cpp
+++ b/src/scf_solver/KAIN.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/KAIN.h
+++ b/src/scf_solver/KAIN.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/LinearResponseSolver.cpp
+++ b/src/scf_solver/LinearResponseSolver.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/LinearResponseSolver.h
+++ b/src/scf_solver/LinearResponseSolver.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/scf_solver/SCFSolver.cpp
+++ b/src/scf_solver/SCFSolver.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -169,11 +169,7 @@ void SCFSolver::printUpdate(int plevel, const std::string &txt, double P, double
  * @param Phi: orbital vector
  * @param flag: interpret epsilon as energy or norm
  */
-void SCFSolver::printOrbitals(const DoubleVector &norms,
-                              const DoubleVector &errors,
-                              OrbitalVector &Phi,
-                              int flag,
-                              bool print_head) const {
+void SCFSolver::printOrbitals(const DoubleVector &norms, const DoubleVector &errors, OrbitalVector &Phi, int flag, bool print_head) const {
     int pprec = Printer::getPrecision();
     int w0 = (Printer::getWidth() - 1);
     int w1 = 5;
@@ -314,8 +310,7 @@ void SCFSolver::printMemory() const {
     mrcpp::print::value(2, "Average memory process", mem_vec.mean(), mem_unit, 2, false);
     if (mpi::bank_size > 0 and mpi::grand_master()) {
         if (mem_unit == "(GB)") {
-            mrcpp::print::value(
-                1, "Maximum data in bank", (double)dataBank.get_maxtotalsize() / 1024, mem_unit, 2, false);
+            mrcpp::print::value(1, "Maximum data in bank", (double)dataBank.get_maxtotalsize() / 1024, mem_unit, 2, false);
         } else {
             mrcpp::print::value(1, "Maximum data in bank", (double)dataBank.get_maxtotalsize(), "(MB)", 2, false);
         }

--- a/src/scf_solver/SCFSolver.h
+++ b/src/scf_solver/SCFSolver.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -73,7 +73,6 @@ protected:
     std::vector<double> error;    ///< Convergence orbital error
     std::vector<double> property; ///< Convergence property error
 
-
     virtual void reset();
 
     double adjustPrecision(double error);
@@ -86,11 +85,7 @@ protected:
     void printConvergence(bool converged, const std::string &txt) const;
     void printConvergenceHeader(const std::string &txt) const;
     void printConvergenceRow(int i) const;
-    void printOrbitals(const DoubleVector &norms,
-                       const DoubleVector &errors,
-                       OrbitalVector &Phi,
-                       int flag,
-                       bool print_head = true) const;
+    void printOrbitals(const DoubleVector &norms, const DoubleVector &errors, OrbitalVector &Phi, int flag, bool print_head = true) const;
     void printResidual(double residual, bool converged) const;
     void printMemory() const;
 };

--- a/src/tensor/RankOneOperator.cpp
+++ b/src/tensor/RankOneOperator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/tensor/RankOneOperator.h
+++ b/src/tensor/RankOneOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/tensor/RankTwoOperator.cpp
+++ b/src/tensor/RankTwoOperator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/tensor/RankTwoOperator.h
+++ b/src/tensor/RankTwoOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/tensor/RankZeroOperator.cpp
+++ b/src/tensor/RankZeroOperator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/tensor/RankZeroOperator.h
+++ b/src/tensor/RankZeroOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/tensor/TensorOperator.h
+++ b/src/tensor/TensorOperator.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/tensor/tensor_fwd.h
+++ b/src/tensor/tensor_fwd.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/tensor/tensor_utils.cpp
+++ b/src/tensor/tensor_utils.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/tensor/tensor_utils.h
+++ b/src/tensor/tensor_utils.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/Bank.h
+++ b/src/utils/Bank.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -112,7 +112,7 @@ private:
     std::map<int, std::vector<queue_struct> *> get_queue;            // gives deposits of an account
     std::map<int, std::map<int, std::vector<int>> *> get_readytasks; // used by task manager
     std::map<int, long long> currentsize;                            // total deposited data size (without containers)
-    long long maxsize = 0; // max total deposited data size (without containers)
+    long long maxsize = 0;                                           // max total deposited data size (without containers)
 };
 
 class BankAccount {

--- a/src/utils/MolPlotter.h
+++ b/src/utils/MolPlotter.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/NonlinearMaximizer.cpp
+++ b/src/utils/NonlinearMaximizer.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -52,8 +52,7 @@ int NonlinearMaximizer::maximize() {
     double old_norm, new_norm, gradient_norm, value_functional, expected_change, relative_change;
     double value_functional_old, step_norm2, first_order, second_order, valdiff;
 
-    int print =
-        0; // 0: print nothing, 1: print only one line, 2: print one line per iteration; >50 print entire matrices
+    int print = 0;      // 0: print nothing, 1: print only one line, 2: print one line per iteration; >50 print entire matrices
     int maxIter = 150;  // max number of iterations
     int CG_maxiter = 5; // max number of iterations for the Conjugated Gradient solver for Newton step
     bool converged = false;
@@ -97,15 +96,12 @@ int NonlinearMaximizer::maximize() {
         // To find mu, the trust radius is approximated using only the largest contribution in the series
         mu = mu_min;
         for (i = 0; i < N2h; i++) {
-            if (eiVal(i) + std::abs(this->gradient(i)) / h > mu)
-                mu = eiVal(i) + std::abs(this->gradient(i)) / h + 1.E-16;
+            if (eiVal(i) + std::abs(this->gradient(i)) / h > mu) mu = eiVal(i) + std::abs(this->gradient(i)) / h + 1.E-16;
         }
 
         diag = DoubleVector::Constant(N2h, -mu);
         diag += eiVal; // shifted eigenvalues of Hessian
-        if (print > 100 and mpi::orb_rank == 0) {
-            cout << "mu and The shifted eigenvalues of H are: " << mu << " h= " << h << "  " << diag << endl;
-        }
+        if (print > 100 and mpi::orb_rank == 0) { cout << "mu and The shifted eigenvalues of H are: " << mu << " h= " << h << "  " << diag << endl; }
         if (print > 10 and mpi::orb_rank == 0) cout << "largest eigenvalues of H: " << maxEiVal << endl;
 
         for (i = 0; i < N2h; i++) { step(i) = -this->gradient(i) / diag(i); }
@@ -135,8 +131,7 @@ int NonlinearMaximizer::maximize() {
         first_order = this->gradient.transpose() * step;
         second_order = 0.0; // step.transpose()*this->hessian*step;
         for (i = 0; i < N2h; i++) { second_order += step(i) * step(i) * eiVal(i); }
-        if (print > 10 and mpi::orb_rank == 0)
-            cout << " gradient magnitude: " << first_order * first_order / step_norm2 << endl;
+        if (print > 10 and mpi::orb_rank == 0) cout << " gradient magnitude: " << first_order * first_order / step_norm2 << endl;
 
         // Newton step when all eigenvalues are <0, and gradient/h sufficiently small
         newton_step = 0;
@@ -204,9 +199,7 @@ int NonlinearMaximizer::maximize() {
                 mu_Newton = mu_Newton_init;
             }
 
-            if (print == 20 and mpi::orb_rank == 0)
-                cout << endl
-                     << " 2nd  " << second_order << " fi*fi/d  " << x << " s g " << step.transpose() * gradient << endl;
+            if (print == 20 and mpi::orb_rank == 0) cout << endl << " 2nd  " << second_order << " fi*fi/d  " << x << " s g " << step.transpose() * gradient << endl;
         } else {
             N_newton_step = 0;
             newton_step_exact = 0;
@@ -224,21 +217,18 @@ int NonlinearMaximizer::maximize() {
 
         if (print > 10 and mpi::orb_rank == 0) cout << "step size  " << std::sqrt(step_norm2) << endl;
         if (print > 10 and mpi::orb_rank == 0) cout << "expected first, second order and total change in r*r  ";
-        if (print > 10 and mpi::orb_rank == 0)
-            cout << first_order << " " << 0.5 * second_order << " " << expected_change << endl;
+        if (print > 10 and mpi::orb_rank == 0) cout << first_order << " " << 0.5 * second_order << " " << expected_change << endl;
 
         t_step.resume();
         this->do_step(step);
         t_step.stop();
         value_functional = this->functional();
         valdiff = value_functional - value_functional_old;
-        if (print > 10 and mpi::orb_rank == 0)
-            cout << " r*r  " << value_functional << " change in r*r  " << valdiff << endl;
+        if (print > 10 and mpi::orb_rank == 0) cout << " r*r  " << value_functional << " change in r*r  " << valdiff << endl;
 
         // relative_change is the size of  second order change compared to actual change
         // = 0 if no higher order contributions
-        relative_change = std::abs(expected_change - (value_functional - value_functional_old)) /
-                          (1.0E-25 + std::abs(value_functional - value_functional_old));
+        relative_change = std::abs(expected_change - (value_functional - value_functional_old)) / (1.0E-25 + std::abs(value_functional - value_functional_old));
         gradient_norm = this->make_gradient() / value_functional / N2h; // update gradient
         direction = 0.0;
         old_norm = 0.0;
@@ -294,9 +284,7 @@ int NonlinearMaximizer::maximize() {
             }
             if (h < 1.E-8) h = 1.E-8;
         }
-        if (print > 10 and mpi::orb_rank == 0)
-            cout << "trust radius set  to " << h << " test: " << relative_change << " mu: " << mu
-                 << " maxeival: " << maxEiVal << endl;
+        if (print > 10 and mpi::orb_rank == 0) cout << "trust radius set  to " << h << " test: " << relative_change << " mu: " << mu << " maxeival: " << maxEiVal << endl;
         if (print > 10 and mpi::orb_rank == 0) cout << "gradient norm " << gradient_norm << endl;
 
         if (gradient_norm < threshold && maxEiVal < 10 * std::sqrt(std::abs(threshold))) {

--- a/src/utils/NonlinearMaximizer.h
+++ b/src/utils/NonlinearMaximizer.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/RRMaximizer.cpp
+++ b/src/utils/RRMaximizer.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/RRMaximizer.h
+++ b/src/utils/RRMaximizer.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/gto_utils/AOBasis.cpp
+++ b/src/utils/gto_utils/AOBasis.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/gto_utils/AOBasis.h
+++ b/src/utils/gto_utils/AOBasis.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/gto_utils/AOContraction.cpp
+++ b/src/utils/gto_utils/AOContraction.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/gto_utils/AOContraction.h
+++ b/src/utils/gto_utils/AOContraction.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -55,9 +55,7 @@ public:
 
     friend std::ostream &operator<<(std::ostream &o, const AOContraction &c) {
         o << " " << c.L << " " << c.coefs.size() << std::endl;
-        for (unsigned int i = 0; i < c.expo.size(); i++) {
-            o << "    " << c.expo[i] << "   " << c.coefs[i] << std::endl;
-        }
+        for (unsigned int i = 0; i < c.expo.size(); i++) { o << "    " << c.expo[i] << "   " << c.coefs[i] << std::endl; }
         return o;
     }
 

--- a/src/utils/gto_utils/Intgrl.cpp
+++ b/src/utils/gto_utils/Intgrl.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -29,8 +29,8 @@
 
 #include <MRCPP/Printer>
 
-#include "chemistry/Nucleus.h"
 #include "AOBasis.h"
+#include "chemistry/Nucleus.h"
 
 using mrcpp::GaussExp;
 

--- a/src/utils/gto_utils/Intgrl.h
+++ b/src/utils/gto_utils/Intgrl.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/gto_utils/OrbitalExp.cpp
+++ b/src/utils/gto_utils/OrbitalExp.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/gto_utils/OrbitalExp.h
+++ b/src/utils/gto_utils/OrbitalExp.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/math_utils.cpp
+++ b/src/utils/math_utils.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/math_utils.h
+++ b/src/utils/math_utils.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/src/utils/print_utils.cpp
+++ b/src/utils/print_utils.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -197,16 +197,12 @@ void print_utils::qmfunction(int level, const std::string &txt, const QMFunction
 
 // trim from start (in place)
 void print_utils::ltrim(std::string &s) {
-    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
-        return !std::isspace(ch);
-    }));
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) { return !std::isspace(ch); }));
 }
 
 // trim from end (in place)
 void print_utils::rtrim(std::string &s) {
-    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
-        return !std::isspace(ch);
-    }).base(), s.end());
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), s.end());
 }
 
 // trim from both ends (in place)

--- a/src/utils/print_utils.h
+++ b/src/utils/print_utils.h
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *
@@ -43,7 +43,7 @@ std::vector<double> eigen_to_vector(const DoubleVector &inp, double thrs);
 std::vector<double> eigen_to_vector(const DoubleMatrix &inpm, double thrs);
 void ltrim(std::string &s);
 void rtrim(std::string &s);
-void trim(std::string &s); 
+void trim(std::string &s);
 std::string ltrim_copy(std::string s);
 std::string rtrim_copy(std::string s);
 std::string trim_copy(std::string s);

--- a/tests/qmfunctions/density.cpp
+++ b/tests/qmfunctions/density.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmfunctions/orbital.cpp
+++ b/tests/qmfunctions/orbital.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmfunctions/orbital_vector.cpp
+++ b/tests/qmfunctions/orbital_vector.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmfunctions/qmfunction.cpp
+++ b/tests/qmfunctions/qmfunction.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/coulomb_hessian.cpp
+++ b/tests/qmoperators/coulomb_hessian.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/coulomb_operator.cpp
+++ b/tests/qmoperators/coulomb_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/electric_field_operator.cpp
+++ b/tests/qmoperators/electric_field_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/exchange_hessian.cpp
+++ b/tests/qmoperators/exchange_hessian.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/exchange_operator.cpp
+++ b/tests/qmoperators/exchange_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/identity_operator.cpp
+++ b/tests/qmoperators/identity_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/kinetic_operator.cpp
+++ b/tests/qmoperators/kinetic_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/momentum_operator.cpp
+++ b/tests/qmoperators/momentum_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/nuclear_operator.cpp
+++ b/tests/qmoperators/nuclear_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/operator_composition.cpp
+++ b/tests/qmoperators/operator_composition.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/position_operator.cpp
+++ b/tests/qmoperators/position_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/xc_hessian_lda.cpp
+++ b/tests/qmoperators/xc_hessian_lda.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/xc_hessian_pbe.cpp
+++ b/tests/qmoperators/xc_hessian_pbe.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/xc_operator_blyp.cpp
+++ b/tests/qmoperators/xc_operator_blyp.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/qmoperators/xc_operator_lda.cpp
+++ b/tests/qmoperators/xc_operator_lda.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/solventeffect/cavity_function.cpp
+++ b/tests/solventeffect/cavity_function.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/solventeffect/reaction_operator.cpp
+++ b/tests/solventeffect/reaction_operator.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *

--- a/version.h.in
+++ b/version.h.in
@@ -2,7 +2,7 @@
  * MRChem, a numerical real-space code for molecular electronic structure
  * calculations within the self-consistent field (SCF) approximations of quantum
  * chemistry (Hartree-Fock and Density Functional Theory).
- * Copyright (C) 2021 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
+ * Copyright (C) 2022 Stig Rune Jensen, Luca Frediani, Peter Wind and contributors.
  *
  * This file is part of MRChem.
  *


### PR DESCRIPTION
 ~~I noticed~~ `Visual Studio Code` noticed an unused variable, though in an a-bit-unlikely-to-reach `else` clause. I renamed to what I deduced to be the correct variable.

And the githooks also complained about the year in the source file headers, so those were updated to `2022`.

Oh, and `clang-format` also complained for a couple of files.