### PR TITLE
Print information about the external environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ Pipfile.lock
 
 #Containers
 *.sif
+
+#Visual Studio Code
+.vscode

--- a/doc/users/user_inp.rst
+++ b/doc/users/user_inp.rst
@@ -100,8 +100,10 @@ Available print levels are:
 - ``print_level=0`` prints mainly properties
 - ``print_level=1`` adds timings for individual steps
 - ``print_level=2`` adds memory and timing information on ``OrbitalVector`` level
-- ``print_level=3`` adds memory and timing information on ``Orbital`` level
-- ``print_level>10`` adds a *lot* more output from deep within MRCPP
+- ``print_level=3`` adds details for individual terms of the Fock operator
+- ``print_level=4`` adds memory and timing information on ``Orbital`` level
+- ``print_level>=5`` adds debug information at MRChem level
+- ``print_level>=10`` adds debug information at MRCPP level
 
 
 MPI
@@ -572,7 +574,7 @@ affect the convergence rate.
 
 For response calculations, the important convergence threshold is that of the
 orbitals, and by default this is set one order of magnitude higher than the
-overall ``world_prec``. 
+overall ``world_prec``.
 
 .. note::
 

--- a/src/chemistry/Molecule.cpp
+++ b/src/chemistry/Molecule.cpp
@@ -208,6 +208,54 @@ void Molecule::printGeometry() const {
     mrcpp::print::separator(0, '=', 2);
 }
 
