### PR TITLE
use const for defining OrbitalVectors

### DIFF
--- a/src/qmfunctions/Orbital.h
+++ b/src/qmfunctions/Orbital.h
@@ -71,14 +71,14 @@ public:
 // All MPI processes have a vector of full length, but
 // only "my_func" are fully defined.
 // The others orbitals (not my_func) have only basic data (spin etc) but no trees defined.
-// Vector of orbitals where all orbitals are defined for all MPI, should not have typoe
+// Vector of orbitals where all orbitals are defined for all MPI, should not have type
 // OrbitalVectors, but directly vector<Orbital>.
 class OrbitalVector : public mrcpp::CompFunctionVector {
 public:
     explicit OrbitalVector(int N = 0)
             : mrcpp::CompFunctionVector(N) {}
-    void push_back(Orbital orb) {
-        mrcpp::CompFunction<3> &compfunc = orb;
+    void push_back(const Orbital& orb) {
+        const mrcpp::CompFunction<3> &compfunc = orb;
         compfunc.func_ptr->rank = size();
         mrcpp::CompFunctionVector *compfuncvec = this;
         compfuncvec->push_back(compfunc); // we must push in the vector<CompFunction>, not into the OrbitalVector!


### PR DESCRIPTION
The definition without const gave segmentation errors when doing some more complicated changes in mrcpp (like adding an int in the CompFunctionVector class)
Edit: the problem was elsewhere, so this PR is not really needed, though it does not harm.