### PR TITLE
Use dynamic thrs in initial SCRF

### DIFF
--- a/src/environment/SCRF.cpp
+++ b/src/environment/SCRF.cpp
@@ -216,6 +216,7 @@ void SCRF::nestedSCRF(QMFunction V_vac) {
         printConvergenceRow(iter, norm, update, t_iter.elapsed());
         iter++;
     }
+    if (iter > max_iter) println(0, "Reaction potential failed to converge after " << iter-1 << " iterations, residual " << update);
     mrcpp::print::separator(3, '-');
     this->dVr_n.real().clear();
     this->dVr_n.real().setZero();

--- a/src/environment/SCRF.cpp
+++ b/src/environment/SCRF.cpp
@@ -65,7 +65,7 @@ SCRF::SCRF(Permittivity e,
         , history(kain_hist)
         , apply_prec(orb_prec)
         , conv_thrs(1.0)
-        , mo_residual(-1.0)
+        , mo_residual(1.0)
         , epsilon(e)
         , rho_nuc(false)
         , rho_ext(false)

--- a/tests/li_solv/li.inp
+++ b/tests/li_solv/li.inp
@@ -16,7 +16,7 @@
   "SCRF": {
     "kain": 5,
     "max_iter": 100,
-    "dynamic_thrs": true,
+    "dynamic_thrs": false,
     "optimizer": "potential"
   },
   "Cavity": {

--- a/tests/solventeffect/reaction_operator.cpp
+++ b/tests/solventeffect/reaction_operator.cpp
@@ -88,7 +88,7 @@ TEST_CASE("ReactionOperator", "[reaction_operator]") {
     if (mpi::my_orb(Phi[0])) qmfunction::project(Phi[0], f, NUMBER::Real, prec);
 
     int kain = 4;
-    auto scrf_p = std::make_unique<SCRF>(dielectric_func, molecule, P_p, D_p, prec, kain, 100, true, true, "total");
+    auto scrf_p = std::make_unique<SCRF>(dielectric_func, molecule, P_p, D_p, prec, kain, 100, true, false, "total");
 
     auto Reo = std::make_shared<ReactionOperator>(std::move(scrf_p), Phi_p);
     Reo->setup(prec);


### PR DESCRIPTION
Turned out to be a comically simple fix. By initializing the MO residual to `1.0` instead of `-1.0` we trigger the dynamic threshold also for the 0th iteration. For cases when we want to compute the total energy accurately on the initial guess, use `dynamic_thrs = false`.

@Gabrielgerez please try this version on some real-world cases.

Closes #426