### PR TITLE
Plotter bugfix

### DIFF
--- a/src/utils/MolPlotter.h
+++ b/src/utils/MolPlotter.h
@@ -40,15 +40,15 @@ public:
             , molecule(&mol) {}
 
     void linePlot(const std::array<int, 1> &npts, const mrcpp::CompFunction<3> &func, const std::string &fname) {
-        if (func.isreal()) linePlot(npts, func, fname + "_re");
+        if (func.isreal()) linePlot(npts, func.real(), fname + "_re");
         if (func.iscomplex()) MSG_ERROR("Not implemented"); // linePlot(npts, func.imag(), fname + "_im");
     }
     void surfPlot(const std::array<int, 2> &npts, const mrcpp::CompFunction<3> &func, const std::string &fname) {
-        if (func.isreal()) surfPlot(npts, func, fname + "_re");
+        if (func.isreal()) surfPlot(npts, func.real(), fname + "_re");
         if (func.iscomplex()) MSG_ERROR("Not implemented"); // surfPlot(npts, func.imag(), fname + "_im");
     }
     void cubePlot(const std::array<int, 3> &npts, const mrcpp::CompFunction<3> &func, const std::string &fname) {
-        if (func.isreal()) cubePlot(npts, func, fname + "_re");
+        if (func.isreal()) cubePlot(npts, func.real(), fname + "_re");
         if (func.iscomplex()) MSG_ERROR("Not implemented"); // cubePlot(npts, func.imag(), fname + "_im");
     }
 


### PR DESCRIPTION
pass `func.real()` to plotter functions in `MolPlotter.h` to call mrcpp function instead of endlessly recursing.