### PR TITLE
Option to remove build/install dirs in sigma2 compile scripts

### DIFF
--- a/tools/betzy.sh
+++ b/tools/betzy.sh
@@ -12,15 +12,27 @@ cd ${mrchem_dir}
 build_dir=${mrchem_dir}/build
 install_dir=${mrchem_dir}/install
 
+
 if [ -d "${build_dir}" ]; then
-    echo "Build directory already exists, please remove"
-    exit 1
-else
-    ./setup --prefix=${install_dir} --omp --mpi --cxx=mpicxx ${build_dir} && \
-    cd ${build_dir} && \
-    make && \
-    OMP_NUM_THREADS=1 ctest -L unit --output-on-failure && \
-    make install
+    echo "Build directory '${build_dir}' already exists."
+    read -p "Would you like to delete the existing build and install folders and continue? (y/N): " response
+    case "${response,}" in
+        y|yes)
+            echo "Removing old build and install directories..."
+            rm -rf "${build_dir}"
+            rm -rf "${install_dir}"
+            ;;
+        *)
+            echo "Aborting build to prevent overwriting..."
+            exit 1
+            ;;
+    esac
 fi
+
+./setup --prefix=${install_dir} --omp --mpi --cxx=mpicxx ${build_dir} && \
+cd ${build_dir} && \
+make && \
+OMP_NUM_THREADS=1 ctest -L unit --output-on-failure && \
+make install
 
 exit 0

--- a/tools/betzy.sh
+++ b/tools/betzy.sh
@@ -14,8 +14,8 @@ install_dir=${mrchem_dir}/install
 
 
 if [ -d "${build_dir}" ]; then
-    echo "Build directory '${build_dir}' already exists."
-    read -p "Would you like to delete the existing build and install folders and continue? (y/N): " response
+    echo "Build directory already exists."
+    read -p "\nWould you like to delete the existing build and install folders and continue? (y/N): " response
     case "${response,}" in
         y|yes)
             echo "Removing old build and install directories..."

--- a/tools/betzy.sh
+++ b/tools/betzy.sh
@@ -12,10 +12,9 @@ cd ${mrchem_dir}
 build_dir=${mrchem_dir}/build
 install_dir=${mrchem_dir}/install
 
-
 if [ -d "${build_dir}" ]; then
     echo "Build directory already exists."
-    read -p "\nWould you like to delete the existing build and install folders and continue? (y/N): " response
+    read -p $'\nWould you like to delete the existing build and install folders and continue? (y/N): ' response
     case "${response,}" in
         y|yes)
             echo "Removing old build and install directories..."

--- a/tools/olivia.sh
+++ b/tools/olivia.sh
@@ -16,13 +16,9 @@ cd ${mrchem_dir}
 build_dir=${mrchem_dir}/build
 install_dir=${mrchem_dir}/install
 
-
-
-
-
 if [ -d "${build_dir}" ]; then
     echo "Build directory already exists."
-    read -p "\nWould you like to delete the existing build and install folders and continue? (y/N): " response
+    read -p $'\nWould you like to delete the existing build and install folders and continue? (y/N): ' response
     case "${response,}" in
         y|yes)
             echo "Removing old build and install directories..."

--- a/tools/olivia.sh
+++ b/tools/olivia.sh
@@ -16,17 +16,32 @@ cd ${mrchem_dir}
 build_dir=${mrchem_dir}/build
 install_dir=${mrchem_dir}/install
 
+
+
+
+
 if [ -d "${build_dir}" ]; then
-    echo "Build directory already exists, please remove"
-    exit 1
-else
-    ./setup --prefix=${install_dir} --omp --mpi ${build_dir} && \
-    cd ${build_dir} && \
-    srun --cpus-per-task=4 --mem-per-cpu=2G --time=01:00:00 --account=$account bash -c \
-    "source ${mrchem_dir}/tools/olivia.env ; \
-    make -j4 ; \
-    OMP_NUM_THREADS=4 ctest -L unit --output-on-failure ; \
-    make install -j4"
+    echo "Build directory already exists."
+    read -p "\nWould you like to delete the existing build and install folders and continue? (y/N): " response
+    case "${response,}" in
+        y|yes)
+            echo "Removing old build and install directories..."
+            rm -rf "${build_dir}"
+            rm -rf "${install_dir}"
+            ;;
+        *)
+            echo "Aborting build to prevent overwriting..."
+            exit 1
+            ;;
+    esac
 fi
+
+./setup --prefix=${install_dir} --omp --mpi ${build_dir} && \
+cd ${build_dir} && \
+srun --cpus-per-task=4 --mem-per-cpu=2G --time=01:00:00 --account=$account bash -c \
+"source ${mrchem_dir}/tools/olivia.env ; \
+make -j4 ; \
+OMP_NUM_THREADS=4 ctest -L unit --output-on-failure ; \
+make install -j4"
 
 exit 0

--- a/tools/saga.sh
+++ b/tools/saga.sh
@@ -12,15 +12,27 @@ cd ${mrchem_dir}
 build_dir=${mrchem_dir}/build
 install_dir=${mrchem_dir}/install
 
+
 if [ -d "${build_dir}" ]; then
-    echo "Build directory already exists, please remove"
-    exit 1
-else
-    ./setup --prefix=${install_dir} --omp --mpi --cxx=mpicxx ${build_dir} && \
-    cd ${build_dir} && \
-    make && \
-    OMP_NUM_THREADS=1 ctest -L unit --output-on-failure && \
-    make install
+    echo "Build directory already exists."
+    read -p "\nWould you like to delete the existing build and install folders and continue? (y/N): " response
+    case "${response,}" in
+        y|yes)
+            echo "Removing old build and install directories..."
+            rm -rf "${build_dir}"
+            rm -rf "${install_dir}"
+            ;;
+        *)
+            echo "Aborting build to prevent overwriting..."
+            exit 1
+            ;;
+    esac
 fi
+
+./setup --prefix=${install_dir} --omp --mpi --cxx=mpicxx ${build_dir} && \
+cd ${build_dir} && \
+make && \
+OMP_NUM_THREADS=1 ctest -L unit --output-on-failure && \
+make install
 
 exit 0

--- a/tools/saga.sh
+++ b/tools/saga.sh
@@ -12,7 +12,6 @@ cd ${mrchem_dir}
 build_dir=${mrchem_dir}/build
 install_dir=${mrchem_dir}/install
 
-
 if [ -d "${build_dir}" ]; then
     echo "Build directory already exists."
     read -p $'\nWould you like to delete the existing build and install folders and continue? (y/N): ' response

--- a/tools/saga.sh
+++ b/tools/saga.sh
@@ -15,7 +15,7 @@ install_dir=${mrchem_dir}/install
 
 if [ -d "${build_dir}" ]; then
     echo "Build directory already exists."
-    read -p "\nWould you like to delete the existing build and install folders and continue? (y/N): " response
+    read -p $'\nWould you like to delete the existing build and install folders and continue? (y/N): ' response
     case "${response,}" in
         y|yes)
             echo "Removing old build and install directories..."


### PR DESCRIPTION
Added a terminal prompt to delete existing build/install folders before compiling using sigma2 compile scripts. Defaults to aborting if no confirmation is given.