### PR TITLE
Fix failing macos ci pipeline

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -21,7 +21,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        # setup-miniconda not compatible with macos-latest presently.
+        # https://github.com/conda-incubator/setup-miniconda/issues/344
+        os: [ubuntu-latest, macos-12]
 
     steps:
     - uses: actions/checkout@v2
@@ -35,7 +37,7 @@ jobs:
         key:
           ${{ matrix.os }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('.github/mrchem-gha.yml') }}
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
           auto-update-conda: true
           auto-activate-base: false


### PR DESCRIPTION
Temporary workaround, see https://github.com/conda-incubator/setup-miniconda/issues/344