### PR TITLE
Fix incoming build error in rtd

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,10 @@
 version: 2
 
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.6"
+
 sphinx:
   configuration: doc/conf.py
 
@@ -8,6 +13,5 @@ formats:
   - pdf
 
 python:
-  version: 3.6
   install:
     - requirements: doc/requirements.txt

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.6"
+    python: "3.9"
 
 sphinx:
   configuration: doc/conf.py

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,5 +1,5 @@
 breathe
 recommonmark
-Sphinx>=2.0
+sphinx<7
 sphinx_rtd_theme
 sphinxcontrib-bibtex==1.0.0


### PR DESCRIPTION
the key `build.os` will start being a requirement soon (see [link](https://blog.readthedocs.com/use-build-os-config/) )
Hopefully this fixes any issues