### PR TITLE
Fix importing of pyparsing

### DIFF
--- a/python/mrchem/input_parser/plumbing/atoms.py
+++ b/python/mrchem/input_parser/plumbing/atoms.py
@@ -34,6 +34,9 @@ from typing import Any, List, Union
 
 try:
     import pyparsing as pp
+    if pp.__version__.split(".")[0] < "3":
+       # Import local copy
+       from . import pyparsing as pp  # type: ignore
 except ImportError:
     # Import local copy
     from . import pyparsing as pp  # type: ignore

--- a/python/mrchem/input_parser/plumbing/getkw.py
+++ b/python/mrchem/input_parser/plumbing/getkw.py
@@ -43,6 +43,9 @@ from .atoms import (
 
 try:
     import pyparsing as pp
+    if pp.__version__.split(".")[0] < "3":
+       # Import local copy
+       from . import pyparsing as pp  # type: ignore
 except ImportError:
     # Import local copy
     from . import pyparsing as pp  # type: ignore


### PR DESCRIPTION
If an older `pyparsing` is available (and it usually always is), then it is imported, but it won't work with the parser generated by `parselglossy`. I've added a check so that if the existing `pyparsing` is not of major version >=3, the local copy is used instead. I will port this to `parselglossy` itself as well.