### PR TITLE
Fix singularity master pipeline

### DIFF
--- a/external/upstream/fetch_eigen3.cmake
+++ b/external/upstream/fetch_eigen3.cmake
@@ -1,3 +1,4 @@
+option(EIGEN3_FIND_BEHAVIOUR "Find Eigen3 behavior" "default")
 cpm_set_find_behaviour(${EIGEN3_FIND_BEHAVIOUR})
 CPMAddPackage(
   NAME Eigen3

--- a/external/upstream/fetch_libxc.cmake
+++ b/external/upstream/fetch_libxc.cmake
@@ -1,3 +1,4 @@
+option(LIBXC_FIND_BEHAVIOUR "Find LibXC behavior" "default")
 cpm_set_find_behaviour(${LIBXC_FIND_BEHAVIOUR})
 set(_saved_install_includedir "${CMAKE_INSTALL_INCLUDEDIR}")
 set(CMAKE_INSTALL_INCLUDEDIR "include/LibXC" CACHE STRING "" FORCE)

--- a/external/upstream/fetch_mrcpp.cmake
+++ b/external/upstream/fetch_mrcpp.cmake
@@ -1,3 +1,4 @@
+option(MRCPP_FIND_BEHAVIOUR "Find MRCPP behavior" "default")
 cpm_set_find_behaviour(${MRCPP_FIND_BEHAVIOUR})
 set(CMAKE_BUILD_TYPE Release)
 set(Eigen3_DIR ${eigen3_BINARY_DIR})

--- a/external/upstream/fetch_nlohmann_json.cmake
+++ b/external/upstream/fetch_nlohmann_json.cmake
@@ -1,3 +1,4 @@
+option(NLOHMANN_JSON_FIND_BEHAVIOUR "Find nlohmann_json behavior" "default")
 cpm_set_find_behaviour(${NLOHMANN_JSON_FIND_BEHAVIOUR})
 CPMAddPackage(
   NAME nlohmann_json

--- a/external/upstream/fetch_xcfun.cmake
+++ b/external/upstream/fetch_xcfun.cmake
@@ -1,3 +1,4 @@
+option(XCFUN_FIND_BEHAVIOUR "Find XCFun behavior" "default")
 cpm_set_find_behaviour(${XCFUN_FIND_BEHAVIOUR})
 set(CMAKE_BUILD_TYPE Release)
 if(NOT XCFUN_OLD_PBE)

--- a/recipes/Singularity.nompi
+++ b/recipes/Singularity.nompi
@@ -1,7 +1,7 @@
 # NOTE: this definition file depends on features only available in
 # Singularity 3.2 and later.
 BootStrap: docker
-From: ubuntu:20.04
+From: ubuntu:24.04
 Stage: build
 %post
     . /.singularity.d/env/10-docker*.sh
@@ -23,7 +23,7 @@ Stage: build
         git
     rm -rf /var/lib/apt/lists/*
 
-# CMake version 3.20.6
+# CMake version 3.31.12
 %post
     apt-get update -y
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -32,10 +32,10 @@ Stage: build
     rm -rf /var/lib/apt/lists/*
 %post
     cd /
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Kitware/CMake/releases/download/v3.20.6/cmake-3.20.6-linux-x86_64.sh
+    mkdir -p /var/tmp && wget -q -nc -P /var/tmp https://github.com/Kitware/CMake/releases/download/v3.31.12/cmake-3.31.12-linux-x86_64.sh
     mkdir -p /usr/local
-    /bin/sh /var/tmp/cmake-3.20.6-linux-x86_64.sh --prefix=/usr/local --skip-license
-    rm -rf /var/tmp/cmake-3.20.6-linux-x86_64.sh
+    /bin/sh /var/tmp/cmake-3.31.12-linux-x86_64.sh --prefix=/usr/local --skip-license
+    rm -rf /var/tmp/cmake-3.31.12-linux-x86_64.sh
 %environment
     export PATH=/usr/local/bin:$PATH
 %post
@@ -45,7 +45,7 @@ Stage: build
 %post
     apt-get update -y
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        python3.9
+        python3
     rm -rf /var/lib/apt/lists/*
 
 
@@ -62,7 +62,7 @@ Stage: build
 
 
 BootStrap: docker
-From: ubuntu:20.04
+From: ubuntu:24.04
 %post
     . /.singularity.d/env/10-docker*.sh
 
@@ -70,7 +70,7 @@ From: ubuntu:20.04
 %post
     apt-get update -y
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        libgfortran4 \
+        libgfortran5 \
         libgomp1
     rm -rf /var/lib/apt/lists/*
 
@@ -78,7 +78,7 @@ From: ubuntu:20.04
 %post
     apt-get update -y
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        python3.9
+        python3
     rm -rf /var/lib/apt/lists/*
 
 

--- a/recipes/Singularity.openmpi4.0
+++ b/recipes/Singularity.openmpi4.0
@@ -1,7 +1,7 @@
 # NOTE: this definition file depends on features only available in
 # Singularity 3.2 and later.
 BootStrap: docker
-From: ubuntu:20.04
+From: ubuntu:24.04
 Stage: build
 %post
     . /.singularity.d/env/10-docker*.sh
@@ -23,7 +23,7 @@ Stage: build
         git
     rm -rf /var/lib/apt/lists/*
 
-# Mellanox OFED version 5.2-2.2.0.0
+# Mellanox OFED version 5.6-2.0.9.0
 %post
     apt-get update -y
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -33,7 +33,7 @@ Stage: build
     rm -rf /var/lib/apt/lists/*
 %post
     wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add -
-    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/5.2-2.2.0.0/ubuntu20.04/mellanox_mlnx_ofed.list
+    mkdir -p /etc/apt/sources.list.d && wget -q -nc -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/5.6-2.0.9.0/ubuntu22.04/mellanox_mlnx_ofed.list
     apt-get update -y
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ibverbs-providers \
@@ -48,7 +48,7 @@ Stage: build
         librdmacm1
     rm -rf /var/lib/apt/lists/*
 
-# UCX version 1.9.0
+# UCX version 1.17.0
 %post
     apt-get update -y
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -60,12 +60,12 @@ Stage: build
     rm -rf /var/lib/apt/lists/*
 %post
     cd /
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.9.0/ucx-1.9.0.tar.gz
-    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.9.0.tar.gz -C /var/tmp -z
-    cd /var/tmp/ucx-1.9.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-rdmacm --with-verbs --without-cuda
+    mkdir -p /var/tmp && wget -q -nc -P /var/tmp https://github.com/openucx/ucx/releases/download/v1.17.0/ucx-1.17.0.tar.gz
+    mkdir -p /var/tmp && tar -x -f /var/tmp/ucx-1.17.0.tar.gz -C /var/tmp -z
+    cd /var/tmp/ucx-1.17.0 &&   ./configure --prefix=/usr/local/ucx --disable-assertions --disable-debug --disable-doxygen-doc --disable-logging --disable-params-check --enable-optimizations --with-rdmacm --with-verbs --without-cuda
     make -j$(nproc)
     make -j$(nproc) install
-    rm -rf /var/tmp/ucx-1.9.0 /var/tmp/ucx-1.9.0.tar.gz
+    rm -rf /var/tmp/ucx-1.17.0 /var/tmp/ucx-1.17.0.tar.gz
 %environment
     export CPATH=/usr/local/ucx/include:$CPATH
     export LD_LIBRARY_PATH=/usr/local/ucx/lib:$LD_LIBRARY_PATH
@@ -90,7 +90,7 @@ Stage: build
     rm -rf /var/lib/apt/lists/*
 %post
     cd /
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://download.schedmd.com/slurm/slurm-21.08.8.tar.bz2
+    mkdir -p /var/tmp && wget -q -nc -P /var/tmp https://download.schedmd.com/slurm/slurm-21.08.8.tar.bz2
     mkdir -p /var/tmp && tar -x -f /var/tmp/slurm-21.08.8.tar.bz2 -C /var/tmp -j
     cd /var/tmp/slurm-21.08.8 &&   ./configure --prefix=/usr/local/slurm-pmi2
     cd /var/tmp/slurm-21.08.8
@@ -113,7 +113,7 @@ Stage: build
     rm -rf /var/lib/apt/lists/*
 %post
     cd /
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.5.tar.bz2
+    mkdir -p /var/tmp && wget -q -nc -P /var/tmp https://www.open-mpi.org/software/ompi/v4.0/downloads/openmpi-4.0.5.tar.bz2
     mkdir -p /var/tmp && tar -x -f /var/tmp/openmpi-4.0.5.tar.bz2 -C /var/tmp -j
     cd /var/tmp/openmpi-4.0.5 &&  CC=gcc CXX=g++ F77=gfortran F90=gfortran FC=gfortran ./configure --prefix=/usr/local/openmpi --disable-getpwuid --enable-orterun-prefix-by-default --with-pmi=/usr/local/slurm-pmi2 --with-ucx=/usr/local/ucx --without-cuda --without-verbs
     make -j$(nproc)
@@ -126,7 +126,7 @@ Stage: build
     export LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH
     export PATH=/usr/local/openmpi/bin:$PATH
 
-# CMake version 3.20.6
+# CMake version 3.31.12
 %post
     apt-get update -y
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -135,10 +135,10 @@ Stage: build
     rm -rf /var/lib/apt/lists/*
 %post
     cd /
-    mkdir -p /var/tmp && wget -q -nc --no-check-certificate -P /var/tmp https://github.com/Kitware/CMake/releases/download/v3.20.6/cmake-3.20.6-linux-x86_64.sh
+    mkdir -p /var/tmp && wget -q -nc -P /var/tmp https://github.com/Kitware/CMake/releases/download/v3.31.12/cmake-3.31.12-linux-x86_64.sh
     mkdir -p /usr/local
-    /bin/sh /var/tmp/cmake-3.20.6-linux-x86_64.sh --prefix=/usr/local --skip-license
-    rm -rf /var/tmp/cmake-3.20.6-linux-x86_64.sh
+    /bin/sh /var/tmp/cmake-3.31.12-linux-x86_64.sh --prefix=/usr/local --skip-license
+    rm -rf /var/tmp/cmake-3.31.12-linux-x86_64.sh
 %environment
     export PATH=/usr/local/bin:$PATH
 %post
@@ -165,7 +165,7 @@ Stage: build
 
 
 BootStrap: docker
-From: ubuntu:20.04
+From: ubuntu:24.04
 %post
     . /.singularity.d/env/10-docker*.sh
 
@@ -173,11 +173,11 @@ From: ubuntu:20.04
 %post
     apt-get update -y
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        libgfortran4 \
+        libgfortran5 \
         libgomp1
     rm -rf /var/lib/apt/lists/*
 
-# Mellanox OFED version 5.2-2.2.0.0
+# Mellanox OFED version 5.6-2.0.9.0
 %post
     apt-get update -y
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -187,7 +187,7 @@ From: ubuntu:20.04
     rm -rf /var/lib/apt/lists/*
 %post
     wget -qO - https://www.mellanox.com/downloads/ofed/RPM-GPG-KEY-Mellanox | apt-key add -
-    mkdir -p /etc/apt/sources.list.d && wget -q -nc --no-check-certificate -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/5.2-2.2.0.0/ubuntu20.04/mellanox_mlnx_ofed.list
+    mkdir -p /etc/apt/sources.list.d && wget -q -nc -P /etc/apt/sources.list.d https://linux.mellanox.com/public/repo/mlnx_ofed/5.6-2.0.9.0/ubuntu22.04/mellanox_mlnx_ofed.list
     apt-get update -y
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ibverbs-providers \
@@ -284,7 +284,7 @@ From: ubuntu:20.04
     (--dryrun) the container on the main input file, here called molecule.inp:
 
         $ ./<image-name>.sif --dryrun molecule
-    
+
     This will produce a new file molecule.json in the current directory which can
     be passed to the mrchem.x program inside the container using the singularity
     exec command:

--- a/recipes/recipe_nompi.py
+++ b/recipes/recipe_nompi.py
@@ -2,18 +2,18 @@
 HPCCM recipe for MRChem Singularity image (OpenMP)
 
 Contents:
-  Ubuntu 20.04
+  Ubuntu 24.04
   GNU compilers (upstream)
-  CMake 3.20.6
-  Python3.9
+  CMake 3.31.12
+  Python3.12
   MRChem (current source version)
 
 Generating recipe (stdout):
   $ hpccm --recipe recipe_nompi.py --format singularity --singularity-version=3.2
 """
 
-os_version="20.04"
-cmake_version="3.20.6"
+os_version="24.04"
+cmake_version="3.31.12"
 
 # Ubuntu base image
 Stage0 += baseimage(image=f"ubuntu:{os_version}", _as="build")

--- a/recipes/recipe_openmpi4.0.py
+++ b/recipes/recipe_openmpi4.0.py
@@ -2,22 +2,22 @@
 HPCCM recipe for MRChem Singularity image (MPI+OpenMP)
 
 Contents:
-  Ubuntu 20.04
+  Ubuntu 24.04
   GNU compilers (upstream)
   OFED/MOFED
   PMI2 (SLURM)
   UCX
   OpenMPI 4.0.5
-  CMake 3.20.6
-  Python3.9
+  CMake 3.31.12
+  Python3.12
   MRChem (current source version)
 
 Generating recipe (stdout):
   $ hpccm --recipe recipe_openmpi4.0.py --format singularity --singularity-version=3.2
 """
 
-os_version="20.04"
-cmake_version="3.20.6"
+os_version="24.04"
+cmake_version="3.31.12"
 openmpi_version="4.0.5"
 
 # CentOS base image

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 option(ENABLE_TESTS "Enable test suite" ON)
 
 if(ENABLE_TESTS)
-
+option(CATCH2_FIND_BEHAVIOUR "Find Catch2 behavior" "default")
 cpm_set_find_behaviour(${CATCH2_FIND_BEHAVIOUR})
 CPMAddPackage(
   NAME Catch2


### PR DESCRIPTION
Fixed versioning in singularity scripts.
MRChem can be built without the setup script again.

Tested by successfully building the singularity container manually on Sandel.