### PR TITLE
Fix mpi error on SAD_GTO guess, closes #452

### DIFF
--- a/src/initial_guess/gto.cpp
+++ b/src/initial_guess/gto.cpp
@@ -221,6 +221,7 @@ void initial_guess::gto::project_ao(OrbitalVector &Phi, double prec, const Nucle
         for (int i = 0; i < gto_exp.size(); i++) {
             Timer t_i;
             Phi.push_back(Orbital(SPIN::Paired));
+            Phi.back().setRank(Phi.size() - 1);
             GaussExp<3> ao_i = gto_exp.getAO(i);
             ao_i.calcScreening(screen);
             if (mrcpp::mpi::my_orb(Phi.back())) {


### PR DESCRIPTION
@gitpeterwind , not exactly sure why the rank should be set incrementally by the number of orbitals rather than the number of MPI ranks, but this is the way it's done in the `core::project_ao` equivalent, and it seems to work :shrug: 