### PR TITLE
Generalize code in gto_utils to allow for arbitrary angular momentum

### DIFF
--- a/doc/users/user_inp.rst
+++ b/doc/users/user_inp.rst
@@ -561,9 +561,9 @@ The ``gto`` initial guess requires ``.bas`` and ``.mop`` (or ``.moa/.mob``)
 files containing information about the gto basis (in the ``.bas`` file), and the
 mo coefficients (in the ``.mo...`` files). These files are in dalton format, but
 can be generated from orca calculations using the script ``tools/initial_guess/from_orca.py``.
-Currently, MRChem only supports reading AO basis functions with angular momentum
-up to ``l = 4`` (g orbitals), which in practice means that basis sets up to quadruple zeta
-(e.g. ``def2-QZVP`` and ``cc-pVQZ``) will work for most elements.
+.. note::
+    For previous users of MRChem: The code for gto initial guess has been generalized
+    to allow for arbitrary high angular momentum.
 
 Checkpointing
 +++++++++++++

--- a/src/utils/gto_utils/AOContraction.cpp
+++ b/src/utils/gto_utils/AOContraction.cpp
@@ -35,8 +35,25 @@ using mrcpp::GaussFunc;
 namespace mrchem {
 namespace gto_utils {
 
-// TODO: Docs
-static std::array<int, 3> ind_to_crt(int l, int i) {
+/**
+ * This computes directly the exponents of the ith cartesian orbital with angular momentum l.
+ * For example, the f orbitals (l = 3) come in the order:
+ * index_to_cartesian(3, 0) == {3, 0, 0} (x^3)
+ * index_to_cartesian(3, 1) == {2, 1, 0} (x^2 y)
+ * index_to_cartesian(3, 2) == {2, 0, 1} (x^2 z)
+ * index_to_cartesian(3, 3) == {1, 2, 0} (x y^2)
+ * index_to_cartesian(3, 4) == {1, 1, 1} (x y z)
+ * index_to_cartesian(3, 5) == {1, 0, 2} (x z^2)
+ * index_to_cartesian(3, 6) == {0, 3, 0} (y^3)
+ * index_to_cartesian(3, 7) == {0, 2, 1} (y^2 z)
+ * index_to_cartesian(3, 8) == {0, 1, 2} (y z^2)
+ * index_to_cartesian(3, 9) == {0, 0, 3} (z^3)
+ * 
+ * @brief Compute the exponents of the ith cartesian orbital with angular momentum l
+ * @param l total angular momentum quantum number
+ * @param i index of specific cartesian orbital
+ */
+static std::array<int, 3> index_to_cartesian(int l, int i) {
     int lx = l;
 
     for (int j = 1; i > l - lx; j++) {
@@ -61,6 +78,10 @@ GaussExp<3> AOContraction::getNormContraction(int m, const mrcpp::Coord<3> &cent
     return ctr;
 }
 
+double cartesianNormFac(int l) {
+    return math_utils::double_factorial(2 * l - 1);
+}
+
 /** Normalization goes like this (thanks Radovan)
 
     < AO | AO > =   1 for s, px, py, pz, dxy, dxz, dyz, fxyz
@@ -70,11 +91,9 @@ GaussExp<3> AOContraction::getNormContraction(int m, const mrcpp::Coord<3> &cent
               ...     ...
             9 for gxxyy, ...
               etc     ...
-*/
-double cartesianNormFac(int l) {
-    return math_utils::double_factorial(2 * l - 1);
-}
 
+    This conveniently can be expressed using the double factorial in each dimension
+*/
 double cartesianNormFac(int lx, int ly, int lz) {
     int l = lx + ly + lz;
 
@@ -86,7 +105,7 @@ double cartesianNormFac(int lx, int ly, int lz) {
 GaussExp<3> AOContraction::getContraction(int m, const mrcpp::Coord<3> &center) const {
     assert(m >= 0 and m < this->nComp);
     GaussExp<3> ctr;
-    std::array<int, 3> pow = ind_to_crt(this->L, m);
+    std::array<int, 3> pow = index_to_cartesian(this->L, m);
     double normFac = cartesianNormFac(pow[0], pow[1], pow[2]);
 
     for (unsigned int i = 0; i < expo.size(); i++) {

--- a/src/utils/gto_utils/AOContraction.cpp
+++ b/src/utils/gto_utils/AOContraction.cpp
@@ -27,78 +27,28 @@
 
 #include "AOContraction.h"
 
+#include "utils/math_utils.h"
+
 using mrcpp::GaussExp;
 using mrcpp::GaussFunc;
 
 namespace mrchem {
 namespace gto_utils {
 
-// clang-format off
-static const int s_gto[][3] = {
-    {0, 0, 0}
-};
+// TODO: Docs
+static std::array<int, 3> ind_to_crt(int l, int i) {
+    int lx = l;
 
-int p_gto[][3] = {
-    {1, 0, 0},
-    {0, 1, 0},
-    {0, 0, 1}
-};
+    for (int j = 1; i > l - lx; j++) {
+        lx--;
+        i -= j;
+    }
 
-static const int d_gto[][3] = {
-    {2, 0, 0},
-    {1, 1, 0},
-    {1, 0, 1},
-    {0, 2, 0},
-    {0, 1, 1},
-    {0, 0, 2}
-};
+    int ly = l - lx - i;
+    int lz = l - lx - ly;
 
-static const int f_gto[][3] = {
-    {3, 0, 0},
-    {2, 1, 0},
-    {2, 0, 1},
-    {1, 2, 0},
-    {1, 1, 1},
-    {1, 0, 2},
-    {0, 3, 0},
-    {0, 2, 1},
-    {0, 1, 2},
-    {0, 0, 3}
-};
-
-static const int g_gto[][3] = {
-    {4, 0, 0},
-    {3, 1, 0},
-    {3, 0, 1},
-    {2, 2, 0},
-    {2, 1, 1},
-    {2, 0, 2},
-    {1, 3, 0},
-    {1, 2, 1},
-    {1, 1, 2},
-    {1, 0, 3},
-    {0, 4, 0},
-    {0, 3, 1},
-    {0, 2, 2},
-    {0, 1, 3},
-    {0, 0, 4}
-};
-
-struct gtoDef {
-    int l;
-    int ncomp;
-    const int *comp[(MAX_L + 1) * (MAX_L + 2) / 2];
-
-};
-
-static const gtoDef GTOS[MAX_L+1] = {
-    { 0,  1, {s_gto[0]} },
-    { 1,  3, {p_gto[0], p_gto[1], p_gto[2]}},
-    { 2,  6, {d_gto[0], d_gto[1], d_gto[2], d_gto[3], d_gto[4], d_gto[5]}},
-    { 3, 10, {f_gto[0], f_gto[1], f_gto[2], f_gto[3], f_gto[4], f_gto[5], f_gto[6], f_gto[7], f_gto[8], f_gto[9]}},
-    { 4, 15, {g_gto[0], g_gto[1], g_gto[2], g_gto[3], g_gto[4], g_gto[5], g_gto[6], g_gto[7], g_gto[8], g_gto[9], g_gto[10], g_gto[11], g_gto[12], g_gto[13], g_gto[14]}}
-};
-// clang-format on
+    return {lx, ly, lz};
+}
 
 AOContraction::AOContraction(int l) {
     this->L = l;
@@ -121,35 +71,24 @@ GaussExp<3> AOContraction::getNormContraction(int m, const mrcpp::Coord<3> &cent
             9 for gxxyy, ...
               etc     ...
 */
+static double computeNormFac(int l) {
+    return math_utils::double_factorial(2 * l - 1);
+}
+
+static double computeNormFac(int lx, int ly, int lz) {
+    int l = lx + ly + lz;
+
+    double n = computeNormFac(lx) * computeNormFac(ly) * computeNormFac(lz) / computeNormFac(l);
+
+    return std::sqrt(n);
+}
+
 GaussExp<3> AOContraction::getContraction(int m, const mrcpp::Coord<3> &center) const {
     assert(m >= 0 and m < this->nComp);
     GaussExp<3> ctr;
-    double normFac = 1.0;
-    const int *angMom = GTOS[this->L].comp[m];
-    for (int i = 0; i < 3; i++) {
-        switch (angMom[i]) {
-            case 0:
-                normFac *= 1.0;
-                break;
-            case 1:
-                normFac *= 1.0;
-                break;
-            case 2:
-                normFac *= 3.0;
-                break;
-            case 3:
-                normFac *= 15.0;
-                break;
-            case 4:
-                normFac *= 105.0;
-                break;
-            default:
-                MSG_ERROR("We don't support h-functions at the moment");
-        }
-    }
-    normFac = std::sqrt(normFac);
+    std::array<int, 3> pow = ind_to_crt(this->L, m);
+    double normFac = computeNormFac(pow[0], pow[1], pow[2]);
 
-    std::array<int, 3> pow{angMom[0], angMom[1], angMom[2]};
     for (unsigned int i = 0; i < expo.size(); i++) {
         GaussFunc<3> gto(this->expo[i], 1.0, center, pow);
         gto.normalize();

--- a/src/utils/gto_utils/AOContraction.cpp
+++ b/src/utils/gto_utils/AOContraction.cpp
@@ -71,14 +71,14 @@ GaussExp<3> AOContraction::getNormContraction(int m, const mrcpp::Coord<3> &cent
             9 for gxxyy, ...
               etc     ...
 */
-static double computeNormFac(int l) {
+double cartesianNormFac(int l) {
     return math_utils::double_factorial(2 * l - 1);
 }
 
-static double computeNormFac(int lx, int ly, int lz) {
+double cartesianNormFac(int lx, int ly, int lz) {
     int l = lx + ly + lz;
 
-    double n = computeNormFac(lx) * computeNormFac(ly) * computeNormFac(lz) / computeNormFac(l);
+    double n = cartesianNormFac(lx) * cartesianNormFac(ly) * cartesianNormFac(lz) / cartesianNormFac(l);
 
     return std::sqrt(n);
 }
@@ -87,7 +87,7 @@ GaussExp<3> AOContraction::getContraction(int m, const mrcpp::Coord<3> &center) 
     assert(m >= 0 and m < this->nComp);
     GaussExp<3> ctr;
     std::array<int, 3> pow = ind_to_crt(this->L, m);
-    double normFac = computeNormFac(pow[0], pow[1], pow[2]);
+    double normFac = cartesianNormFac(pow[0], pow[1], pow[2]);
 
     for (unsigned int i = 0; i < expo.size(); i++) {
         GaussFunc<3> gto(this->expo[i], 1.0, center, pow);

--- a/src/utils/gto_utils/AOContraction.h
+++ b/src/utils/gto_utils/AOContraction.h
@@ -33,7 +33,6 @@
 namespace mrchem {
 namespace gto_utils {
 
-// static const int MAX_L = 4; // Max f-functions
 
 double cartesianNormFac(int l);
 double cartesianNormFac(int lx, int ly, int lz);

--- a/src/utils/gto_utils/AOContraction.h
+++ b/src/utils/gto_utils/AOContraction.h
@@ -33,7 +33,10 @@
 namespace mrchem {
 namespace gto_utils {
 
-static const int MAX_L = 4; // Max f-functions
+// static const int MAX_L = 4; // Max f-functions
+
+double cartesianNormFac(int l);
+double cartesianNormFac(int lx, int ly, int lz);
 
 /** Contracted atomic orbital.
  *

--- a/src/utils/gto_utils/Intgrl.cpp
+++ b/src/utils/gto_utils/Intgrl.cpp
@@ -104,7 +104,6 @@ void Intgrl::readAtomData(std::ifstream &ifs, int n_atoms, double z) {
 }
 
 void Intgrl::readContractionBlock(std::ifstream &ifs, AOBasis &bas, int l) {
-    if (l > 4) MSG_ABORT("Only s, p, d, f and g orbitals are currently supported");
     int nprim, nctr;
     ifs >> nprim;
     ifs >> nctr;

--- a/src/utils/gto_utils/OrbitalExp.cpp
+++ b/src/utils/gto_utils/OrbitalExp.cpp
@@ -29,9 +29,11 @@
 #include "MRCPP/Printer"
 
 #include "AOBasis.h"
+#include "AOContraction.h"
 #include "Intgrl.h"
 #include "OrbitalExp.h"
 #include "chemistry/Nucleus.h"
+#include "utils/math_utils.h"
 
 using mrcpp::GaussExp;
 using mrcpp::GaussFunc;
@@ -135,6 +137,74 @@ void OrbitalExp::readAOExpansion(Intgrl &intgrl) {
     transformToSpherical();
 }
 
+static double ns_coeff(int l, int m) {
+    double lf = math_utils::factorial(l);
+    double f1 = math_utils::factorial(l + m) / lf;
+    double f2 = math_utils::factorial(l - m) / lf;
+    double f3 = math_utils::pow_by_squaring(2.0, -(2 * std::abs(m) + (m == 0 ? 1 : 0) - 1));
+
+    return std::sqrt(f1 * f2 * f3);
+}
+
+static double c_coeff(int l, int m, int t, int u, int v) {
+    uint64_t c = math_utils::binomial(l, t) * math_utils::binomial(l - t, std::abs(m) + t) *
+                 math_utils::binomial(t, u) *
+                 math_utils::binomial(std::abs(m), 2 * v + (m < 0 ? 1 : 0));
+
+    double cd = static_cast<double>(c);
+
+    return ((t + v) % 2 == 0 ? cd : -cd) * math_utils::pow_by_squaring(4.0, -t);
+}
+
+static int crt_to_ind(int ly, int lz) {
+    return (ly * (ly + 2 * lz + 1) + lz * (lz + 3)) / 2;
+}
+
+static CartToSphTransformation initializeSphCoeffs(int l) {
+    CartToSphTransformation transformation;
+
+    for (int m = -l; m <= l; m++) {
+        std::vector<int> inds;
+        std::vector<double> coeffs;
+
+        int ml0 = m < 0 ? 1 : 0;
+        double ns = ns_coeff(l, m);
+
+        for (int t = 0; t <= (l - std::abs(m)) / 2; t++) {
+            for (int u = 0; u <= t; u++) {
+                for (int v = 0; v <= (std::abs(m) - ml0) / 2; v++) {
+                    int lx = 2 * t + std::abs(m) - 2 * u - 2 * v - ml0;
+                    int ly = 2 * u + 2 * v + ml0;
+                    int lz = l - 2 * t - std::abs(m);
+
+                    int ind = crt_to_ind(ly, lz);
+
+                    double coeff = c_coeff(l, m, t, u, v);
+                    double norm = cartesianNormFac(lx, ly, lz);
+
+                    inds.push_back(ind);
+                    coeffs.push_back(ns * coeff * norm);
+                }
+            }
+        }
+
+        transformation.inds.push_back(inds);
+        transformation.coeffs.push_back(coeffs);
+    }
+
+    return transformation;
+}
+
+CartToSphTransformation &OrbitalExp::getSphTransformation(int l) {
+    while (sph_transformation_data.size() <= l) {
+        int new_l = sph_transformation_data.size();
+        CartToSphTransformation new_transformation = initializeSphCoeffs(new_l);
+        sph_transformation_data.push_back(new_transformation);
+    }
+
+    return sph_transformation_data[l];
+}
+
 void OrbitalExp::transformToSpherical() {
     if (not this->cartesian) { return; }
     std::vector<GaussExp<3> *> tmp;
@@ -147,190 +217,39 @@ void OrbitalExp::transformToSpherical() {
             tmp.push_back(orb);
             this->orbitals[n] = nullptr;
             n++;
-        } else if (l == 2) {
-            int nprim = this->orbitals[n]->size();
-
-            for (int i = 0; i < 6; i++) {
-                if (this->orbitals[n + i]->size() != nprim) { MSG_ABORT("Contracted d orbials with different number of primitives"); }
-            }
-
-            auto *sph_xy = new GaussExp<3>;
-            auto *sph_yz = new GaussExp<3>;
-            auto *sph_z2 = new GaussExp<3>;
-            auto *sph_xz = new GaussExp<3>;
-            auto *sph_x2 = new GaussExp<3>;
-
-            double sqrt3 = std::sqrt(3.0);
-
-            for (int i = 0; i < nprim; i++) {
-                Gaussian<3> &xx = this->orbitals[n + 0]->getFunc(i);
-                Gaussian<3> &xy = this->orbitals[n + 1]->getFunc(i);
-                Gaussian<3> &xz = this->orbitals[n + 2]->getFunc(i);
-                Gaussian<3> &yy = this->orbitals[n + 3]->getFunc(i);
-                Gaussian<3> &yz = this->orbitals[n + 4]->getFunc(i);
-                Gaussian<3> &zz = this->orbitals[n + 5]->getFunc(i);
-
-                sph_xy->append(xy);
-                sph_yz->append(yz);
-
-                sph_z2->append(xx);
-                sph_z2->getFunc(sph_z2->size() - 1).setCoef(-0.5 * xx.getCoef());
-                sph_z2->append(yy);
-                sph_z2->getFunc(sph_z2->size() - 1).setCoef(-0.5 * yy.getCoef());
-                sph_z2->append(zz);
-                sph_z2->getFunc(sph_z2->size() - 1).setCoef(zz.getCoef());
-
-                sph_xz->append(xz);
-
-                sph_x2->append(xx);
-                sph_x2->getFunc(sph_x2->size() - 1).setCoef(0.5 * sqrt3 * xx.getCoef());
-                sph_x2->append(yy);
-                sph_x2->getFunc(sph_x2->size() - 1).setCoef(-0.5 * sqrt3 * yy.getCoef());
-            }
-
-            tmp.push_back(sph_xy);
-            tmp.push_back(sph_yz);
-            tmp.push_back(sph_z2);
-            tmp.push_back(sph_xz);
-            tmp.push_back(sph_x2);
-
-            n += 6;
-        } else if (l == 3) {
-            GaussExp<3> *sph[7];
-
-            for (int i = 0; i < 7; i++) { sph[i] = new GaussExp<3>; }
-
-            // order of cartesian f orbitals:
-            // xxx xxy xxz xyy xyz xzz yyy yyz yzz zzz
-
-            double c1 = std::sqrt(2.5), c2 = std::sqrt(15.0), c3 = std::sqrt(1.5);
-
-            // from page 211 of Molecular Electronic Structure Theory (Helgaker, et. al.)
-            double coeffs[7][10] = {
-                {0.0, 1.5 * c1, 0.0, 0.0, 0.0, 0.0, -0.5 * c1, 0.0, 0.0, 0.0},
-                {0.0, 0.0, 0.0, 0.0, c2, 0.0, 0.0, 0.0, 0.0, 0.0},
-                {0.0, -0.5 * c3, 0.0, 0.0, 0.0, 0.0, -0.5 * c3, 0.0, 2.0 * c3, 0.0},
-                {0.0, 0.0, -1.5, 0.0, 0.0, 0.0, 0.0, -1.5, 0.0, 1.0},
-                {-0.5 * c3, 0.0, 0.0, -0.5 * c3, 0.0, 2.0 * c3, 0.0, 0.0, 0.0, 0.0},
-                {0.0, 0.0, 0.5 * c2, 0.0, 0.0, 0.0, 0.0, -0.5 * c2, 0.0, 0.0},
-                {0.5 * c1, 0.0, 0.0, -1.5 * c1, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0},
-            };
-
-            double normalization[10] = {15.0, 3.0, 3.0, 3.0, 1.0, 3.0, 15.0, 3.0, 3.0, 15.0};
-            for (int i = 0; i < 10; i++) { normalization[i] = std::sqrt(normalization[i] / 15.0); }
-
-            int nprim = this->orbitals[n]->size();
-
-            for (int i = 0; i < 10; i++) {
-                if (this->orbitals[n + i]->size() != nprim) { MSG_ABORT("Contracted f orbials with different number of primitives"); }
-            }
-
-            for (int i = 0; i < nprim; i++) {
-                for (int j = 0; j < 7; j++) {
-                    for (int k = 0; k < 10; k++) {
-                        if (coeffs[j][k] != 0.0) {
-                            Gaussian<3> &func = this->orbitals[n + k]->getFunc(i);
-                            sph[j]->append(func);
-                            sph[j]->getFunc(sph[j]->size() - 1).setCoef(coeffs[j][k] * normalization[k] * func.getCoef());
-                        }
-                    }
-                }
-            }
-
-            for (int i = 0; i < 7; i++) {
-                tmp.push_back(sph[i]);
-            }
-
-            n += 10;
-        } else if (l == 4) {
-            GaussExp<3> *sph[9];
-
-            for (int i = 0; i < 9; i++) { sph[i] = new GaussExp<3>; }
-
-            // order of cartesian g orbitals:
-            // xxxx xxxy xxxz xxyy xxyz xxzz xyyy xyyz xyzz xzzz yyyy yyyz yyzz yzzz zzzz
-            // 0    1    2    3    4    5    6    7    8    9    10   11   12   13   14
-
-            double c1 = std::sqrt(35.0), c2 = std::sqrt(35.0 * 0.5), c3 = std::sqrt(5.0), c4 = std::sqrt(2.5);
-
-            // from page 211 of Molecular Electronic Structure Theory (Helgaker, et. al.)
-            double coeffs[9][15] = {};
-            {
-                // ml = -4
-                coeffs[0][1] = 0.5 * c1;
-                coeffs[0][6] = -0.5 * c1;
-
-                // ml = -3
-                coeffs[1][4] = 1.5 * c2;
-                coeffs[1][11] = -0.5 * c2;
-
-                // ml = -2
-                coeffs[2][1] = -0.5 * c3;
-                coeffs[2][6] = -0.5 * c3;
-                coeffs[2][8] = 3.0 * c3;
-
-                // ml = -1
-                coeffs[3][4] = -1.5 * c4;
-                coeffs[3][11] = -1.5 * c4;
-                coeffs[3][13] = 2.0 * c4;
-
-                // ml = 0
-                coeffs[4][0] = 3.0 / 8.0;
-                coeffs[4][3] = 3.0 / 4.0;
-                coeffs[4][5] = -3.0;
-                coeffs[4][10] = 3.0 / 8.0;
-                coeffs[4][12] = -3.0;
-                coeffs[4][14] = 1.0;
-
-                // ml = 1
-                coeffs[5][2] = -1.5 * c4;
-                coeffs[5][7] = -1.5 * c4;
-                coeffs[5][9] = 2.0 * c4;
-
-                // ml = 2
-                coeffs[6][0] = -0.25 * c3;
-                coeffs[6][5] = 1.5 * c3;
-                coeffs[6][10] = 0.25 * c3;
-                coeffs[6][12] = -1.5 * c3;
-
-                // ml = 3
-                coeffs[7][2] = 0.5 * c2;
-                coeffs[7][7] = -1.5 * c2;
-
-                // ml = 4
-                coeffs[8][0] = 1.0 / 8.0 * c1;
-                coeffs[8][3] = -3.0 / 4.0 * c1;
-                coeffs[8][10] = 1.0 / 8.0 * c1;
-            }
-
-            double normalization[15] = {105.0, 15.0, 15.0, 9.0, 3.0, 9.0, 15.0, 3.0, 3.0, 15.0, 105.0, 15.0, 9.0, 15.0, 105.0};
-            for (int i = 0; i < 15; i++) { normalization[i] = std::sqrt(normalization[i] / 105.0); }
-
-            int nprim = this->orbitals[n]->size();
-
-            for (int i = 0; i < 15; i++) {
-                if (this->orbitals[n + i]->size() != nprim) { MSG_ABORT("Contracted g orbials with different number of primitives"); }
-            }
-
-            for (int i = 0; i < nprim; i++) {
-                for (int j = 0; j < 9; j++) {
-                    for (int k = 0; k < 15; k++) {
-                        if (coeffs[j][k] != 0.0) {
-                            Gaussian<3> &func = this->orbitals[n + k]->getFunc(i);
-                            sph[j]->append(func);
-                            sph[j]->getFunc(sph[j]->size() - 1).setCoef(coeffs[j][k] * normalization[k] * func.getCoef());
-                        }
-                    }
-                }
-            }
-
-            for (int i = 0; i < 9; i++) {
-                tmp.push_back(sph[i]);
-            }
-
-            n += 15;
         } else {
-            MSG_ABORT("Only s, p, d, f and g orbitals are supported");
+            std::vector<GaussExp<3> *> sph;
+
+            int ncart = ((l + 1) * (l + 2)) / 2;
+            int nsph = 2 * l + 1;
+
+            for (int i = 0; i < nsph; i++) { sph.push_back(new GaussExp<3>); }
+
+            int nprim = this->orbitals[n]->size();
+
+            CartToSphTransformation &trans_data = getSphTransformation(l);
+
+            for (int i = 0; i < nprim; i++) {
+                for (int j = 0; j < nsph; j++) {
+                    std::vector<int> &inds = trans_data.inds[j];
+                    std::vector<double> &coeffs = trans_data.coeffs[j];
+
+                    for (int k = 0; k < inds.size(); k++) {
+                        int ind = inds[k];
+                        double coeff = coeffs[k];
+
+                        Gaussian<3> &func = this->orbitals[n + ind]->getFunc(i);
+                        sph[j]->append(func);
+                        sph[j]->getFunc(sph[j]->size() - 1).setCoef(coeff * func.getCoef());
+                    }
+                }
+            }
+
+            for (int i = 0; i < nsph; i++) {
+                tmp.push_back(sph[i]);
+            }
+
+            n += ncart;
         }
     }
     for (int i = 0; i < nOrbs; i++) {

--- a/src/utils/gto_utils/OrbitalExp.cpp
+++ b/src/utils/gto_utils/OrbitalExp.cpp
@@ -137,6 +137,9 @@ void OrbitalExp::readAOExpansion(Intgrl &intgrl) {
     transformToSpherical();
 }
 
+/**
+ * Computes the Ns coefficient from equation 6.4.49 on page 215 of the "Molecular Electronic Structure Theory" Book
+ */
 static double ns_coeff(int l, int m) {
     double lf = math_utils::factorial(l);
     double f1 = math_utils::factorial(l + m) / lf;
@@ -146,6 +149,9 @@ static double ns_coeff(int l, int m) {
     return std::sqrt(f1 * f2 * f3);
 }
 
+/**
+ * Computes the C_tuv^lm coefficient from equation 6.4.48 on page 215 of the "Molecular Electronic Structure Theory" Book
+ */
 static double c_coeff(int l, int m, int t, int u, int v) {
     uint64_t c = math_utils::binomial(l, t) * math_utils::binomial(l - t, std::abs(m) + t) *
                  math_utils::binomial(t, u) *
@@ -156,10 +162,33 @@ static double c_coeff(int l, int m, int t, int u, int v) {
     return ((t + v) % 2 == 0 ? cd : -cd) * math_utils::pow_by_squaring(4.0, -t);
 }
 
-static int crt_to_ind(int ly, int lz) {
+/**
+ * This computes directly the index a cartesian orbital given only the exponents of y and z.
+ * (Note that the exponent of x is not needed)
+ *
+ * For example, the f orbitals (l = 3) come in the order:
+ * cartesian_to_index(0, 0) == 0 (x^3)
+ * cartesian_to_index(1, 0) == 1 (x^2 y)
+ * cartesian_to_index(0, 1) == 2 (x^2 z)
+ * cartesian_to_index(2, 0) == 3 (x y^2)
+ * cartesian_to_index(1, 1) == 4 (x y z)
+ * cartesian_to_index(0, 2) == 5 (x z^2)
+ * cartesian_to_index(3, 0) == 6 (y^3)
+ * cartesian_to_index(2, 1) == 7 (y^2 z)
+ * cartesian_to_index(1, 2) == 8 (y z^2)
+ * cartesian_to_index(0, 3) == 9 (z^3)
+ *
+ * @param ly exponent of y
+ * @param lz exponent of z
+ */
+static int cartesian_to_index(int ly, int lz) {
     return (ly * (ly + 2 * lz + 1) + lz * (lz + 3)) / 2;
 }
 
+/**
+ * Computes the coefficients for the solid spherical harmonics using
+ * equation 6.4.47 on page 215 of the "Molecular Electronic Structure Theory" Book
+ */
 static CartToSphTransformation initializeSphCoeffs(int l) {
     CartToSphTransformation transformation;
 
@@ -177,7 +206,7 @@ static CartToSphTransformation initializeSphCoeffs(int l) {
                     int ly = 2 * u + 2 * v + ml0;
                     int lz = l - 2 * t - std::abs(m);
 
-                    int ind = crt_to_ind(ly, lz);
+                    int ind = cartesian_to_index(ly, lz);
 
                     double coeff = c_coeff(l, m, t, u, v);
                     double norm = cartesianNormFac(lx, ly, lz);

--- a/src/utils/gto_utils/OrbitalExp.h
+++ b/src/utils/gto_utils/OrbitalExp.h
@@ -36,6 +36,11 @@ namespace mrchem {
 namespace gto_utils {
 class Intgrl;
 
+struct CartToSphTransformation {
+    std::vector<std::vector<int>> inds;
+    std::vector<std::vector<double>> coeffs;
+};
+
 class OrbitalExp final {
 public:
     OrbitalExp(Intgrl &intgrl);
@@ -54,8 +59,12 @@ protected:
     bool cartesian;
     std::vector<mrcpp::GaussExp<3> *> orbitals;
 
+    std::vector<CartToSphTransformation> sph_transformation_data;
+
     void readAOExpansion(Intgrl &intgrl);
     void transformToSpherical();
+
+    CartToSphTransformation &getSphTransformation(int l);
 };
 
 } // namespace gto_utils

--- a/src/utils/math_utils.cpp
+++ b/src/utils/math_utils.cpp
@@ -236,7 +236,7 @@ double pow_by_squaring(double b, int e) {
     double acc = 1.0;
 
     while (e != 0) {
-        if (e & 1 != 0) {
+        if ((e & 1) != 0) {
             acc *= p;
         }
         p *= p;

--- a/src/utils/math_utils.cpp
+++ b/src/utils/math_utils.cpp
@@ -180,5 +180,27 @@ double logsumexp(const Eigen::VectorXd &x) {
     return max + std::log((x.array() - max).exp().sum());
 }
 
+/**
+ * @brief Compute the binomial coefficient (n, k).
+ * @warning Will not warn or crash in case of overflow, use at own risk!
+ * @param n Number of elements in collection
+ * @param k Number of elements in selection
+ * @result Number of ways to chose k unordered elements from n.
+ */
+u_int64_t binomial(u_int64_t n, u_int64_t k) {
+    // The implementation is translated to C++ from the Julia standard library
+    // (https://github.com/JuliaLang/julia/blob/15346901f0039751c5488744f1f62de7d87510a8/base/intfuncs.jl#L1252-L1279)
+
+    if (k > n) { return 0; }
+    if (k > (n >> 1)) { k = n - k; }
+    if (k == 0) { return 1; }
+
+    uint64_t x = n - k + 1;
+
+    for (uint64_t nn = x + 1, rr = 2; rr <= k; rr++, nn++) { x = (x * nn) / rr; }
+
+    return x;
+}
+
 } // namespace math_utils
 } // namespace mrchem

--- a/src/utils/math_utils.cpp
+++ b/src/utils/math_utils.cpp
@@ -195,11 +195,55 @@ u_int64_t binomial(u_int64_t n, u_int64_t k) {
     if (k > (n >> 1)) { k = n - k; }
     if (k == 0) { return 1; }
 
-    uint64_t x = n - k + 1;
+    u_int64_t x = n - k + 1;
 
-    for (uint64_t nn = x + 1, rr = 2; rr <= k; rr++, nn++) { x = (x * nn) / rr; }
+    for (u_int64_t nn = x + 1, rr = 2; rr <= k; rr++, nn++) { x = (x * nn) / rr; }
 
     return x;
+}
+
+// TODO: Docs
+double factorial(int n) {
+    double acc = 1.0;
+
+    for (int i = 2; i <= n; i++) {
+        acc *= static_cast<double>(i);
+    }
+
+    return acc;
+}
+
+// TODO: Docs
+double double_factorial(int n) {
+    double acc = 1.0;
+
+    while (n >= 2) {
+        acc *= static_cast<double>(n);
+        n -= 2;
+    }
+
+    return acc;
+}
+
+// TODO: Docs
+double pow_by_squaring(double b, int e) {
+    if (e < 0) {
+        e = -e;
+        b = 1.0 / b;
+    }
+
+    double p = b;
+    double acc = 1.0;
+
+    while (e != 0) {
+        if (e & 1 != 0) {
+            acc *= p;
+        }
+        p *= p;
+        e >>= 1;
+    }
+
+    return acc;
 }
 
 } // namespace math_utils

--- a/src/utils/math_utils.cpp
+++ b/src/utils/math_utils.cpp
@@ -202,7 +202,11 @@ u_int64_t binomial(u_int64_t n, u_int64_t k) {
     return x;
 }
 
-// TODO: Docs
+/**
+ * @brief Compute n! using floating point numbers to allow for higher inputs
+ * @param n
+ * @result n! = 1 * 2 * ... * (n - 1) * n
+ */
 double factorial(int n) {
     double acc = 1.0;
 
@@ -213,7 +217,12 @@ double factorial(int n) {
     return acc;
 }
 
-// TODO: Docs
+/**
+ * @brief Compute the double factorial n!!
+ * @warning This is not the same as the factorial of the factorial of n. n!! != (n!)!
+ * @param n
+ * @result n!! = n * (n - 2) * (n - 4) * ...
+ */
 double double_factorial(int n) {
     double acc = 1.0;
 
@@ -225,7 +234,12 @@ double double_factorial(int n) {
     return acc;
 }
 
-// TODO: Docs
+/**
+ * @brief Compute b^e using the power by squaring method (https://en.wikipedia.org/wiki/Exponentiation_by_squaring)
+ * @param b Base
+ * @param e Integer exponent. Can be negative.
+ * @result b^e
+ */
 double pow_by_squaring(double b, int e) {
     if (e < 0) {
         e = -e;

--- a/src/utils/math_utils.h
+++ b/src/utils/math_utils.h
@@ -48,6 +48,10 @@ ComplexMatrix diagonalize_hermitian_matrix(const ComplexMatrix &A, DoubleVector 
 void diagonalize_block(ComplexMatrix &M, ComplexMatrix &U, int nstart, int nsize);
 double logsumexp(const Eigen::VectorXd &x);
 u_int64_t binomial(u_int64_t n, u_int64_t, k);
+double factorial(int i);
+double double_factorial(int i);
+double pow_by_squaring(double b, int e);
+
 
 } // namespace math_utils
 } // namespace mrchem

--- a/src/utils/math_utils.h
+++ b/src/utils/math_utils.h
@@ -47,7 +47,7 @@ ComplexMatrix hermitian_matrix_pow(const ComplexMatrix &A, double b);
 ComplexMatrix diagonalize_hermitian_matrix(const ComplexMatrix &A, DoubleVector &diag);
 void diagonalize_block(ComplexMatrix &M, ComplexMatrix &U, int nstart, int nsize);
 double logsumexp(const Eigen::VectorXd &x);
-u_int64_t binomial(u_int64_t n, u_int64_t, k);
+u_int64_t binomial(u_int64_t n, u_int64_t k);
 double factorial(int i);
 double double_factorial(int i);
 double pow_by_squaring(double b, int e);

--- a/src/utils/math_utils.h
+++ b/src/utils/math_utils.h
@@ -47,6 +47,7 @@ ComplexMatrix hermitian_matrix_pow(const ComplexMatrix &A, double b);
 ComplexMatrix diagonalize_hermitian_matrix(const ComplexMatrix &A, DoubleVector &diag);
 void diagonalize_block(ComplexMatrix &M, ComplexMatrix &U, int nstart, int nsize);
 double logsumexp(const Eigen::VectorXd &x);
+u_int64_t binomial(u_int64_t n, u_int64_t, k);
 
 } // namespace math_utils
 } // namespace mrchem

--- a/tools/initial_guess/from_orca.py
+++ b/tools/initial_guess/from_orca.py
@@ -123,6 +123,7 @@ angmom_to_l = {
     'f': 3,
     'g': 4,
     'h': 5,
+    'i': 6,
 }
 
 
@@ -145,15 +146,16 @@ def shell_permutation(angmom):
 
 def shell_signs(angmom):
     l = angmom_to_l[angmom]
-    if l <= 2:
-        return [1] * (2 * l + 1)
+    signs = [1]
 
-    if angmom == 'f':
-        return [-1, 1, 1, 1, 1, 1, -1]
-    elif angmom == 'g':
-        return [-1, -1, 1, 1, 1, 1, 1, -1, -1]
-    else:
-        raise NotImplementedError
+    for m in range(1, l + 1):
+        if m in (3, 4): # Flip signs of ml = -4, -3, 3, 4
+            s = -1
+        else:
+            s = 1
+        signs = [s] + signs + [s]
+
+    return signs
 
 
 def atom_basis_permutation(atom_basis):


### PR DESCRIPTION
Generalize the code in gto_utils to allow for arbitrary angular momentum.
Also update the from_orca.py script to allow for 'i' orbitals in gto initial guess.