### PR TITLE
Use only LDA exchange in SAD guess instead of SVWN5.

### DIFF
--- a/src/initial_guess/sad.cpp
+++ b/src/initial_guess/sad.cpp
@@ -71,7 +71,7 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, c
     print_utils::text(0, "Precision   ", print_utils::dbl_to_str(prec, 5, true));
     print_utils::text(0, "Screening   ", print_utils::dbl_to_str(screen, 5, true) + " StdDev");
     print_utils::text(0, "Restricted  ", (restricted) ? "True" : "False");
-    print_utils::text(0, "Functional  ", "LDA (SVWN5)");
+    print_utils::text(0, "Functional  ", "LDA (SLATERX)");
     print_utils::text(0, "AO basis    ", "Hydrogenic orbitals");
     print_utils::text(0, "Zeta quality", std::to_string(zeta));
     mrcpp::print::separator(0, '~', 2);
@@ -84,7 +84,6 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, c
     mrdft::Factory xc_factory(*MRA);
     xc_factory.setSpin(false);
     xc_factory.setFunctional("SLATERX", 1.0);
-    xc_factory.setFunctional("VWN5C", 1.0);
     auto mrdft_p = xc_factory.build();
 
     MomentumOperator p(D_p);
@@ -150,7 +149,7 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, c
     print_utils::text(0, "Precision   ", print_utils::dbl_to_str(prec, 5, true));
     print_utils::text(0, "Screening   ", print_utils::dbl_to_str(screen, 5, true) + " StdDev");
     print_utils::text(0, "Restricted  ", (restricted) ? "True" : "False");
-    print_utils::text(0, "Functional  ", "LDA (SVWN5)");
+    print_utils::text(0, "Functional  ", "LDA (SLATERX)");
     print_utils::text(0, "AO basis    ", "3-21G");
     mrcpp::print::separator(0, '~', 2);
 
@@ -162,7 +161,6 @@ bool initial_guess::sad::setup(OrbitalVector &Phi, double prec, double screen, c
     mrdft::Factory xc_factory(*MRA);
     xc_factory.setSpin(false);
     xc_factory.setFunctional("SLATERX", 1.0);
-    xc_factory.setFunctional("VWN5C", 1.0);
     auto mrdft_p = xc_factory.build();
     MomentumOperator p(D_p);
     NuclearOperator V_nuc(nucs, prec);


### PR DESCRIPTION
In our study on initial guesses in [J. Chem. Phys. 152, 144105 (2020)](https://doi.org/10.1063/5.0004046), we examined the importance of including correlation in the guess potential. However, we found out that the correlation functional only plays a minor importance, and that it also can sometimes lead to unexpected results; as far as I remember, the correlated potentials were sometimes more shallow than those obtained from an exchange only calculation.

This PR removes the correlation contribution from the initial guess.