### PR TITLE
Remove dead link to old slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ chemistry (Hartree-Fock and Density Functional Theory).
 The code is being developed at the Hylleraas Centre for Quantum Molecular
 Sciences at UiT - The Arctic University of Norway.
 
-### User support: [mrchem.slack.com](https://join.slack.com/t/mrchem/shared_invite/enQtNTI3MjMzNjM0NTk0LWNkODZjNTMwYmM4NmRmODExMjQzMDc3NThlMzNmNmIyNWQwM2YwOGY0OWY4NmNmNzE4ZmM2NzgxYzUzNDg3NDM)
 ### Documentation: [mrchem.readthedocs.io](http://mrchem.readthedocs.io)
 
 


### PR DESCRIPTION
Removed user support link to the old slack channel. We can probably replace it with something else, but I think it is better to stop users from hoping too much