### PR TITLE
Update Slurm version in Singularity recipe

### DIFF
--- a/recipes/Singularity.openmpi4.0
+++ b/recipes/Singularity.openmpi4.0
@@ -77,7 +77,7 @@ Stage: build
     export LIBRARY_PATH=/usr/local/ucx/lib:$LIBRARY_PATH
     export PATH=/usr/local/ucx/bin:$PATH
 
-# SLURM PMI2 version 20.11.7
+# SLURM PMI2 version 21.08.8
 %post
     apt-get update -y
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -90,12 +90,12 @@ Stage: build
     rm -rf /var/lib/apt/lists/*
 %post
     cd /
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-20.11.7.tar.bz2
-    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-20.11.7.tar.bz2 -C /var/tmp -j
-    cd /var/tmp/slurm-20.11.7 &&   ./configure --prefix=/usr/local/slurm-pmi2
-    cd /var/tmp/slurm-20.11.7
+    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-21.08.8.tar.bz2
+    mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-21.08.8.tar.bz2 -C /var/tmp -j
+    cd /var/tmp/slurm-21.08.8 &&   ./configure --prefix=/usr/local/slurm-pmi2
+    cd /var/tmp/slurm-21.08.8
     make -C contribs/pmi2 install
-    rm -rf /var/tmp/slurm-20.11.7 /var/tmp/slurm-20.11.7.tar.bz2
+    rm -rf /var/tmp/slurm-21.08.8 /var/tmp/slurm-21.08.8.tar.bz2
 
 # OpenMPI version 4.0.5
 %post


### PR DESCRIPTION
This fixes the failing GHA build, as the old version download suddenly resulted in a 404