### PR TITLE
KAIN for complex orbitals

### DIFF
--- a/src/scf_solver/KAIN.cpp
+++ b/src/scf_solver/KAIN.cpp
@@ -75,9 +75,9 @@ void KAIN::setupLinearSystem() {
 
                     // Ref. Harrisons KAIN paper the following has the wrong sign,
                     // but we define the updates (lowercase f) with opposite sign.
-                    orbA(i, j) -= mrcpp::dot(dPhi_im, dfPhi_jm);
+                    orbA(i, j) -= ComplexDouble( std::real(mrcpp::dot(dPhi_im, dfPhi_jm)), 0.0 );
                 }
-                orbB(i) += mrcpp::dot(dPhi_im, fPhi_m);
+                orbB(i) += ComplexDouble( std::real(mrcpp::dot(dPhi_im, fPhi_m)), 0.0 );
             }
         }
         double alpha = (this->scaling.size() == nOrbitals) ? scaling[n] : 1.0;


### PR DESCRIPTION
Changed the complex L2 inner product to the real L2 inner product.
It makes it consistent with optimization problems appearing in quantum chemistry.

We need to check:
H2_magnetic_properties_LDA (Failed)

We should operate with different inner products in energy expressions (`mrcpp::dot`) and in optimization tools (real part of `mrcpp::dot`). They are conceptually different. For example, the gradient of Lagrangian is an optimization tool, and so it uses the latter one (with the real part).