### PR TITLE
Fetch libxc release tarball instead of full git repository in autocmake

### DIFF
--- a/external/upstream/fetch_libxc.cmake
+++ b/external/upstream/fetch_libxc.cmake
@@ -7,8 +7,7 @@ else()
   message(STATUS "Suitable LibXC could not be located. Fetching and building!")
   include(FetchContent)
   FetchContent_Declare(libxc_sources
-    GIT_REPOSITORY https://gitlab.com/libxc/libxc
-    GIT_TAG 7.0.0
+    URL https://gitlab.com/libxc/libxc/-/archive/7.0.0/libxc-7.0.0.tar.gz
   )
   set(CMAKE_INSTALL_INCLUDEDIR "include/" CACHE STRING "" FORCE) # Creates Libxc subdir in install
   set(BUILD_TESTING     OFF CACHE BOOL "Build LibXC tests" FORCE)


### PR DESCRIPTION
This reduces the needed download size considaribly, about halfing the time to run the setup script on my machine on work wifi.