### PR TITLE
Fix Eigen3 detection for version 5.x and newer

### DIFF
--- a/external/upstream/fetch_eigen3.cmake
+++ b/external/upstream/fetch_eigen3.cmake
@@ -1,4 +1,7 @@
-find_package(Eigen3 3.4 CONFIG QUIET
+# Use a version range so that newer Eigen releases are accepted: with modern
+# Eigen3ConfigVersion.cmake a bare "3.4" means "3.4.x only" (3.4 <= v < 3.5),
+# which rejects e.g. Eigen 5.x. The range matches 3.4.0 up to (but not incl.) 6.0.
+find_package(Eigen3 3.4...6 CONFIG QUIET
   NO_CMAKE_PATH
   NO_CMAKE_PACKAGE_REGISTRY
   )


### PR DESCRIPTION
## Summary
- `find_package(Eigen3 3.4 CONFIG)` is rejected by modern `Eigen3ConfigVersion.cmake`, where a single requested version `3.4` means "3.4.x only" (`3.4 <= v < 3.5`).
- This caused an installed Eigen **5.x** to be treated as incompatible, falling back to fetching/building Eigen 3.4.0.
- Switch to a CMake version range `3.4...6` so any `3.4 <= v < 6.0` (including 5.x) is accepted.

## Test plan
- [x] Verified `find_package(Eigen3 3.4...6 CONFIG REQUIRED ...)` detects system Eigen `5.0.1` (previously fell through to FetchContent).
- [ ] Confirm a clean configure still works on systems with Eigen 3.4.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)