+/** @brief Pretty output of solvation cavity spheres */
+void Molecule::printCavity() {
+    // Collect relevant quantities
+    Cavity &cavity = getCavity();
+    std::vector<mrcpp::Coord<3>> coords = cavity.getCoordinates();
+    std::vector<double> radii = cavity.getRadii();
+
+    // Set widths
+    auto w0 = Printer::getWidth() - 1;
+    auto w1 = 5;
+    auto w2 = 12;
+    auto w3 = 2 * w0 / 9;
+    auto w4 = w0 - w1 - w2 - 3 * w3;
+
+    // Build table column headers
+    std::stringstream o_head;
+    o_head << std::setw(w1) << "N";
+    o_head << std::setw(w2) << "Radius";
+    o_head << std::string(w4 - 1, ' ') << ':';
+    o_head << std::setw(w3) << "x";
+    o_head << std::setw(w3) << "y";
+    o_head << std::setw(w3) << "z";
+
+    // Print
+    mrcpp::print::header(0, "Solvation Cavity");
+    print_utils::scalar(0, "Cavity width", cavity.getWidth(), "", 6);
+    mrcpp::print::separator(0, '-');
+    println(0, o_head.str());
+    mrcpp::print::separator(0, '-');
+    for (int i = 0; i < coords.size(); i++) {
+        mrcpp::Coord<3> coord = coords[i];
+        double r = radii[i];
+        double x = coord[0];
+        double y = coord[1];
+        double z = coord[2];
+
+        std::stringstream o_coord;
+        o_coord << std::setw(w1) << i;
+        o_coord << std::setw(w2) << std::setprecision(6) << std::fixed << r;
+        o_coord << std::string(w4 - 1, ' ') << ':';
+        o_coord << std::setw(w3) << std::setprecision(6) << std::fixed << x;
+        o_coord << std::setw(w3) << std::setprecision(6) << std::fixed << y;
+        o_coord << std::setw(w3) << std::setprecision(6) << std::fixed << z;
+        println(0, o_coord.str());
+    }
+    mrcpp::print::separator(0, '=', 2);
+}
+
 void Molecule::printEnergies(const std::string &txt) const {
     energy.print(txt);
     epsilon.print(txt);

--- a/src/chemistry/Molecule.h
+++ b/src/chemistry/Molecule.h
@@ -106,6 +106,7 @@ public:
     void printGeometry() const;
     void printEnergies(const std::string &txt) const;
     void printProperties() const;
+    void printCavity();
 
     void initPerturbedOrbitals(bool dynamic);
     void initCavity(std::vector<mrcpp::Coord<3>> &coords, std::vector<double> &R, double slope);

--- a/src/chemistry/PhysicalConstants.cpp
+++ b/src/chemistry/PhysicalConstants.cpp
@@ -59,6 +59,8 @@ PhysicalConstants &PhysicalConstants::Initialize(const json &constants) {
 /** @brief Pretty print physical constants */
 void PhysicalConstants::Print() {
     mrcpp::print::separator(0, '~');
+    print_utils::centeredText(0, "Physical Constants");
+    mrcpp::print::separator(0, '~');
     print_utils::json(0, constants_, true);
     mrcpp::print::separator(0, '~', 2);
 }

--- a/src/chemistry/PhysicalConstants.cpp
+++ b/src/chemistry/PhysicalConstants.cpp
@@ -58,9 +58,9 @@ PhysicalConstants &PhysicalConstants::Initialize(const json &constants) {
 
 /** @brief Pretty print physical constants */
 void PhysicalConstants::Print() {
-    mrcpp::print::header(0, "Physical Constants");
+    mrcpp::print::separator(0, '~');
     print_utils::json(0, constants_, true);
-    mrcpp::print::separator(0, '=', 2);
+    mrcpp::print::separator(0, '~', 2);
 }
 
 } // namespace mrchem

--- a/src/chemistry/PhysicalConstants.cpp
+++ b/src/chemistry/PhysicalConstants.cpp
@@ -59,7 +59,7 @@ PhysicalConstants &PhysicalConstants::Initialize(const json &constants) {
 /** @brief Pretty print physical constants */
 void PhysicalConstants::Print() {
     mrcpp::print::separator(0, '~');
-    print_utils::centeredText(0, "Physical Constants");
+    print_utils::centered_text(0, "Physical Constants");
     mrcpp::print::separator(0, '~');
     print_utils::json(0, constants_, true);
     mrcpp::print::separator(0, '~', 2);

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -1034,7 +1034,7 @@ void driver::build_fock_operator(const json &json_fock, Molecule &mol, FockBuild
         Permittivity dielectric_func(*cavity_r, eps_in_r, eps_out_r, formulation);
 
         auto scrf_p = std::make_unique<SCRF>(dielectric_func, nuclei, P_r, D_r, poisson_prec, hist_r, max_iter, accelerate_Vr, convergence_criterion, algorithm, density_type);
-        auto V_R = std::make_shared<ReactionOperator>(scrf_p, Phi_p);
+        auto V_R = std::make_shared<ReactionOperator>(std::move(scrf_p), Phi_p);
         F.getReactionOperator() = V_R;
     }
     ///////////////////////////////////////////////////////////

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -258,6 +258,7 @@ json driver::scf::run(const json &json_scf, Molecule &mol) {
         auto kain = json_scf["scf_solver"]["kain"];
         auto method = json_scf["scf_solver"]["method"];
         auto relativity = json_scf["scf_solver"]["relativity"];
+        auto environment = json_scf["scf_solver"]["environment"];
         auto max_iter = json_scf["scf_solver"]["max_iter"];
         auto rotation = json_scf["scf_solver"]["rotation"];
         auto localize = json_scf["scf_solver"]["localize"];
@@ -275,6 +276,7 @@ json driver::scf::run(const json &json_scf, Molecule &mol) {
         solver.setLocalize(localize);
         solver.setMethodName(method);
         solver.setRelativityName(relativity);
+        solver.setEnvironmentName(environment);
         solver.setCheckpoint(checkpoint);
         solver.setCheckpointFile(file_chk);
         solver.setMaxIterations(max_iter);
@@ -1036,6 +1038,8 @@ void driver::build_fock_operator(const json &json_fock, Molecule &mol, FockBuild
         auto scrf_p = std::make_unique<SCRF>(dielectric_func, nuclei, P_r, D_r, poisson_prec, hist_r, max_iter, accelerate_Vr, convergence_criterion, algorithm, density_type);
         auto V_R = std::make_shared<ReactionOperator>(std::move(scrf_p), Phi_p);
         F.getReactionOperator() = V_R;
+
+        V_R->getHelper()->printParameters();
     }
     ///////////////////////////////////////////////////////////
     ////////////////////   XC Operator   //////////////////////

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -1039,6 +1039,7 @@ void driver::build_fock_operator(const json &json_fock, Molecule &mol, FockBuild
         auto V_R = std::make_shared<ReactionOperator>(std::move(scrf_p), Phi_p);
         F.getReactionOperator() = V_R;
 
+        mol.printCavity();
         V_R->getHelper()->printParameters();
     }
     ///////////////////////////////////////////////////////////

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -141,6 +141,7 @@ void driver::init_molecule(const json &json_mol, Molecule &mol) {
         auto xyz = coord["xyz"];
         nuclei.push_back(atom, xyz);
     }
+    mol.printGeometry();
 
     if (json_mol.contains("cavity")) {
         auto json_cavity = json_mol["cavity"];
@@ -153,8 +154,8 @@ void driver::init_molecule(const json &json_mol, Molecule &mol) {
         auto width = json_cavity["width"];
 
         mol.initCavity(coords, radii, width);
+        mol.printCavity();
     }
-    mol.printGeometry();
 }
 
 void driver::init_properties(const json &json_prop, Molecule &mol) {

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -1038,9 +1038,6 @@ void driver::build_fock_operator(const json &json_fock, Molecule &mol, FockBuild
         auto scrf_p = std::make_unique<SCRF>(dielectric_func, nuclei, P_r, D_r, poisson_prec, hist_r, max_iter, accelerate_Vr, convergence_criterion, algorithm, density_type);
         auto V_R = std::make_shared<ReactionOperator>(std::move(scrf_p), Phi_p);
         F.getReactionOperator() = V_R;
-
-        mol.printCavity();
-        V_R->getHelper()->printParameters();
     }
     ///////////////////////////////////////////////////////////
     ////////////////////   XC Operator   //////////////////////

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -1038,13 +1038,11 @@ void driver::build_fock_operator(const json &json_fock, Molecule &mol, FockBuild
         auto formulation = json_fock["reaction_operator"]["formulation"];
         auto density_type = json_fock["reaction_operator"]["density_type"];
         Permittivity dielectric_func(*cavity_r, eps_in_r, eps_out_r, formulation);
+        dielectric_func.printParameters();
 
         auto scrf_p = std::make_unique<SCRF>(dielectric_func, nuclei, P_r, D_r, poisson_prec, hist_r, max_iter, accelerate_Vr, convergence_criterion, algorithm, density_type);
         auto V_R = std::make_shared<ReactionOperator>(std::move(scrf_p), Phi_p);
         F.getReactionOperator() = V_R;
-
-        // dielectric_func.printParameters();
-        // V_R->getHelper()->printParameters();
     }
     ///////////////////////////////////////////////////////////
     ////////////////////   XC Operator   //////////////////////

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -154,7 +154,7 @@ void driver::init_molecule(const json &json_mol, Molecule &mol) {
         auto width = json_cavity["width"];
 
         mol.initCavity(coords, radii, width);
-        mol.printCavity();
+        // mol.printCavity();
     }
 }
 
@@ -223,7 +223,7 @@ void driver::init_properties(const json &json_prop, Molecule &mol) {
  * This function expects the "scf_calculation" subsection of the input.
  */
 json driver::scf::run(const json &json_scf, Molecule &mol) {
-    print_utils::headline(0, "Computing Ground State Wavefunction");
+    // print_utils::headline(0, "Computing Ground State Wavefunction");
     json json_out = {{"success", true}};
 
     if (json_scf.contains("properties")) driver::init_properties(json_scf["properties"], mol);
@@ -241,6 +241,7 @@ json driver::scf::run(const json &json_scf, Molecule &mol) {
     ///////////////////////////////////////////////////////////
     ///////////////   Setting Up Initial Guess   //////////////
     ///////////////////////////////////////////////////////////
+    print_utils::headline(0, "Computing Initial Guess Wavefunction");
     const auto &json_guess = json_scf["initial_guess"];
     if (scf::guess_orbitals(json_guess, mol)) {
         scf::guess_energy(json_guess, mol, F);
@@ -256,6 +257,8 @@ json driver::scf::run(const json &json_scf, Molecule &mol) {
 
     // Run GroundStateSolver if present in input JSON
     if (json_scf.contains("scf_solver")) {
+        print_utils::headline(0, "Computing Ground State Wavefunction");
+
         auto kain = json_scf["scf_solver"]["kain"];
         auto method = json_scf["scf_solver"]["method"];
         auto relativity = json_scf["scf_solver"]["relativity"];
@@ -1039,6 +1042,9 @@ void driver::build_fock_operator(const json &json_fock, Molecule &mol, FockBuild
         auto scrf_p = std::make_unique<SCRF>(dielectric_func, nuclei, P_r, D_r, poisson_prec, hist_r, max_iter, accelerate_Vr, convergence_criterion, algorithm, density_type);
         auto V_R = std::make_shared<ReactionOperator>(std::move(scrf_p), Phi_p);
         F.getReactionOperator() = V_R;
+
+        // dielectric_func.printParameters();
+        // V_R->getHelper()->printParameters();
     }
     ///////////////////////////////////////////////////////////
     ////////////////////   XC Operator   //////////////////////

--- a/src/environment/Cavity.h
+++ b/src/environment/Cavity.h
@@ -50,6 +50,7 @@ public:
     auto getGradVector() const { return this->gradvector; }
     std::vector<mrcpp::Coord<3>> getCoordinates() const { return centers; } //!< Returns #centers.
     std::vector<double> getRadii() const { return radii; }                  //!< Returns #radii.
+    double getWidth() { return width; }                                     //!< Returns #width.
     friend class Permittivity;
 
 protected:

--- a/src/environment/Permittivity.cpp
+++ b/src/environment/Permittivity.cpp
@@ -44,4 +44,54 @@ double Permittivity::evalf(const mrcpp::Coord<3> &r) const {
     }
 }
 
+void Permittivity::printParameters() {
+    // Collect relevant quantities
+    Cavity cavity = getCavity();
+    std::vector<mrcpp::Coord<3>> coords = cavity.getCoordinates();
+    std::vector<double> radii = cavity.getRadii();
+
+    // Set widths
+    auto w0 = mrcpp::Printer::getWidth() - 1;
+    auto w1 = 5;
+    auto w2 = 12;
+    auto w3 = 2 * w0 / 9;
+    auto w4 = w0 - w1 - w2 - 3 * w3;
+
+    // Build table column headers
+    std::stringstream o_head;
+    o_head << std::setw(w1) << "N";
+    o_head << std::setw(w2) << "Radius";
+    o_head << std::string(w4 - 1, ' ') << ':';
+    o_head << std::setw(w3) << "x";
+    o_head << std::setw(w3) << "y";
+    o_head << std::setw(w3) << "z";
+
+    // Print
+    mrcpp::print::header(0, "Solvation Cavity");
+    print_utils::scalar(0, "Cavity width", cavity.getWidth(), "", 6);
+    print_utils::scalar(0, "Dielec. Const. (in)", getEpsIn(), "", 6);
+    print_utils::scalar(0, "Dielec. Const. (out)", getEpsOut(), "", 6);
+    print_utils::text(0, "Formulation", getFormulation(), true);
+    mrcpp::print::separator(0, '-');
+    println(0, o_head.str());
+    mrcpp::print::separator(0, '-');
+    for (int i = 0; i < coords.size(); i++) {
+        mrcpp::Coord<3> coord = coords[i];
+        double r = radii[i];
+        double x = coord[0];
+        double y = coord[1];
+        double z = coord[2];
+
+        std::stringstream o_coord;
+        o_coord << std::setw(w1) << i;
+        o_coord << std::setw(w2) << std::setprecision(6) << std::fixed << r;
+        o_coord << std::string(w4 - 1, ' ') << ':';
+        o_coord << std::setw(w3) << std::setprecision(6) << std::fixed << x;
+        o_coord << std::setw(w3) << std::setprecision(6) << std::fixed << y;
+        o_coord << std::setw(w3) << std::setprecision(6) << std::fixed << z;
+        println(0, o_coord.str());
+    }
+    mrcpp::print::separator(0, '=', 2);
+}
+
 } // namespace mrchem

--- a/src/environment/Permittivity.h
+++ b/src/environment/Permittivity.h
@@ -26,7 +26,9 @@
 #pragma once
 
 #include "Cavity.h"
+#include "utils/print_utils.h"
 #include <MRCPP/MWFunctions>
+#include <MRCPP/Printer>
 
 namespace mrchem {
 /** @class Permittivity
@@ -82,6 +84,15 @@ public:
 
     /** @brief Returns the value of #epsilon_out. */
     auto getEpsOut() const { return this->epsilon_out; }
+
+    /** @brief Returns the cavity */
+    Cavity getCavity() const { return this->cavity; }
+
+    /** @brief Returns the formulation */
+    std::string getFormulation() const { return this->formulation; }
+
+    /** @brief Print parameters */
+    void printParameters();
 
 private:
     bool inverse = false;    //!< State of #evalf

--- a/src/environment/SCRF.cpp
+++ b/src/environment/SCRF.cpp
@@ -295,9 +295,9 @@ void SCRF::updateCurrentGamma(QMFunction &gamma_np1) {
 
 void SCRF::printParameters() {
     nlohmann::json data = {
-        {"Dielectric constant (inside)", epsilon.getEpsIn()},
-        {"Dielectric constant (outside)", epsilon.getEpsOut()},
-        {"Max. number of micro-iterations", max_iter},
+        {"Dielectric const. (inside)", epsilon.getEpsIn()},
+        {"Dielectric const. (outside)", epsilon.getEpsOut()},
+        {"Max. iterations", max_iter},
         {"Accelerate with KAIN", (accelerate_Vr) ? "true" : "false"},
         {"Algorithm", algorithm},
         {"Density type", density_type},

--- a/src/environment/SCRF.cpp
+++ b/src/environment/SCRF.cpp
@@ -295,8 +295,8 @@ void SCRF::updateCurrentGamma(QMFunction &gamma_np1) {
 
 void SCRF::printParameters() {
     nlohmann::json data = {
-        {"Dielectric const. (inside)", epsilon.getEpsIn()},
-        {"Dielectric const. (outside)", epsilon.getEpsOut()},
+        {"Dielec. const. (in)", epsilon.getEpsIn()},
+        {"Dielec. const. (out)", epsilon.getEpsOut()},
         {"Max. iterations", max_iter},
         {"Accelerate with KAIN", (accelerate_Vr) ? "true" : "false"},
         {"Algorithm", algorithm},
@@ -304,9 +304,11 @@ void SCRF::printParameters() {
         {"Convergence criterion", convergence_criterion},
     };
 
-    mrcpp::print::header(0, "Self-Consistent Reaction Field");
-    print_utils::json(0, data, true);
-    mrcpp::print::separator(0, '=', 2);
+    mrcpp::print::separator(0, '~');
+    print_utils::centeredText(0, "Self-Consistent Reaction Field");
+    mrcpp::print::separator(0, '~');
+    print_utils::json(0, data, false);
+    mrcpp::print::separator(0, '~', 2);
 }
 
 } // namespace mrchem

--- a/src/environment/SCRF.cpp
+++ b/src/environment/SCRF.cpp
@@ -26,6 +26,7 @@
 #include "SCRF.h"
 
 #include <MRCPP/MWOperators>
+#include <MRCPP/Printer>
 
 #include "chemistry/PhysicalConstants.h"
 #include "chemistry/chemistry_utils.h"
@@ -288,6 +289,23 @@ void SCRF::updateCurrentGamma(QMFunction &gamma_np1) {
     resetQMFunction(this->gamma_n);
     qmfunction::deep_copy(this->gamma_n, gamma_np1);
     gamma_np1.free(NUMBER::Real);
+}
+
+void SCRF::printParameters() {
+    int buffer = 3; // Extra space for long names
+    mrcpp::print::header(0, "Self-Consistent Reaction Field");
+    print_utils::scalar(0, "Dielectric constant (inside) ", epsilon.getEpsIn(), "", 5, true, buffer);
+    print_utils::scalar(0, "Dielectric constant (outside)", epsilon.getEpsOut(), "", 5, true, buffer);
+    print_utils::scalar(0, "Max number of micro-ierations", max_iter, "", 1, false, buffer);
+    print_utils::text(0, "Accelerate with KAIN", (accelerate_Vr) ? "true" : "false", true, buffer);
+    print_utils::text(0, "Algorithm", algorithm, true, buffer);
+    print_utils::text(0, "Density type", density_type, true, buffer);
+    print_utils::text(0, "Convergence criterion", convergence_criterion, true, buffer);
+    mrcpp::print::separator(0, '=');
+
+    // A couple of new lines to have a pleasing spacing to next section
+    println(0, "");
+    println(0, "");
 }
 
 } // namespace mrchem

--- a/src/environment/SCRF.cpp
+++ b/src/environment/SCRF.cpp
@@ -296,16 +296,12 @@ void SCRF::printParameters() {
     mrcpp::print::header(0, "Self-Consistent Reaction Field");
     print_utils::scalar(0, "Dielectric constant (inside) ", epsilon.getEpsIn(), "", 5, true, buffer);
     print_utils::scalar(0, "Dielectric constant (outside)", epsilon.getEpsOut(), "", 5, true, buffer);
-    print_utils::scalar(0, "Max number of micro-ierations", max_iter, "", 1, false, buffer);
+    print_utils::scalar(0, "Max number of micro-iterations", max_iter, "", 0, false, buffer);
     print_utils::text(0, "Accelerate with KAIN", (accelerate_Vr) ? "true" : "false", true, buffer);
     print_utils::text(0, "Algorithm", algorithm, true, buffer);
     print_utils::text(0, "Density type", density_type, true, buffer);
     print_utils::text(0, "Convergence criterion", convergence_criterion, true, buffer);
-    mrcpp::print::separator(0, '=');
-
-    // A couple of new lines to have a pleasing spacing to next section
-    println(0, "");
-    println(0, "");
+    mrcpp::print::separator(0, '=', 2);
 }
 
 } // namespace mrchem

--- a/src/environment/SCRF.cpp
+++ b/src/environment/SCRF.cpp
@@ -294,15 +294,11 @@ void SCRF::updateCurrentGamma(QMFunction &gamma_np1) {
 }
 
 void SCRF::printParameters() {
-    nlohmann::json data = {
-        {"Dielec. const. (in)", epsilon.getEpsIn()},
-        {"Dielec. const. (out)", epsilon.getEpsOut()},
-        {"Max. iterations", max_iter},
-        {"Accelerate with KAIN", (accelerate_Vr) ? "true" : "false"},
-        {"Algorithm", algorithm},
-        {"Density type", density_type},
-        {"Convergence criterion", convergence_criterion},
-    };
+    nlohmann::json data = {{"Max iterations", max_iter},
+                           {"Accelerate with KAIN", (accelerate_Vr) ? "true" : "false"},
+                           {"Algorithm", algorithm},
+                           {"Density type", density_type},
+                           {"Convergence criterion", convergence_criterion}};
 
     mrcpp::print::separator(0, '~');
     print_utils::centeredText(0, "Self-Consistent Reaction Field");

--- a/src/environment/SCRF.cpp
+++ b/src/environment/SCRF.cpp
@@ -36,6 +36,8 @@
 #include "scf_solver/KAIN.h"
 #include "utils/print_utils.h"
 
+#include <nlohmann/json.hpp>
+
 using mrcpp::Printer;
 using mrcpp::Timer;
 
@@ -292,15 +294,18 @@ void SCRF::updateCurrentGamma(QMFunction &gamma_np1) {
 }
 
 void SCRF::printParameters() {
-    int buffer = 3; // Extra space for long names
+    nlohmann::json data = {
+        {"Dielectric constant (inside)", epsilon.getEpsIn()},
+        {"Dielectric constant (outside)", epsilon.getEpsOut()},
+        {"Max. number of micro-iterations", max_iter},
+        {"Accelerate with KAIN", (accelerate_Vr) ? "true" : "false"},
+        {"Algorithm", algorithm},
+        {"Density type", density_type},
+        {"Convergence criterion", convergence_criterion},
+    };
+
     mrcpp::print::header(0, "Self-Consistent Reaction Field");
-    print_utils::scalar(0, "Dielectric constant (inside) ", epsilon.getEpsIn(), "", 5, true, buffer);
-    print_utils::scalar(0, "Dielectric constant (outside)", epsilon.getEpsOut(), "", 5, true, buffer);
-    print_utils::scalar(0, "Max number of micro-iterations", max_iter, "", 0, false, buffer);
-    print_utils::text(0, "Accelerate with KAIN", (accelerate_Vr) ? "true" : "false", true, buffer);
-    print_utils::text(0, "Algorithm", algorithm, true, buffer);
-    print_utils::text(0, "Density type", density_type, true, buffer);
-    print_utils::text(0, "Convergence criterion", convergence_criterion, true, buffer);
+    print_utils::json(0, data, true);
     mrcpp::print::separator(0, '=', 2);
 }
 

--- a/src/environment/SCRF.cpp
+++ b/src/environment/SCRF.cpp
@@ -295,7 +295,7 @@ void SCRF::updateCurrentGamma(QMFunction &gamma_np1) {
 
 void SCRF::printParameters() {
     nlohmann::json data = {{"Max iterations", max_iter},
-                           {"Accelerate with KAIN", (accelerate_Vr) ? "true" : "false"},
+                           {"Accelerate with KAIN", (accelerate_Vr) ? "True" : "False"},
                            {"Algorithm", algorithm},
                            {"Density type", density_type},
                            {"Convergence criterion", convergence_criterion}};

--- a/src/environment/SCRF.h
+++ b/src/environment/SCRF.h
@@ -59,6 +59,8 @@ public:
     QMFunction &getPreviousGamma() { return this->gamma_nm1; }
     QMFunction &getCurrentDifferenceGamma() { return this->dgamma_n; }
 
+    Permittivity &getPermittivity() { return this->epsilon; }
+
     void updateMOResidual(double const err_t) { this->mo_residual = err_t; }
     void printParameters();
 

--- a/src/environment/SCRF.h
+++ b/src/environment/SCRF.h
@@ -51,6 +51,8 @@ public:
     ~SCRF();
     void UpdateExternalDensity(Density new_density) { this->rho_ext = new_density; }
 
+    double setConvergenceThreshold(double prec);
+
     QMFunction &getCurrentReactionPotential() { return this->Vr_n; }
     QMFunction &getPreviousReactionPotential() { return this->Vr_nm1; }
     QMFunction &getCurrentDifferenceReactionPotential() { return this->dVr_n; }
@@ -62,7 +64,6 @@ public:
     Permittivity &getPermittivity() { return this->epsilon; }
 
     void updateMOResidual(double const err_t) { this->mo_residual = err_t; }
-    void printParameters();
 
     friend class ReactionPotential;
 
@@ -78,6 +79,7 @@ private:
     int max_iter;
     int history;
     double apply_prec;
+    double conv_thrs;
     double mo_residual;
 
     Permittivity epsilon;
@@ -117,5 +119,8 @@ private:
     void resetQMFunction(QMFunction &function);
     void updateCurrentReactionPotential(QMFunction &Vr_np1);
     void updateCurrentGamma(QMFunction &gamma_np1);
+
+    void printParameters() const;
+    void printConvergenceRow(int i, double norm, double update, double time) const;
 };
 } // namespace mrchem

--- a/src/environment/SCRF.h
+++ b/src/environment/SCRF.h
@@ -60,6 +60,7 @@ public:
     QMFunction &getCurrentDifferenceGamma() { return this->dgamma_n; }
 
     void updateMOResidual(double const err_t) { this->mo_residual = err_t; }
+    void printParameters();
 
     friend class ReactionPotential;
 

--- a/src/initial_guess/core.cpp
+++ b/src/initial_guess/core.cpp
@@ -134,7 +134,7 @@ bool initial_guess::core::setup(OrbitalVector &Phi, double prec, const Nuclei &n
     V.clear();
     p.clear();
 
-    mrcpp::print::footer(2, t_lap, 2);
+    mrcpp::print::footer(2, t_tot, 2);
     if (plevel == 1) mrcpp::print::footer(1, t_tot, 2);
     return true;
 }
@@ -258,10 +258,12 @@ void initial_guess::core::rotate_orbitals(OrbitalVector &Psi, double prec, Compl
 ComplexMatrix initial_guess::core::diagonalize(OrbitalVector &Phi, MomentumOperator &p, RankZeroOperator &V) {
     Timer t1;
     ComplexMatrix S_m12 = orbital::calc_lowdin_matrix(Phi);
+    mrcpp::print::separator(2, '-');
     ComplexMatrix t_tilde = qmoperator::calc_kinetic_matrix(p, Phi, Phi);
     ComplexMatrix v_tilde = V(Phi, Phi);
     ComplexMatrix f_tilde = t_tilde + v_tilde;
     ComplexMatrix f = S_m12.adjoint() * f_tilde * S_m12;
+    mrcpp::print::separator(2, '-');
     mrcpp::print::time(1, "Computing Fock matrix", t1);
 
     Timer t2;

--- a/src/initial_guess/core.cpp
+++ b/src/initial_guess/core.cpp
@@ -112,7 +112,6 @@ bool initial_guess::core::setup(OrbitalVector &Phi, double prec, const Nuclei &n
     t_lap.start();
     OrbitalVector Psi;
     initial_guess::core::project_ao(Psi, prec, nucs, zeta);
-    ComplexMatrix S_m12 = orbital::calc_lowdin_matrix(Psi);
     if (plevel == 1) mrcpp::print::time(1, "Projecting Hydrogen AOs", t_lap);
 
     p.setup(prec);

--- a/src/parallel.cpp
+++ b/src/parallel.cpp
@@ -196,7 +196,7 @@ void mpi::initialize() {
 void mpi::finalize() {
 #ifdef MRCHEM_HAS_MPI
     if (mpi::bank_size > 0 and mpi::grand_master()) {
-        println(3, " max data in bank " << dataBank.get_maxtotalsize() << " MB ");
+        println(4, " max data in bank " << dataBank.get_maxtotalsize() << " MB ");
         dataBank.close();
     }
     MPI_Barrier(MPI_COMM_WORLD); // to ensure everybody got here

--- a/src/properties/SCFEnergy.h
+++ b/src/properties/SCFEnergy.h
@@ -74,6 +74,9 @@ public:
         auto E_kJ = E_au * PhysicalConstants::get("hartree2kjmol");
         auto E_kcal = E_au * PhysicalConstants::get("hartree2kcalmol");
 
+        bool has_ext = (std::abs(E_eext) > mrcpp::MachineZero) || (std::abs(E_next) > mrcpp::MachineZero);
+        bool has_react = (std::abs(Er_el) > mrcpp::MachineZero) || (std::abs(Er_nuc) > mrcpp::MachineZero);
+
         auto pprec = 2 * mrcpp::Printer::getPrecision();
         mrcpp::print::header(0, "Molecular Energy (" + id + ")");
         print_utils::scalar(0, "Kinetic energy   ", E_kin,  "(au)", pprec, false);
@@ -81,13 +84,19 @@ public:
         print_utils::scalar(0, "Coulomb energy   ", E_ee,   "(au)", pprec, false);
         print_utils::scalar(0, "Exchange energy  ", E_x,    "(au)", pprec, false);
         print_utils::scalar(0, "X-C energy       ", E_xc,   "(au)", pprec, false);
-        print_utils::scalar(0, "Ext. field (el)  ", E_eext, "(au)", pprec, false);
-        mrcpp::print::separator(0, '-');
         print_utils::scalar(0, "N-N energy       ", E_nn,   "(au)", pprec, false);
-        print_utils::scalar(0, "Ext. field (nuc) ", E_next, "(au)", pprec, false);
-        print_utils::scalar(0, "Tot. Reac. Energy", Er_tot,  "(au)", pprec, false);
-        print_utils::scalar(0, "El. Reac. Energy ", Er_el,  "(au)", pprec, false);
-        print_utils::scalar(0, "Nuc. Reac. Energy", Er_nuc,  "(au)", pprec, false);
+        if (has_ext) {
+            mrcpp::print::separator(0, '-');
+            print_utils::scalar(0, "External field (el)  ", E_eext, "(au)", pprec, false);
+            print_utils::scalar(0, "External field (nuc) ", E_next, "(au)", pprec, false);
+            print_utils::scalar(0, "External field (tot) ", E_eext + E_next, "(au)", pprec, false);
+        }
+        if (has_react) {
+            mrcpp::print::separator(0, '-');
+            print_utils::scalar(0, "Reaction energy (el)  ", Er_el,  "(au)", pprec, false);
+            print_utils::scalar(0, "Reaction energy (nuc) ", Er_nuc,  "(au)", pprec, false);
+            print_utils::scalar(0, "Reaction energy (tot) ", Er_tot,  "(au)", pprec, false);
+        }
         mrcpp::print::separator(0, '-');
         print_utils::scalar(0, "Electronic energy", E_el,   "(au)", pprec, false);
         print_utils::scalar(0, "Nuclear energy   ", E_nuc,  "(au)", pprec, false);

--- a/src/qmfunctions/orbital_utils.cpp
+++ b/src/qmfunctions/orbital_utils.cpp
@@ -1593,18 +1593,22 @@ int orbital::get_electron_number(const OrbitalVector &Phi, int spin) {
     return nElectrons;
 }
 
-/** @brief Returns the total number of nodes in the vector */
-int orbital::get_n_nodes(const OrbitalVector &Phi) {
-    int nNodes = 0;
-    for (const auto &phi_i : Phi) nNodes += phi_i.getNNodes(NUMBER::Total);
-    return nNodes;
+/** @brief Returns the total number of nodes in the vector, toggle to get average. */
+int orbital::get_n_nodes(const OrbitalVector &Phi, bool avg) {
+    long long totNodes = 0;
+    for (const auto &phi_i : Phi) totNodes += phi_i.getNNodes(NUMBER::Total);
+    if (avg) totNodes /= Phi.size();
+    if (totNodes > INT_MAX) MSG_WARN("Integer overflow: " << totNodes);
+    return static_cast<int>(totNodes);
 }
 
-/** @brief Returns the size of the coefficients of all nodes in the vector in kBytes */
-int orbital::get_size_nodes(const OrbitalVector &Phi) {
-    int tot_size = 0;
-    for (const auto &phi_i : Phi) tot_size += phi_i.getSizeNodes(NUMBER::Total);
-    return tot_size;
+/** @brief Returns the size of the coefficients of all nodes in the vector in kBytes, toggle to get average.*/
+int orbital::get_size_nodes(const OrbitalVector &Phi, bool avg) {
+    long long totSize = 0;
+    for (const auto &phi_i : Phi) totSize += phi_i.getSizeNodes(NUMBER::Total);
+    if (avg) totSize /= Phi.size();
+    if (totSize > INT_MAX) MSG_WARN("Integer overflow: " << totSize);
+    return static_cast<int>(totSize);
 }
 
 /** @brief Returns a vector containing the orbital spins */

--- a/src/qmfunctions/orbital_utils.h
+++ b/src/qmfunctions/orbital_utils.h
@@ -81,8 +81,8 @@ int size_beta(const OrbitalVector &Phi);
 int get_multiplicity(const OrbitalVector &Phi);
 int get_electron_number(const OrbitalVector &Phi, int spin = SPIN::Paired);
 int start_index(const OrbitalVector &Phi, int spin);
-int get_n_nodes(const OrbitalVector &Phi);
-int get_size_nodes(const OrbitalVector &Phi);
+int get_n_nodes(const OrbitalVector &Phi, bool avg = false);
+int get_size_nodes(const OrbitalVector &Phi, bool avg = false);
 bool orbital_vector_is_sane(const OrbitalVector &Phi);
 
 void set_spins(OrbitalVector &Phi, const IntVector &spins);

--- a/src/qmoperators/one_electron/CMakeLists.txt
+++ b/src/qmoperators/one_electron/CMakeLists.txt
@@ -1,3 +1,4 @@
 target_sources(mrchem PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/NuclearOperator.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/ZoraOperator.cpp
     )

--- a/src/qmoperators/two_electron/CoulombPotentialD1.cpp
+++ b/src/qmoperators/two_electron/CoulombPotentialD1.cpp
@@ -53,7 +53,7 @@ void CoulombPotentialD1::setupGlobalDensity(double prec) {
 
     Timer timer;
     density::compute(prec, rho, Phi, DensityType::Total);
-    print_utils::qmfunction(2, "Coulomb density", rho, timer);
+    print_utils::qmfunction(3, "Compute global density", rho, timer);
 }
 
 /** @brief compute local electron density (only own MPI orbitals)
@@ -71,7 +71,7 @@ void CoulombPotentialD1::setupLocalDensity(double prec) {
 
     Timer timer;
     density::compute_local(prec, rho, Phi, DensityType::Total);
-    print_utils::qmfunction(2, "Coulomb density", rho, timer);
+    print_utils::qmfunction(3, "Compute local density", rho, timer);
 }
 
 } // namespace mrchem

--- a/src/qmoperators/two_electron/CoulombPotentialD2.cpp
+++ b/src/qmoperators/two_electron/CoulombPotentialD2.cpp
@@ -57,7 +57,7 @@ void CoulombPotentialD2::setupGlobalDensity(double prec) {
 
     Timer timer;
     density::compute(prec, rho, Phi, X, Y, DensityType::Total);
-    print_utils::qmfunction(2, "Coulomb density", rho, timer);
+    print_utils::qmfunction(3, "Compute global density", rho, timer);
 }
 
 void CoulombPotentialD2::setupLocalDensity(double prec) {
@@ -73,7 +73,7 @@ void CoulombPotentialD2::setupLocalDensity(double prec) {
 
     Timer timer;
     density::compute_local(prec, rho, Phi, X, Y, DensityType::Total);
-    print_utils::qmfunction(2, "Coulomb density", rho, timer);
+    print_utils::qmfunction(3, "Compute local density", rho, timer);
 }
 
 } // namespace mrchem

--- a/src/qmoperators/two_electron/ExchangePotentialD2.cpp
+++ b/src/qmoperators/two_electron/ExchangePotentialD2.cpp
@@ -76,7 +76,7 @@ void ExchangePotentialD2::setupBank() {
         if (mpi::my_orb(Y[i])) YBank.put_orb(i, Y[i]);
     }
     mpi::barrier(mpi::comm_orb);
-    mrcpp::print::time(4, "Setting up exchange bank", timer);
+    mrcpp::print::time(3, "Setting up exchange bank", timer);
 }
 
 /** @brief Clears the Exchange Operator
@@ -144,7 +144,7 @@ Orbital ExchangePotentialD2::apply(Orbital phi_p) {
     Orbital out_p = phi_p.paramCopy();
     Eigen::Map<ComplexVector> coefs(coef_vec.data(), coef_vec.size());
     qmfunction::linear_combination(out_p, coefs, func_vec, prec);
-    print_utils::qmfunction(3, "Applied exchange", out_p, timer);
+    print_utils::qmfunction(4, "Applied exchange", out_p, timer);
     return out_p;
 }
 
@@ -203,7 +203,7 @@ Orbital ExchangePotentialD2::dagger(Orbital phi_p) {
     Orbital ex_p = phi_p.paramCopy();
     Eigen::Map<ComplexVector> coefs(coef_vec.data(), coef_vec.size());
     qmfunction::linear_combination(ex_p, coefs, func_vec, prec);
-    print_utils::qmfunction(3, "Applied exchange", ex_p, timer);
+    print_utils::qmfunction(4, "Applied exchange", ex_p, timer);
     return ex_p;
 }
 

--- a/src/qmoperators/two_electron/ReactionOperator.h
+++ b/src/qmoperators/two_electron/ReactionOperator.h
@@ -47,6 +47,7 @@ public:
         // Invoke operator= to assign *this operator
         RankZeroOperator &V = (*this);
         V = potential;
+        V.name() = "V_r";
     }
 
     ComplexDouble trace(OrbitalVector &Phi) { return RankZeroOperator::trace(Phi); }

--- a/src/qmoperators/two_electron/ReactionOperator.h
+++ b/src/qmoperators/two_electron/ReactionOperator.h
@@ -42,8 +42,8 @@ class SCRF;
 
 class ReactionOperator final : public RankZeroOperator {
 public:
-    ReactionOperator(std::unique_ptr<SCRF> &scrf_p, std::shared_ptr<mrchem::OrbitalVector> Phi_p) {
-        potential = std::make_shared<ReactionPotential>(scrf_p, Phi_p);
+    ReactionOperator(std::unique_ptr<SCRF> scrf_p, std::shared_ptr<mrchem::OrbitalVector> Phi_p) {
+        potential = std::make_shared<ReactionPotential>(std::move(scrf_p), Phi_p);
         // Invoke operator= to assign *this operator
         RankZeroOperator &V = (*this);
         V = potential;

--- a/src/qmoperators/two_electron/ReactionPotential.cpp
+++ b/src/qmoperators/two_electron/ReactionPotential.cpp
@@ -23,6 +23,9 @@
  * <https://mrchem.readthedocs.io/>
  */
 
+#include <MRCPP/Printer>
+#include <MRCPP/Timer>
+
 #include "ReactionPotential.h"
 
 #include "qmfunctions/qmfunction_utils.h"
@@ -43,8 +46,19 @@ void ReactionPotential::setup(double prec) {
         this->first_iteration = false;
         return;
     }
+    auto thrs = this->helper->setConvergenceThreshold(prec);
+    mrcpp::Timer timer;
+    auto plevel = mrcpp::Printer::getPrintLevel();
+    mrcpp::print::separator(3, '=');
+    print_utils::centered_text(3, "Building Reaction operator");
+    this->helper->printParameters();
+    mrcpp::print::value(3, "Precision", prec, "(rel)", 5);
+    mrcpp::print::value(3, "Threshold", thrs, "(abs)", 5);
+    mrcpp::print::separator(3, '-');
     auto potential = this->helper->setup(prec, this->Phi);
     qmfunction::deep_copy(*this, potential);
+    if (plevel == 2) print_utils::qmfunction(2, "Reaction operator", *this, timer);
+    mrcpp::print::footer(3, timer, 2);
 }
 
 void ReactionPotential::clear() {

--- a/src/qmoperators/two_electron/ReactionPotential.cpp
+++ b/src/qmoperators/two_electron/ReactionPotential.cpp
@@ -32,7 +32,7 @@ using OrbitalVector_p = std::shared_ptr<mrchem::OrbitalVector>;
 
 namespace mrchem {
 
-ReactionPotential::ReactionPotential(SCRF_p &scrf_p, OrbitalVector_p Phi_p)
+ReactionPotential::ReactionPotential(SCRF_p scrf_p, OrbitalVector_p Phi_p)
         : QMPotential(1, false)
         , helper(std::move(scrf_p))
         , Phi(Phi_p) {}

--- a/src/qmoperators/two_electron/ReactionPotential.h
+++ b/src/qmoperators/two_electron/ReactionPotential.h
@@ -44,7 +44,7 @@ public:
     /** @brief Initializes the ReactionPotential class.
      *  @param scrf_p A SCRF instance which contains the parameters needed to compute the ReactionPotential.
      *  @param Phi_p A pointer to a vector which contains the orbitals optimized in the SCF procedure. */
-    ReactionPotential(std::unique_ptr<SCRF> &scrf_p, std::shared_ptr<mrchem::OrbitalVector> Phi_p);
+    ReactionPotential(std::unique_ptr<SCRF> scrf_p, std::shared_ptr<mrchem::OrbitalVector> Phi_p);
     ~ReactionPotential() override { free(NUMBER::Total); }
 
     SCRF *getHelper() { return this->helper.get(); }

--- a/src/qmoperators/two_electron/XCPotentialD1.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD1.cpp
@@ -58,7 +58,7 @@ mrcpp::FunctionTreeVector<3> XCPotentialD1::setupDensities(double prec, mrcpp::F
                 mrcpp::copy_grid(rho.real(), grid);
                 density::compute(prec, rho, *orbitals, DensityType::Total);
             }
-            print_utils::qmfunction(2, "XC rho", rho, timer);
+            print_utils::qmfunction(3, "Compute rho", rho, timer);
             dens_vec.push_back(std::make_tuple(1.0, &rho.real()));
         }
     } else {
@@ -70,7 +70,7 @@ mrcpp::FunctionTreeVector<3> XCPotentialD1::setupDensities(double prec, mrcpp::F
                 mrcpp::copy_grid(rho.real(), grid);
                 density::compute(prec, rho, *orbitals, DensityType::Alpha);
             }
-            print_utils::qmfunction(2, "XC rho (alpha)", rho, timer);
+            print_utils::qmfunction(3, "Compute rho (alpha)", rho, timer);
             dens_vec.push_back(std::make_tuple(1.0, &rho.real()));
         }
         { // Unperturbed beta density
@@ -81,7 +81,7 @@ mrcpp::FunctionTreeVector<3> XCPotentialD1::setupDensities(double prec, mrcpp::F
                 mrcpp::copy_grid(rho.real(), grid);
                 density::compute(prec, rho, *orbitals, DensityType::Beta);
             }
-            print_utils::qmfunction(2, "XC rho (beta)", rho, timer);
+            print_utils::qmfunction(3, "Compute rho (beta)", rho, timer);
             dens_vec.push_back(std::make_tuple(1.0, &rho.real()));
         }
     }

--- a/src/qmoperators/two_electron/XCPotentialD2.cpp
+++ b/src/qmoperators/two_electron/XCPotentialD2.cpp
@@ -80,7 +80,7 @@ mrcpp::FunctionTreeVector<3> XCPotentialD2::setupDensities(double prec, mrcpp::F
                 mrcpp::copy_grid(rho.real(), grid);
                 density::compute(prec, rho, *orbitals, DensityType::Total);
             }
-            print_utils::qmfunction(2, "XC rho_0", rho, timer);
+            print_utils::qmfunction(3, "Compute rho_0", rho, timer);
             dens_vec.push_back(std::make_tuple(1.0, &rho.real()));
         }
         { // Perturbed total density
@@ -91,7 +91,7 @@ mrcpp::FunctionTreeVector<3> XCPotentialD2::setupDensities(double prec, mrcpp::F
                 mrcpp::copy_grid(rho.real(), grid);
                 density::compute(prec, rho, *orbitals, *orbitals_x, *orbitals_y, DensityType::Total);
             }
-            print_utils::qmfunction(2, "XC rho_1", rho, timer);
+            print_utils::qmfunction(3, "Compute rho_1", rho, timer);
             dens_vec.push_back(std::make_tuple(1.0, &rho.real()));
         }
     } else {
@@ -103,7 +103,7 @@ mrcpp::FunctionTreeVector<3> XCPotentialD2::setupDensities(double prec, mrcpp::F
                 mrcpp::copy_grid(rho.real(), grid);
                 density::compute(prec, rho, *orbitals, DensityType::Alpha);
             }
-            print_utils::qmfunction(2, "XC rho_0 (alpha)", rho, timer);
+            print_utils::qmfunction(3, "Compute rho_0 (alpha)", rho, timer);
             dens_vec.push_back(std::make_tuple(1.0, &rho.real()));
         }
         { // Unperturbed beta density
@@ -114,7 +114,7 @@ mrcpp::FunctionTreeVector<3> XCPotentialD2::setupDensities(double prec, mrcpp::F
                 mrcpp::copy_grid(rho.real(), grid);
                 density::compute(prec, rho, *orbitals, DensityType::Beta);
             }
-            print_utils::qmfunction(2, "XC rho_0 (beta)", rho, timer);
+            print_utils::qmfunction(3, "Compute rho_0 (beta)", rho, timer);
             dens_vec.push_back(std::make_tuple(1.0, &rho.real()));
         }
         { // Perturbed alpha density
@@ -125,7 +125,7 @@ mrcpp::FunctionTreeVector<3> XCPotentialD2::setupDensities(double prec, mrcpp::F
                 mrcpp::copy_grid(rho.real(), grid);
                 density::compute(prec, rho, *orbitals, *orbitals_x, *orbitals_y, DensityType::Alpha);
             }
-            print_utils::qmfunction(2, "XC rho_1 (alpha)", rho, timer);
+            print_utils::qmfunction(3, "Compute rho_1 (alpha)", rho, timer);
             dens_vec.push_back(std::make_tuple(1.0, &rho.real()));
         }
         { // Perturbed beta density
@@ -136,7 +136,7 @@ mrcpp::FunctionTreeVector<3> XCPotentialD2::setupDensities(double prec, mrcpp::F
                 mrcpp::copy_grid(rho.real(), grid);
                 density::compute(prec, rho, *orbitals, *orbitals_x, *orbitals_y, DensityType::Beta);
             }
-            print_utils::qmfunction(2, "XC rho_1 (beta)", rho, timer);
+            print_utils::qmfunction(3, "Compute rho_1 (beta)", rho, timer);
             dens_vec.push_back(std::make_tuple(1.0, &rho.real()));
         }
     }

--- a/src/scf_solver/Accelerator.cpp
+++ b/src/scf_solver/Accelerator.cpp
@@ -107,7 +107,7 @@ void Accelerator::rotate(const ComplexMatrix &U, bool all) {
         F = U.adjoint() * F * U;
         dF = U.adjoint() * dF * U;
     }
-    mrcpp::print::time(2, "Rotating iterative subspace", t_tot);
+    mrcpp::print::time(this->pl + 2, "Rotating iterative subspace", t_tot);
 }
 
 /** @brief Update iterative history with the latest orbitals and updates
@@ -137,7 +137,7 @@ void Accelerator::push_back(OrbitalVector &Phi, OrbitalVector &dPhi, ComplexMatr
     if (historyIsFull and this->dFock.size() > 0) this->dFock.pop_front();
 
     if (not verifyOverlap(Phi)) {
-        println(2, " Clearing accelerator");
+        println(this->pl + 2, " Clearing accelerator");
         this->clear();
     }
 
@@ -146,7 +146,7 @@ void Accelerator::push_back(OrbitalVector &Phi, OrbitalVector &dPhi, ComplexMatr
     if (F != nullptr) this->fock.push_back(*F);
     if (dF != nullptr) this->dFock.push_back(*dF);
 
-    mrcpp::print::time(2, "Push back orbitals", t_tot);
+    mrcpp::print::time(this->pl + 2, "Push back orbitals", t_tot);
 }
 
 /** @brief Verify that the orbital overlap between the two last iterations is positive.
@@ -170,7 +170,7 @@ bool Accelerator::verifyOverlap(OrbitalVector &Phi) {
                 auto sqNorm = phi_i.squaredNorm();
                 auto overlap = orbital::dot(phi_i, last_i);
                 if (std::abs(overlap) < 0.5 * sqNorm) {
-                    mrcpp::print::value(2, "Overlap not verified ", std::abs(overlap));
+                    mrcpp::print::value(this->pl + 2, "Overlap not verified ", std::abs(overlap));
                     out(i) = 1;
                 }
             }
@@ -201,8 +201,8 @@ void Accelerator::accelerate(double prec, OrbitalVector &Phi, OrbitalVector &dPh
     if (this->maxHistory < 1) return;
 
     Timer t_tot;
-    auto plevel = Printer::getPrintLevel();
-    mrcpp::print::header(2, "Iterative subspace accelerator");
+    auto plevel = Printer::getPrintLevel(); // global print level
+    mrcpp::print::header(this->pl + 2, "Iterative subspace accelerator");
 
     // Deep copy into history
     this->push_back(Phi, dPhi, F, dF);
@@ -216,8 +216,8 @@ void Accelerator::accelerate(double prec, OrbitalVector &Phi, OrbitalVector &dPh
         clearLinearSystem();
     }
     printSizeNodes();
-    mrcpp::print::footer(2, t_tot, 2);
-    if (plevel == 1) mrcpp::print::time(1, "Iterative subspace accelerator", t_tot);
+    mrcpp::print::footer(this->pl + 2, t_tot, 2);
+    if (plevel == 1) mrcpp::print::time(this->pl + 1, "Iterative subspace accelerator", t_tot);
 }
 
 /** @brief Solve the linear system of equations
@@ -232,7 +232,7 @@ void Accelerator::solveLinearSystem() {
         auto tmpC = this->A[n].colPivHouseholderQr().solve(this->b[n]).eval();
         this->c.push_back(tmpC);
     }
-    mrcpp::print::time(2, "Solve linear system", t_tot);
+    mrcpp::print::time(this->pl + 2, "Solve linear system", t_tot);
 }
 
 /** @brief Copy orbitals at the given point in history into the given set.
@@ -249,7 +249,7 @@ void Accelerator::copyOrbitals(OrbitalVector &Phi, int nHistory) {
     if (nHistory >= totHistory or nHistory < 0) MSG_ABORT("Requested orbitals unavailable");
     int n = totHistory - 1 - nHistory;
     Phi = orbital::deep_copy(this->orbitals[n]);
-    mrcpp::print::time(2, "Copy orbitals", t_tot);
+    mrcpp::print::time(this->pl + 2, "Copy orbitals", t_tot);
 }
 
 /** @brief Copy orbital updates at the given point in history into the given set.
@@ -265,7 +265,7 @@ void Accelerator::copyOrbitalUpdates(OrbitalVector &dPhi, int nHistory) {
     if (nHistory >= totHistory or nHistory < 0) MSG_ABORT("Requested orbitals unavailable");
     int n = totHistory - 1 - nHistory;
     dPhi = orbital::deep_copy(this->dOrbitals[n]);
-    mrcpp::print::time(2, "Copy orbital updates", t_tot);
+    mrcpp::print::time(this->pl + 2, "Copy orbital updates", t_tot);
 }
 
 /** @brief Replaces the orbital set from a given point in history.
@@ -355,9 +355,9 @@ void Accelerator::printSizeNodes() const {
         dn += orbital::get_n_nodes(orbs_i);
         dm += orbital::get_size_nodes(orbs_i);
     }
-    mrcpp::print::separator(2, '-');
-    mrcpp::print::tree(2, "Orbital sizes", n, m, 0.0);
-    mrcpp::print::tree(2, "Update sizes", dn, dm, 0.0);
+    mrcpp::print::separator(this->pl + 2, '-');
+    mrcpp::print::tree(this->pl + 2, "Orbital sizes", n, m, 0.0);
+    mrcpp::print::tree(this->pl + 2, "Update sizes", dn, dm, 0.0);
 }
 
 } // namespace mrchem

--- a/src/scf_solver/Accelerator.h
+++ b/src/scf_solver/Accelerator.h
@@ -58,6 +58,7 @@ public:
     virtual ~Accelerator() { this->clear(); }
     void clear();
 
+    void setLocalPrintLevel(int p) { this->pl = p; }
     void setMaxHistory(int max) { this->maxHistory = max; }
     void setMinHistory(int min) { this->minHistory = min; }
 
@@ -79,6 +80,7 @@ public:
     void printSizeNodes() const;
 
 protected:
+    int pl{0};        ///< Local print level, relative to global Printer
     int minHistory;   ///< Accelerator is activated when history reaches this size
     int maxHistory;   ///< Oldest iteration is discarded when history exceeds this size
     bool sepOrbitals; ///< Use separate subspace for each orbital

--- a/src/scf_solver/GroundStateSolver.cpp
+++ b/src/scf_solver/GroundStateSolver.cpp
@@ -220,7 +220,12 @@ void GroundStateSolver::reset() {
  */
 json GroundStateSolver::optimize(Molecule &mol, FockBuilder &F) {
     printParameters("Optimize ground state orbitals");
-    if (F.getReactionOperator() != nullptr) F.getReactionOperator()->getHelper()->printParameters();
+
+    // Print solvation cavity and SCRF parameters
+    if (F.getReactionOperator() != nullptr) {
+        F.getReactionOperator()->getHelper()->printParameters();
+        F.getReactionOperator()->getHelper()->getPermittivity().printParameters();
+    }
 
     Timer t_tot;
     json json_out;

--- a/src/scf_solver/GroundStateSolver.cpp
+++ b/src/scf_solver/GroundStateSolver.cpp
@@ -168,6 +168,8 @@ void GroundStateSolver::printParameters(const std::string &calculation) const {
     o_prec_1 << std::setprecision(5) << std::scientific << this->orbPrec[2];
 
     mrcpp::print::separator(0, '~');
+    print_utils::centeredText(0, "Self-Consistent Field");
+    mrcpp::print::separator(0, '~');
     print_utils::text(0, "Calculation        ", calculation);
     print_utils::text(0, "Method             ", this->methodName);
     print_utils::text(0, "Relativity         ", this->relativityName);
@@ -218,6 +220,8 @@ void GroundStateSolver::reset() {
  */
 json GroundStateSolver::optimize(Molecule &mol, FockBuilder &F) {
     printParameters("Optimize ground state orbitals");
+    if (F.getReactionOperator() != nullptr) F.getReactionOperator()->getHelper()->printParameters();
+
     Timer t_tot;
     json json_out;
 

--- a/src/scf_solver/GroundStateSolver.cpp
+++ b/src/scf_solver/GroundStateSolver.cpp
@@ -168,8 +168,6 @@ void GroundStateSolver::printParameters(const std::string &calculation) const {
     o_prec_1 << std::setprecision(5) << std::scientific << this->orbPrec[2];
 
     mrcpp::print::separator(0, '~');
-    print_utils::centeredText(0, "Self-Consistent Field");
-    mrcpp::print::separator(0, '~');
     print_utils::text(0, "Calculation        ", calculation);
     print_utils::text(0, "Method             ", this->methodName);
     print_utils::text(0, "Relativity         ", this->relativityName);
@@ -220,12 +218,6 @@ void GroundStateSolver::reset() {
  */
 json GroundStateSolver::optimize(Molecule &mol, FockBuilder &F) {
     printParameters("Optimize ground state orbitals");
-
-    // Print solvation cavity and SCRF parameters
-    if (F.getReactionOperator() != nullptr) {
-        F.getReactionOperator()->getHelper()->printParameters();
-        F.getReactionOperator()->getHelper()->getPermittivity().printParameters();
-    }
 
     Timer t_tot;
     json json_out;

--- a/src/scf_solver/GroundStateSolver.cpp
+++ b/src/scf_solver/GroundStateSolver.cpp
@@ -171,6 +171,7 @@ void GroundStateSolver::printParameters(const std::string &calculation) const {
     print_utils::text(0, "Calculation        ", calculation);
     print_utils::text(0, "Method             ", this->methodName);
     print_utils::text(0, "Relativity         ", this->relativityName);
+    print_utils::text(0, "Environment        ", this->environmentName);
     print_utils::text(0, "Checkpointing      ", (this->checkpoint) ? "On" : "Off");
     print_utils::text(0, "Max iterations     ", o_iter.str());
     print_utils::text(0, "KAIN solver        ", o_kain.str());

--- a/src/scf_solver/KAIN.cpp
+++ b/src/scf_solver/KAIN.cpp
@@ -120,7 +120,7 @@ void KAIN::setupLinearSystem() {
     }
 
     sortLinearSystem(A_matrices, b_vectors);
-    mrcpp::print::time(2, "Setup linear system", t_tot);
+    mrcpp::print::time(this->pl + 2, "Setup linear system", t_tot);
 }
 
 /** @brief Compute the next step for orbitals and orbital updates
@@ -213,7 +213,7 @@ void KAIN::expandSolution(double prec, OrbitalVector &Phi, OrbitalVector &dPhi, 
         // F is unchanged, dF is overwritten
         *dF = fockStep;
     }
-    mrcpp::print::time(2, "Expand solution", t_tot);
+    mrcpp::print::time(this->pl + 2, "Expand solution", t_tot);
 }
 
 } // namespace mrchem

--- a/src/scf_solver/SCFSolver.cpp
+++ b/src/scf_solver/SCFSolver.cpp
@@ -82,10 +82,10 @@ double SCFSolver::adjustPrecision(double error) {
     this->orbPrec[0] = std::max(this->orbPrec[0], this->orbPrec[2]);
 
     mrcpp::print::separator(2, '=');
-    mrcpp::print::value(1, "Current precision", this->orbPrec[0], "", 5);
+    mrcpp::print::value(1, "Current precision", this->orbPrec[0], "(rel)", 5);
     mrcpp::print::separator(1, '-');
-    mrcpp::print::value(2, "Orbital threshold", this->orbThrs, "", 5);
-    mrcpp::print::value(2, "Property threshold", this->propThrs, "", 5);
+    mrcpp::print::value(2, "Orbital threshold", this->orbThrs, "(abs)", 5);
+    mrcpp::print::value(2, "Property threshold", this->propThrs, "(abs)", 5);
     mrcpp::print::separator(2, '=', 2);
     return this->orbPrec[0];
 }

--- a/src/scf_solver/SCFSolver.h
+++ b/src/scf_solver/SCFSolver.h
@@ -58,6 +58,7 @@ public:
     void setMaxIterations(int iter) { this->maxIter = iter; }
     void setMethodName(const std::string &name) { this->methodName = name; }
     void setRelativityName(const std::string &name) { this->relativityName = name; }
+    void setEnvironmentName(const std::string &name) { this->environmentName = name; }
 
 protected:
     int history{0};                      ///< Maximum length of KAIN history
@@ -69,6 +70,7 @@ protected:
     double orbPrec[3]{-1.0, -1.0, -1.0}; ///< Dynamic precision: [current_prec, start_prec, end_prec]
     std::string methodName;              ///< Name of electronic structure method to appear in output
     std::string relativityName{"None"};  ///< Name of ZORA method
+    std::string environmentName{"None"}; ///< Aggregated name for external environment
 
     std::vector<double> error;    ///< Convergence orbital error
     std::vector<double> property; ///< Convergence property error

--- a/src/tensor/RankZeroOperator.cpp
+++ b/src/tensor/RankZeroOperator.cpp
@@ -292,7 +292,7 @@ OrbitalVector RankZeroOperator::operator()(OrbitalVector &inp) {
         out.push_back(out_i);
         std::stringstream o_name;
         o_name << O.name() << "|" << i << ">";
-        print_utils::qmfunction(3, o_name.str(), out_i, t1);
+        print_utils::qmfunction(4, o_name.str(), out_i, t1);
     }
     return out;
 }
@@ -312,7 +312,7 @@ OrbitalVector RankZeroOperator::dagger(OrbitalVector &inp) {
         out.push_back(out_i);
         std::stringstream o_name;
         o_name << O.name() << "^dagger|" << i << ">";
-        print_utils::qmfunction(3, o_name.str(), out_i, t1);
+        print_utils::qmfunction(4, o_name.str(), out_i, t1);
     }
     return out;
 }

--- a/src/utils/print_utils.cpp
+++ b/src/utils/print_utils.cpp
@@ -147,6 +147,30 @@ void print_utils::json(int level, const nlohmann::json &j, bool ralign) {
     }
 }
 
+void print_utils::json(int level, const nlohmann::json &j, bool ralign) {
+    // Determine longest name
+    int w = 0;
+    for (const auto &item : j.items()) {
+        if (item.key().size() > w) w = item.key().size();
+    }
+
+    // Print
+    for (const auto &item : j.items()) {
+        std::string key = item.key();
+        std::stringstream o_val;
+        o_val << item.value();
+        std::string val = o_val.str();
+
+        // Remove quotes from val and print
+        val.erase(std::remove(val.begin(), val.end(), '\"'), val.end());
+
+        // If right-align, determine how much to shift the vals
+        int shift = (ralign) ? Printer::getWidth() - w - val.size() - 3 : 0;
+
+        std::printf("%-*s%-s%-s%-s\n", w, key.c_str(), " : ", std::string(shift, ' ').c_str(), val.c_str());
+    }
+}
+
 void print_utils::coord(int level, const std::string &txt, const mrcpp::Coord<3> &val, int p, bool s) {
     if (p < 0) p = Printer::getPrecision();
     int w0 = Printer::getWidth() - 2;

--- a/src/utils/print_utils.cpp
+++ b/src/utils/print_utils.cpp
@@ -73,7 +73,7 @@ std::string print_utils::dbl_to_str(double d, int p, bool sci) {
     return o_dbl.str();
 }
 /** @brief Prints text centered according to current print width */
-void print_utils::centeredText(int level, const std::string &txt) {
+void print_utils::centered_text(int level, const std::string &txt) {
     int pwidth = Printer::getWidth();
     int txt_width = txt.size();
     int pre_spaces = (pwidth - txt_width) / 2;

--- a/src/utils/print_utils.cpp
+++ b/src/utils/print_utils.cpp
@@ -127,7 +127,7 @@ void print_utils::json(int level, const nlohmann::json &j, bool ralign) {
         int w0 = Printer::getWidth() - 2; // Defines the printable width
         int w1 = w0 * 2 / 9;              // Space dedicated to the json key
         int w2 = w0 - 3 * w1;
-        int w3 = w2 - (val.size() + 1);
+        // int w3 = w2 - (val.size() + 1);
 
         // Some paddings for book keeping
         int frontEndPadding = 2; // Empty space at beginning and end
@@ -135,51 +135,6 @@ void print_utils::json(int level, const nlohmann::json &j, bool ralign) {
 
         // Use standard spacing if longest name fits
         if (w2 > lshift) lshift = w2 - frontEndPadding;
-
-        // Calculate the shift needed for right-aligning
-        int rshift = (ralign) ? Printer::getWidth() - lshift - val.size() - frontEndPadding - colonPadding : 0;
-
-        // Check that rshift is not negative (caused by very long names)
-        if (rshift < 0) rshift = 0;
-
-        // Print line
-        std::printf(" %-*s%-s%-s%-s \n", lshift, key.c_str(), " : ", std::string(rshift, ' ').c_str(), val.c_str());
-    }
-}
-
-void print_utils::json(int level, const nlohmann::json &j, bool ralign) {
-    // Determine longest name
-    // This will be used for the spacing left of :
-    // if the name is too long to be aligned with
-    // the other sections
-    int lshift = 0;
-    for (const auto &item : j.items()) {
-        if (item.key().size() > lshift) lshift = item.key().size();
-    }
-
-    // Loop over json items
-    for (const auto &item : j.items()) {
-        // Extract key and value from json
-        std::string key = item.key();
-        std::stringstream o_val;
-        o_val << item.value();
-        std::string val = o_val.str();
-
-        // Remove quotes from val
-        val.erase(std::remove(val.begin(), val.end(), '\"'), val.end());
-
-        // Standard shift to align all colons
-        int w0 = Printer::getWidth() - 2; // Defines the printable width
-        int w1 = w0 * 2 / 9;              // Space dedicated to the json key
-        int w2 = w0 - 3 * w1;
-        int w3 = w2 - (val.size() + 1);
-
-        // Some paddings for book keeping
-        int frontEndPadding = 2; // Empty space at beginning and end
-        int colonPadding = 3;    // Two empty spaces around a single colon
-
-        // Use standard spacing if longest name fits
-        if (w3 > lshift) lshift = w3 + frontEndPadding;
 
         // Calculate the shift needed for right-aligning
         int rshift = (ralign) ? Printer::getWidth() - lshift - val.size() - frontEndPadding - colonPadding : 0;

--- a/src/utils/print_utils.cpp
+++ b/src/utils/print_utils.cpp
@@ -109,7 +109,7 @@ void print_utils::text(int level, const std::string &txt, const std::string &val
     shift = (ralign) ? w0 - w2 - val.size() - 1 : 0;
 
     std::stringstream o;
-    o << " " << txt << std::string(w3, ' ') << ": "  << std::string(shift, ' ') << val;
+    o << " " << txt << std::string(w3, ' ') << ": " << std::string(shift, ' ') << val;
     println(level, o.str());
 }
 

--- a/src/utils/print_utils.cpp
+++ b/src/utils/print_utils.cpp
@@ -72,7 +72,8 @@ std::string print_utils::dbl_to_str(double d, int p, bool sci) {
     }
     return o_dbl.str();
 }
-/** @brief Prints text centered according to current print width */ / void print_utils::centeredText(int level, const std::string &txt) {
+/** @brief Prints text centered according to current print width */
+void print_utils::centeredText(int level, const std::string &txt) {
     int pwidth = Printer::getWidth();
     int txt_width = txt.size();
     int pre_spaces = (pwidth - txt_width) / 2;

--- a/src/utils/print_utils.cpp
+++ b/src/utils/print_utils.cpp
@@ -72,6 +72,12 @@ std::string print_utils::dbl_to_str(double d, int p, bool sci) {
     }
     return o_dbl.str();
 }
+/** @brief Prints text centered according to current print width */ / void print_utils::centeredText(int level, const std::string &txt) {
+    int pwidth = Printer::getWidth();
+    int txt_width = txt.size();
+    int pre_spaces = (pwidth - txt_width) / 2;
+    println(level, std::string(pre_spaces, ' ') << txt);
+}
 
 void print_utils::headline(int level, const std::string &txt) {
     auto pwidth = Printer::getWidth();

--- a/src/utils/print_utils.cpp
+++ b/src/utils/print_utils.cpp
@@ -114,6 +114,7 @@ void print_utils::text(int level, const std::string &txt, const std::string &val
 }
 
 void print_utils::json(int level, const nlohmann::json &j, bool ralign) {
+    if (level > mrcpp::Printer::getPrintLevel()) return;
     // Determine longest name
     // This will be used for the spacing left of :
     // if the name is too long to be aligned with

--- a/src/utils/print_utils.cpp
+++ b/src/utils/print_utils.cpp
@@ -98,14 +98,18 @@ void print_utils::headline(int level, const std::string &txt) {
     mrcpp::print::separator(level, ' ');
 }
 
-void print_utils::text(int level, const std::string &txt, const std::string &val) {
+void print_utils::text(int level, const std::string &txt, const std::string &val, bool ralign) {
     int w0 = Printer::getWidth() - 2;
     int w1 = w0 * 2 / 9;
     int w2 = w0 - 3 * w1;
     int w3 = w2 - (txt.size() + 1);
 
+    // Right-aligning
+    int shift;
+    shift = (ralign) ? w0 - w2 - val.size() - 1 : 0;
+
     std::stringstream o;
-    o << " " << txt << std::string(w3, ' ') << ": " << val;
+    o << " " << txt << std::string(w3, ' ') << ": "  << std::string(shift, ' ') << val;
     println(level, o.str());
 }
 

--- a/src/utils/print_utils.cpp
+++ b/src/utils/print_utils.cpp
@@ -167,6 +167,9 @@ void print_utils::json(int level, const nlohmann::json &j, bool ralign) {
         // If right-align, determine how much to shift the vals
         int shift = (ralign) ? Printer::getWidth() - w - val.size() - 3 : 0;
 
+        // Avoid runtime errors due to negative shifts caused by very long names
+        if (shift < 0) shift = 0;
+
         std::printf("%-*s%-s%-s%-s\n", w, key.c_str(), " : ", std::string(shift, ' ').c_str(), val.c_str());
     }
 }

--- a/src/utils/print_utils.h
+++ b/src/utils/print_utils.h
@@ -37,7 +37,7 @@ void headline(int level, const std::string &txt);
 void text(int level, const std::string &txt, const std::string &val);
 void json(int level, const nlohmann::json &j, bool ralign = false);
 void coord(int level, const std::string &txt, const mrcpp::Coord<3> &val, int p = -1, bool s = false);
-void scalar(int level, const std::string &txt, double val, const std::string &unit = "", int p = -1, bool s = false);
+void scalar(int level, const std::string &txt, double val, const std::string &unit = "", int p = -1, bool s = false, int txtBuffer = 0);
 void vector(int level, const std::string &txt, const DoubleVector &val, int p = -1, bool s = false);
 void matrix(int level, const std::string &txt, const DoubleMatrix &val, int p = -1, bool s = false);
 void qmfunction(int level, const std::string &txt, const QMFunction &func, mrcpp::Timer &t);

--- a/src/utils/print_utils.h
+++ b/src/utils/print_utils.h
@@ -37,7 +37,7 @@ void headline(int level, const std::string &txt);
 void text(int level, const std::string &txt, const std::string &val);
 void json(int level, const nlohmann::json &j, bool ralign = false);
 void coord(int level, const std::string &txt, const mrcpp::Coord<3> &val, int p = -1, bool s = false);
-void scalar(int level, const std::string &txt, double val, const std::string &unit = "", int p = -1, bool s = false, int txtBuffer = 0);
+void scalar(int level, const std::string &txt, double val, const std::string &unit = "", int p = -1, bool s = false);
 void vector(int level, const std::string &txt, const DoubleVector &val, int p = -1, bool s = false);
 void matrix(int level, const std::string &txt, const DoubleMatrix &val, int p = -1, bool s = false);
 void qmfunction(int level, const std::string &txt, const QMFunction &func, mrcpp::Timer &t);

--- a/src/utils/print_utils.h
+++ b/src/utils/print_utils.h
@@ -33,6 +33,7 @@
 namespace mrchem {
 namespace print_utils {
 
+void centeredText(int level, const std::string &txt);
 void headline(int level, const std::string &txt);
 void text(int level, const std::string &txt, const std::string &val);
 void json(int level, const nlohmann::json &j, bool ralign = false);

--- a/src/utils/print_utils.h
+++ b/src/utils/print_utils.h
@@ -35,7 +35,7 @@ namespace print_utils {
 
 void centeredText(int level, const std::string &txt);
 void headline(int level, const std::string &txt);
-void text(int level, const std::string &txt, const std::string &val);
+void text(int level, const std::string &txt, const std::string &val, bool ralign = false);
 void json(int level, const nlohmann::json &j, bool ralign = false);
 void coord(int level, const std::string &txt, const mrcpp::Coord<3> &val, int p = -1, bool s = false);
 void scalar(int level, const std::string &txt, double val, const std::string &unit = "", int p = -1, bool s = false);

--- a/src/utils/print_utils.h
+++ b/src/utils/print_utils.h
@@ -33,7 +33,7 @@
 namespace mrchem {
 namespace print_utils {
 
-void centeredText(int level, const std::string &txt);
+void centered_text(int level, const std::string &txt);
 void headline(int level, const std::string &txt);
 void text(int level, const std::string &txt, const std::string &val, bool ralign = false);
 void json(int level, const nlohmann::json &j, bool ralign = false);

--- a/tests/solventeffect/reaction_operator.cpp
+++ b/tests/solventeffect/reaction_operator.cpp
@@ -90,7 +90,7 @@ TEST_CASE("ReactionOperator", "[reaction_operator]") {
     int kain = 4;
     auto scrf_p = std::make_unique<SCRF>(dielectric_func, molecule, P_p, D_p, prec, kain, 100, true, "dynamic", "scrf", "total");
 
-    auto Reo = std::make_shared<ReactionOperator>(scrf_p, Phi_p);
+    auto Reo = std::make_shared<ReactionOperator>(std::move(scrf_p), Phi_p);
     Reo->setTesting();
     Reo->setup(prec);
     double total_energy = Reo->getTotalEnergy();


### PR DESCRIPTION
In response to #406.

During input parsing, now a short summary label is generated and displayed in the SCF solver table. It indicates whether an implicit solvent is being used, and if a finite external electric is applied. For example, if both are active:

```
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Calculation             : Optimize ground state orbitals
 Method                  : Hartree-Fock
 Relativity              : None
 Environment             : PCM ; Electric field (0.0, 0.0, 0.01)
 Checkpointing           : Off
 Max iterations          : 5
 KAIN solver             : 3
 Localization            : Off
 Diagonalization         : First two iterations
 Start precision         : 1.00000e-03
 Final precision         : 1.00000e-03
 Helmholtz precision     : Dynamic
 Energy threshold        : Off
 Orbital threshold       : 1.00000e-02
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

A more detailed table is also printed earlier showing some key settings for the implicit solvent. For example:

```
===========================================================================
                      Self-Consistent Reaction Field
---------------------------------------------------------------------------
 Dielectric constant (inside)     :                            1.00000e+00
 Dielectric constant (outside)    :                            2.00000e+00
 Max number of micro-ierations    :                                  100.0
 Accelerate with KAIN             :                                   true
 Algorithm                        :                                   scrf
 Density type                     :                                  total
 Convergence criterion            :                                dynamic
===========================================================================
```

To allow for the rather long names left of the `:`, some tweaks to `print_utils` were needed. A `txtBuffer` option was added that lets a developer give more room if needed (defaults to 0). Also, an option for right-aligning `print_utils::text` was added, but a left-aligned table is perhaps aesthetically more pleasing...?

Should a table similar to the geometry one be printed for the cavity?